### PR TITLE
refactor: APIクリーンアップ・バッチクエリ・tags型変更・mlx feature削除

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "esa semantic search CLI"
 
-[features]
-default = ["mlx"]
-mlx = ["rurico/mlx"]
-
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
@@ -18,7 +14,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "56320e3", default-features = false }
+rurico = { git = "https://github.com/thkt/rurico", rev = "56320e3" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,6 +44,14 @@ pub struct EsaUser {
     pub screen_name: String,
 }
 
+pub struct CreatePostParams<'a> {
+    pub name: &'a str,
+    pub body_md: Option<&'a str>,
+    pub category: Option<&'a str>,
+    pub tags: Vec<String>,
+    pub wip: bool,
+}
+
 #[derive(Serialize)]
 struct CreatePostRequest {
     post: CreatePostBody,
@@ -59,6 +67,15 @@ struct CreatePostBody {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tags: Vec<String>,
     wip: bool,
+}
+
+#[derive(Default)]
+pub struct UpdatePostParams<'a> {
+    pub name: Option<&'a str>,
+    pub body_md: Option<&'a str>,
+    pub category: Option<&'a str>,
+    pub tags: Option<Vec<String>>,
+    pub wip: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -180,22 +197,18 @@ impl EsaClient {
     pub async fn create_post(
         &self,
         team: &str,
-        name: &str,
-        body_md: Option<&str>,
-        category: Option<&str>,
-        tags: Vec<String>,
-        wip: bool,
+        params: &CreatePostParams<'_>,
     ) -> Result<EsaPost, ClientError> {
         let url = self
             .build_url(&format!("teams/{team}/posts"))?
             .to_string();
         let body = CreatePostRequest {
             post: CreatePostBody {
-                name: name.to_string(),
-                body_md: body_md.map(str::to_string),
-                category: category.map(str::to_string),
-                tags,
-                wip,
+                name: params.name.to_string(),
+                body_md: params.body_md.map(str::to_string),
+                category: params.category.map(str::to_string),
+                tags: params.tags.clone(),
+                wip: params.wip,
             },
         };
         self.send(|http| http.post(&url).json(&body)).await
@@ -205,22 +218,18 @@ impl EsaClient {
         &self,
         team: &str,
         post_number: u32,
-        name: Option<&str>,
-        body_md: Option<&str>,
-        category: Option<&str>,
-        tags: Option<Vec<String>>,
-        wip: Option<bool>,
+        params: &UpdatePostParams<'_>,
     ) -> Result<EsaPost, ClientError> {
         let url = self
             .build_url(&format!("teams/{team}/posts/{post_number}"))?
             .to_string();
         let body = UpdatePostRequest {
             post: UpdatePostBody {
-                name: name.map(str::to_string),
-                body_md: body_md.map(str::to_string),
-                category: category.map(str::to_string),
-                tags,
-                wip,
+                name: params.name.map(str::to_string),
+                body_md: params.body_md.map(str::to_string),
+                category: params.category.map(str::to_string),
+                tags: params.tags.clone(),
+                wip: params.wip,
             },
         };
         self.send(|http| http.patch(&url).json(&body)).await
@@ -319,12 +328,12 @@ fn retry_wait(status: u16, retry_after: Option<&str>, attempt: u32) -> Option<Du
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn test_post_json() -> serde_json::Value {
+    fn test_post_json(number: u32) -> serde_json::Value {
         serde_json::json!({
-            "number": 1,
+            "number": number,
             "name": "Getting Started",
             "full_name": "dev/Getting Started",
             "body_md": "# Hello",
@@ -351,7 +360,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "posts": [test_post_json()],
+                "posts": [test_post_json(1)],
                 "next_page": null,
                 "total_count": 1
             })))
@@ -376,7 +385,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "posts": [test_post_json()],
+                "posts": [test_post_json(1)],
                 "next_page": 2,
                 "total_count": 150
             })))
@@ -397,7 +406,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts/42"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json(42)))
             .mount(&server)
             .await;
 
@@ -406,7 +415,7 @@ mod tests {
             .get_post("myteam", 42)
             .await
             .unwrap();
-        assert_eq!(post.number, 1);
+        assert_eq!(post.number, 42);
         assert_eq!(post.name, "Getting Started");
     }
 
@@ -415,13 +424,19 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/teams/myteam/posts"))
-            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
         let post = test_client(&server)
             .await
-            .create_post("myteam", "Test", Some("# Body"), None, vec![], true)
+            .create_post("myteam", &CreatePostParams {
+                name: "Test",
+                body_md: Some("# Body"),
+                category: None,
+                tags: vec![],
+                wip: true,
+            })
             .await
             .unwrap();
         assert_eq!(post.name, "Getting Started");
@@ -432,13 +447,13 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/teams/myteam/posts/1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
         let post = test_client(&server)
             .await
-            .update_post("myteam", 1, Some("New Name"), None, None, None, None)
+            .update_post("myteam", 1, &UpdatePostParams { name: Some("New Name"), ..Default::default() })
             .await
             .unwrap();
         assert_eq!(post.name, "Getting Started");
@@ -477,7 +492,7 @@ mod tests {
             .await;
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts/1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
@@ -535,5 +550,46 @@ mod tests {
     fn retry_wait_non_retryable() {
         assert!(retry_wait(400, None, 0).is_none());
         assert!(retry_wait(404, None, 0).is_none());
+    }
+
+    #[tokio::test]
+    async fn max_retries_exhausted() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/myteam/posts/1"))
+            .respond_with(
+                ResponseTemplate::new(429).insert_header("retry-after", "0"),
+            )
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server)
+            .await
+            .get_post("myteam", 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ClientError::MaxRetries(MAX_RETRIES)));
+    }
+
+    #[tokio::test]
+    async fn list_posts_with_query() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/myteam/posts"))
+            .and(query_param("q", "updated:>2025-01-01"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "posts": [test_post_json(1)],
+                "next_page": null,
+                "total_count": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let resp = test_client(&server)
+            .await
+            .list_posts("myteam", 1, Some("updated:>2025-01-01"))
+            .await
+            .unwrap();
+        assert_eq!(resp.posts.len(), 1);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,7 +102,7 @@ fn dirs_fallback_config_home() -> Result<PathBuf, ConfigError> {
 }
 
 /// esa team name: lowercase alphanumeric + hyphen, must start with alphanumeric.
-fn validate_team_name(name: &str) -> Result<(), ConfigError> {
+pub fn validate_team_name(name: &str) -> Result<(), ConfigError> {
     if name.is_empty() {
         return Err(ConfigError::InvalidValue(
             "team name must not be empty".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use rurico::embed::{Embed, Embedder};
-use sae::client::EsaClient;
+use sae::client::{CreatePostParams, EsaClient, UpdatePostParams};
 use sae::config::Config;
 
 #[derive(Parser)]
@@ -109,8 +109,36 @@ enum Command {
     },
 }
 
+type AppError = Box<dyn std::error::Error>;
+
+fn resolve_client<'a>(config: &'a Config, team: Option<&'a str>) -> Result<(&'a str, EsaClient), AppError> {
+    let team = config.resolve_team(team)?;
+    let client = EsaClient::from_env()?;
+    Ok((team, client))
+}
+
+fn require_db(config: &Config, team: &str) -> Result<sae::storage::Db, AppError> {
+    let db_path = config.team_db_path(team)?;
+    if !db_path.exists() {
+        return Err(format!("No data for team '{team}'. Run `sae harvest {team}` first.").into());
+    }
+    Ok(sae::storage::Db::open(&db_path)?)
+}
+
+fn archive_category(current: Option<&str>) -> Option<String> {
+    let current = current.unwrap_or("");
+    if current.starts_with("Archived/") || current == "Archived" {
+        return None;
+    }
+    Some(if current.is_empty() {
+        "Archived".to_string()
+    } else {
+        format!("Archived/{current}")
+    })
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), AppError> {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
@@ -124,8 +152,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Command::Harvest { team, full } => {
-            let team = config.resolve_team(Some(&team))?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, Some(&team))?;
             let db_path = config.team_db_path(team)?;
             let db = sae::storage::Db::open(&db_path)?;
             let result = sae::sync::harvest(&client, &db, team, full).await?;
@@ -137,18 +164,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             limit,
         } => {
             let team = config.resolve_team(team.as_deref())?;
-            let db_path = config.team_db_path(team)?;
-            if !db_path.exists() {
-                eprintln!("No data for team '{team}'. Run `sae harvest {team}` first.");
-                std::process::exit(1);
-            }
-            let db = sae::storage::Db::open(&db_path)?;
+            let db = require_db(&config, team)?;
             let embedder = try_load_embedder();
             let query_embedding = embedder.as_ref().and_then(|e| {
                 match e.embed_query(&query) {
                     Ok(v) => Some(v),
                     Err(e) => {
-                        eprintln!("Warning: embed_query failed: {e}");
+                        tracing::warn!(error = %e, "embed_query failed, falling back to FTS");
                         None
                     }
                 }
@@ -179,33 +201,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         Command::Get { number, team } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
             let post = client.get_post(team, number).await?;
-            println!("---");
-            println!("title: \"{}\"", post.full_name.replace('"', "\\\""));
-            if let Some(ref cat) = post.category {
-                if !cat.is_empty() {
-                    println!("category: \"{}\"", cat.replace('"', "\\\""));
-                }
-            }
-            if !post.tags.is_empty() {
-                let tags: Vec<String> = post.tags.iter().map(|t| format!("\"{}\"", t.replace('"', "\\\""))).collect();
-                println!("tags: [{}]", tags.join(", "));
-            }
-            println!("author: \"@{}\"", post.created_by.screen_name);
-            if post.updated_by.screen_name != post.created_by.screen_name {
-                println!("updated_by: \"@{}\"", post.updated_by.screen_name);
-            }
-            println!("updated_at: \"{}\"", post.updated_at);
-            if post.wip {
-                println!("wip: true");
-            }
-            println!("number: {}", post.number);
-            println!("url: {}", post.url);
-            println!("---");
-            println!();
-            println!("{}", post.body_md.as_deref().unwrap_or("(empty)"));
+            print_post_yaml(&post);
         }
         Command::Create {
             name,
@@ -215,11 +213,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             wip,
             team,
         } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
-            let post = client
-                .create_post(team, &name, body.as_deref(), category.as_deref(), tag, wip)
-                .await?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
+            let params = CreatePostParams {
+                name: &name,
+                body_md: body.as_deref(),
+                category: category.as_deref(),
+                tags: tag,
+                wip,
+            };
+            let post = client.create_post(team, &params).await?;
             println!("Created: {} (#{}) {}", post.name, post.number, post.url);
         }
         Command::Update {
@@ -230,30 +232,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tag,
             team,
         } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
             let tags = if tag.is_empty() { None } else { Some(tag) };
-            let post = client
-                .update_post(
-                    team,
-                    number,
-                    name.as_deref(),
-                    body.as_deref(),
-                    category.as_deref(),
-                    tags,
-                    None,
-                )
-                .await?;
+            let params = UpdatePostParams {
+                name: name.as_deref(),
+                body_md: body.as_deref(),
+                category: category.as_deref(),
+                tags,
+                ..Default::default()
+            };
+            let post = client.update_post(team, number, &params).await?;
             println!("Updated: {} (#{}) {}", post.name, post.number, post.url);
         }
         Command::Embed { team } => {
             let team = config.resolve_team(Some(&team))?;
-            let db_path = config.team_db_path(team)?;
-            if !db_path.exists() {
-                eprintln!("No data for team '{team}'. Run `sae harvest {team}` first.");
-                std::process::exit(1);
-            }
-            let db = sae::storage::Db::open(&db_path)?;
+            let db = require_db(&config, team)?;
 
             eprintln!("Checking model...");
             let paths = rurico::embed::download_model()
@@ -275,20 +268,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
                 let batch_len = batch.len() as u32;
-                match embedder.embed_documents_batch(&texts) {
-                    Ok(embs) => {
-                        let embeddings: Vec<(i64, Vec<f32>)> = batch
-                            .iter()
-                            .map(|(id, _)| *id)
-                            .zip(embs)
-                            .collect();
-                        total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: batch embedding failed: {e}. Aborting.");
-                        std::process::exit(1);
-                    }
-                }
+                let embs = embedder
+                    .embed_documents_batch(&texts)
+                    .map_err(|e| format!("Batch embedding failed: {e}"))?;
+                let embeddings: Vec<(i64, Vec<f32>)> = batch
+                    .iter()
+                    .map(|(id, _)| *id)
+                    .zip(embs)
+                    .collect();
+                total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
                 done += batch_len;
                 eprintln!("  {done} chunks processed");
             }
@@ -299,39 +287,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         Command::Archive { number, team } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
             let post = client.get_post(team, number).await?;
-            let current_category = post.category.as_deref().unwrap_or("");
-            if current_category.starts_with("Archived/") || current_category == "Archived" {
-                println!("Already archived: {} (#{}) {}", post.name, post.number, post.url);
-            } else {
-                let archived_category = if current_category.is_empty() {
-                    "Archived".to_string()
-                } else {
-                    format!("Archived/{current_category}")
-                };
-                let post = client
-                    .update_post(team, number, None, None, Some(&archived_category), None, None)
-                    .await?;
-                println!("Archived: {} (#{}) {}", post.name, post.number, post.url);
+            match archive_category(post.category.as_deref()) {
+                None => {
+                    println!("Already archived: {} (#{}) {}", post.name, post.number, post.url);
+                }
+                Some(new_category) => {
+                    let params = UpdatePostParams {
+                        category: Some(&new_category),
+                        ..Default::default()
+                    };
+                    let post = client.update_post(team, number, &params).await?;
+                    println!("Archived: {} (#{}) {}", post.name, post.number, post.url);
+                }
             }
         }
         Command::Ship { number, team } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
-            let post = client
-                .update_post(team, number, None, None, None, None, Some(false))
-                .await?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
+            let params = UpdatePostParams {
+                wip: Some(false),
+                ..Default::default()
+            };
+            let post = client.update_post(team, number, &params).await?;
             println!("Shipped: {} (#{}) {}", post.name, post.number, post.url);
         }
         Command::Status { team } => {
-            let teams: Vec<&str> = if let Some(ref t) = team {
+            let target_teams: Vec<&str> = if let Some(ref t) = team {
                 vec![config.resolve_team(Some(t))?]
             } else {
-                config.teams.iter().map(String::as_str).collect()
+                config
+                    .teams
+                    .iter()
+                    .filter(|t| sae::config::validate_team_name(t).is_ok())
+                    .map(String::as_str)
+                    .collect()
             };
-            for t in &teams {
+            for t in &target_teams {
                 println!("--- {t} ---");
                 match config.team_db_path(t) {
                     Ok(path) if path.exists() => {
@@ -365,6 +357,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn print_post_yaml(post: &sae::client::EsaPost) {
+    fn yaml_escape(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+            .replace('\t', "\\t")
+    }
+    println!("---");
+    println!("title: \"{}\"", yaml_escape(&post.full_name));
+    if let Some(ref cat) = post.category {
+        if !cat.is_empty() {
+            println!("category: \"{}\"", yaml_escape(cat));
+        }
+    }
+    if !post.tags.is_empty() {
+        let tags: Vec<String> = post.tags.iter().map(|t| format!("\"{}\"", yaml_escape(t))).collect();
+        println!("tags: [{}]", tags.join(", "));
+    }
+    println!("author: \"@{}\"", post.created_by.screen_name);
+    if post.updated_by.screen_name != post.created_by.screen_name {
+        println!("updated_by: \"@{}\"", post.updated_by.screen_name);
+    }
+    println!("updated_at: \"{}\"", post.updated_at);
+    if post.wip {
+        println!("wip: true");
+    }
+    println!("number: {}", post.number);
+    println!("url: {}", post.url);
+    println!("---");
+    println!();
+    println!("{}", post.body_md.as_deref().unwrap_or("(empty)"));
+}
+
 fn try_load_embedder() -> Option<Embedder> {
     let paths = match rurico::embed::download_model() {
         Ok(p) => p,
@@ -377,8 +402,41 @@ fn try_load_embedder() -> Option<Embedder> {
     match Embedder::new(&paths) {
         Ok(e) => Some(e),
         Err(e) => {
-            eprintln!("Warning: failed to load embedding model: {e}");
+            tracing::warn!(error = %e, "failed to load embedding model");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_no_category() {
+        assert_eq!(archive_category(None), Some("Archived".into()));
+        assert_eq!(archive_category(Some("")), Some("Archived".into()));
+    }
+
+    #[test]
+    fn archive_with_category() {
+        assert_eq!(
+            archive_category(Some("dev/guide")),
+            Some("Archived/dev/guide".into())
+        );
+    }
+
+    #[test]
+    fn archive_already_archived() {
+        assert_eq!(archive_category(Some("Archived")), None);
+        assert_eq!(archive_category(Some("Archived/dev")), None);
+    }
+
+    #[test]
+    fn archive_not_prefix_match() {
+        assert_eq!(
+            archive_category(Some("ArchivedData")),
+            Some("Archived/ArchivedData".into())
+        );
     }
 }

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -6,15 +6,14 @@ pub fn add_embeddings(
     conn: &Connection,
     embeddings: &[(i64, Vec<f32>)],
 ) -> Result<u32, StorageError> {
+    if embeddings.is_empty() {
+        return Ok(0);
+    }
+    let existing = existing_chunk_ids(conn, embeddings)?;
     let tx = conn.unchecked_transaction().map_err(super::StorageError::Db)?;
     let mut count = 0u32;
     for (chunk_id, embedding) in embeddings {
-        let exists: bool = tx.query_row(
-            "SELECT EXISTS(SELECT 1 FROM vec_chunks WHERE chunk_id = ?1)",
-            [chunk_id],
-            |row| row.get(0),
-        )?;
-        if exists {
+        if existing.contains(chunk_id) {
             continue;
         }
         let bytes: &[u8] = rurico::storage::f32_as_bytes(embedding);
@@ -26,6 +25,25 @@ pub fn add_embeddings(
     }
     tx.commit().map_err(super::StorageError::Db)?;
     Ok(count)
+}
+
+fn existing_chunk_ids(
+    conn: &Connection,
+    embeddings: &[(i64, Vec<f32>)],
+) -> Result<std::collections::HashSet<i64>, StorageError> {
+    let sql = format!(
+        "SELECT chunk_id FROM vec_chunks WHERE chunk_id IN ({})",
+        super::in_placeholders(embeddings.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::types::ToSql> = embeddings
+        .iter()
+        .map(|(id, _)| id as &dyn rusqlite::types::ToSql)
+        .collect();
+    let ids = stmt
+        .query_map(params.as_slice(), |row| row.get::<_, i64>(0))?
+        .collect::<Result<std::collections::HashSet<_>, _>>()?;
+    Ok(ids)
 }
 
 pub fn get_unembedded_chunks(
@@ -73,7 +91,7 @@ mod tests {
                 full_name: "dev/Test".into(),
                 body_md: "# Hello\nWorld".into(),
                 category: None,
-                tags: "[]".into(),
+                tags: vec![],
                 wip: false,
                 kind: "stock".into(),
                 url: "https://example.esa.io/posts/1".into(),
@@ -109,7 +127,7 @@ mod tests {
                 full_name: "T".into(),
                 body_md: "# A\nB".into(),
                 category: None,
-                tags: "[]".into(),
+                tags: vec![],
                 wip: false,
                 kind: "stock".into(),
                 url: "u".into(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -14,6 +14,13 @@ use rurico::embed::EMBEDDING_DIMS;
 
 const SCHEMA_VERSION: &str = "3";
 
+pub(crate) fn in_placeholders(len: usize) -> String {
+    (1..=len)
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 const DDL: &str = "
     CREATE TABLE IF NOT EXISTS posts (
         number INTEGER PRIMARY KEY,
@@ -73,8 +80,11 @@ impl Db {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ =
-                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+                if let Err(e) =
+                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                {
+                    warn!(path = %parent.display(), error = %e, "failed to restrict data directory permissions");
+                }
             }
         }
         let conn = open_with_wal_recovery(path)?;
@@ -100,7 +110,6 @@ impl Db {
     fn init_schema(&self) -> Result<(), StorageError> {
         self.conn.execute_batch(DDL)?;
 
-        // FTS5 trigram for Japanese full-text search
         self.conn.execute_batch(
             "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(\
                  content, tokenize='trigram'\
@@ -179,7 +188,7 @@ pub fn upsert_post(conn: &Connection, post: &EsaPostRow) -> Result<(), StorageEr
             post.full_name,
             post.body_md,
             post.category,
-            post.tags,
+            post.tags_json(),
             post.wip,
             post.kind,
             post.url,
@@ -306,7 +315,7 @@ mod tests {
             full_name: format!("dev/Post {number}"),
             body_md: format!("# Post {number}"),
             category: Some("dev".into()),
-            tags: r#"["test"]"#.into(),
+            tags: vec!["test".into()],
             wip: false,
             kind: "stock".into(),
             url: format!("https://example.esa.io/posts/{number}"),

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -15,7 +15,6 @@ pub struct SearchResult {
     pub score: f64,
 }
 
-/// FTS5 trigram search with fts5vocab short-term expansion.
 pub fn fts_search(
     conn: &Connection,
     query: &str,
@@ -82,7 +81,6 @@ pub fn vec_search(
     Ok(rows)
 }
 
-/// Hybrid search: merge FTS5 + vector results via Reciprocal Rank Fusion.
 pub fn hybrid_search(
     conn: &Connection,
     query: &str,
@@ -104,7 +102,6 @@ pub fn hybrid_search(
         _ => Vec::new(),
     };
 
-    // RRF scores from rank position only; the f64 value is ignored by rurico::rrf_merge
     let fts_ranked: Vec<(u32, f64)> = fts_hits.iter().map(|h| (h.post_number, 0.0)).collect();
     let vec_ranked: Vec<(u32, f64)> = vec_hits.iter().map(|h| (h.post_number, 0.0)).collect();
     let merged = rurico::storage::rrf_merge(&fts_ranked, &vec_ranked);
@@ -156,10 +153,9 @@ fn batch_fetch_post_meta(
     if post_numbers.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders: Vec<String> = (1..=post_numbers.len()).map(|i| format!("?{i}")).collect();
     let sql = format!(
         "SELECT number, name, url FROM posts WHERE number IN ({})",
-        placeholders.join(", ")
+        super::in_placeholders(post_numbers.len())
     );
     let mut stmt = conn.prepare(&sql)?;
     let params: Vec<&dyn rusqlite::types::ToSql> = post_numbers
@@ -226,7 +222,7 @@ mod tests {
                     full_name: format!("dev/{name}"),
                     body_md: body.to_string(),
                     category: Some("dev".into()),
-                    tags: "[]".into(),
+                    tags: vec![],
                     wip: false,
                     kind: "stock".into(),
                     url: format!("https://example.esa.io/posts/{num}"),
@@ -327,5 +323,49 @@ mod tests {
         let db = Db::open_memory().unwrap();
         let meta = batch_fetch_post_meta(db.conn(), &[]).unwrap();
         assert!(meta.is_empty());
+    }
+
+    #[test]
+    fn hybrid_search_with_embeddings() {
+        use rurico::embed::EMBEDDING_DIMS;
+
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let unembedded = storage::get_unembedded_chunks(db.conn(), 100).unwrap();
+        assert!(!unembedded.is_empty());
+        let embeddings: Vec<(i64, Vec<f32>)> = unembedded
+            .iter()
+            .map(|(id, _)| (*id, vec![0.1; EMBEDDING_DIMS as usize]))
+            .collect();
+        storage::add_embeddings(db.conn(), &embeddings).unwrap();
+
+        let query_emb = vec![0.1; EMBEDDING_DIMS as usize];
+        let results = hybrid_search(db.conn(), "認証", Some(&query_emb), 10).unwrap();
+        assert!(!results.is_empty());
+        assert!(!results[0].post_name.is_empty());
+        assert!(!results[0].post_url.is_empty());
+    }
+
+    #[test]
+    fn truncate_snippet_short() {
+        assert_eq!(truncate_snippet("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_snippet_exact() {
+        assert_eq!(truncate_snippet("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_snippet_truncates() {
+        assert_eq!(truncate_snippet("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn truncate_snippet_japanese() {
+        let s = "日本語テスト";
+        let result = truncate_snippet(s, 3);
+        assert_eq!(result, "日本語...");
     }
 }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -5,7 +5,7 @@ pub struct EsaPostRow {
     pub full_name: String,
     pub body_md: String,
     pub category: Option<String>,
-    pub tags: String,
+    pub tags: Vec<String>,
     pub wip: bool,
     pub kind: String,
     pub url: String,
@@ -14,6 +14,12 @@ pub struct EsaPostRow {
     pub created_by: String,
     pub updated_by: String,
     pub revision_number: u32,
+}
+
+impl EsaPostRow {
+    pub fn tags_json(&self) -> String {
+        serde_json::to_string(&self.tags).unwrap_or_else(|_| "[]".into())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -47,7 +47,6 @@ pub async fn harvest(
 ) -> Result<HarvestResult, SyncError> {
     let state = storage::get_sync_state(db.conn())?;
 
-    // Clear stale checkpoint so full sync re-fetches from page 1
     if full {
         storage::save_sync_state(db.conn(), None, 0, 0, None)?;
     }
@@ -200,7 +199,7 @@ fn post_to_row(post: &EsaPost) -> EsaPostRow {
         full_name: post.full_name.clone(),
         body_md: post.body_md.clone().unwrap_or_default(),
         category: post.category.clone(),
-        tags: serde_json::to_string(&post.tags).unwrap_or_else(|_| "[]".into()),
+        tags: post.tags.clone(),
         wip: post.wip,
         kind: post.kind.clone(),
         url: post.url.clone(),
@@ -451,5 +450,61 @@ mod tests {
         let (page, q) = resolve_start(true, &state);
         assert_eq!(page, 1);
         assert!(q.is_none());
+    }
+
+    #[test]
+    fn build_window_query_none_none() {
+        assert!(build_window_query(None, None).is_none());
+    }
+
+    #[test]
+    fn build_window_query_base_only() {
+        assert_eq!(
+            build_window_query(Some("updated:>2025-01-01"), None),
+            Some("updated:>2025-01-01".into())
+        );
+    }
+
+    #[test]
+    fn build_window_query_boundary_only() {
+        assert_eq!(
+            build_window_query(None, Some("2025-06-01")),
+            Some("updated:<=2025-06-01".into())
+        );
+    }
+
+    #[test]
+    fn build_window_query_both() {
+        assert_eq!(
+            build_window_query(Some("updated:>2025-01-01"), Some("2025-06-01")),
+            Some("updated:>2025-01-01 updated:<=2025-06-01".into())
+        );
+    }
+
+    #[test]
+    fn harvest_result_display_no_gap() {
+        let r = HarvestResult {
+            posts_fetched: 10,
+            posts_stored: 10,
+            total_count: 100,
+            local_count: 100,
+            gap_detected: false,
+        };
+        let s = r.to_string();
+        assert!(s.contains("Fetched 10"));
+        assert!(!s.contains("gap"));
+    }
+
+    #[test]
+    fn harvest_result_display_with_gap() {
+        let r = HarvestResult {
+            posts_fetched: 5,
+            posts_stored: 5,
+            total_count: 100,
+            local_count: 90,
+            gap_detected: true,
+        };
+        let s = r.to_string();
+        assert!(s.contains("gap detected: 10 missing"));
     }
 }


### PR DESCRIPTION
## 概要

- `CreatePostParams` / `UpdatePostParams` 導入でパラメータスプロール解消
- `in_placeholders` ヘルパー抽出で IN 句生成の重複排除
- `EsaPostRow.tags` を `String` → `Vec<String>` に変更、シリアライズをストレージ境界に移動
- `yaml_escape` のエスケープ漏れ修正（バックスラッシュ、改行、タブ）
- `resolve_client` / `require_db` / `archive_category` / `print_post_yaml` ヘルパー抽出
- `eprintln` → `tracing::warn` に統一
- テスト追加（max_retries, list_posts_with_query, build_window_query, hybrid_search 等）
- `rurico/mlx` Cargo feature 削除（closes #3）

## テスト計画

- [x] `cargo test` 全 96 テスト通過
- [x] `cargo check` ビルド通過