### PR TITLE
GitHub Actions CI ワークフローの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+
+      - name: Check
+        run: cargo check
+
+      - name: Test
+        run: cargo test
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Format check
+        run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
         with:
           toolchain: stable
           components: clippy, rustfmt
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check
         run: cargo check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,11 +2150,12 @@ dependencies = [
 
 [[package]]
 name = "rurico"
-version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=56320e3#56320e30f0c9c639ece68ecd292338a853820cd6"
+version = "0.2.0"
+source = "git+https://github.com/thkt/rurico?rev=cd4f2ad#cd4f2ad796e4814ae15dd50063813356718b4a88"
 dependencies = [
  "bytemuck",
  "hf-hub",
+ "log",
  "mlx-rs",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "esa semantic search CLI"
 
-[features]
-default = ["mlx"]
-mlx = ["rurico/mlx"]
-
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
@@ -18,7 +14,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "56320e3", default-features = false }
+rurico = { git = "https://github.com/thkt/rurico", rev = "cd4f2ad" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default = ["mlx"]
 mlx = ["rurico/mlx"]
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -50,9 +50,7 @@ pub fn chunk_markdown(body_md: &str) -> Vec<Chunk> {
     }
 
     for (idx, (line_idx, title)) in headings.iter().enumerate() {
-        let end = headings
-            .get(idx + 1)
-            .map_or(lines.len(), |(next, _)| *next);
+        let end = headings.get(idx + 1).map_or(lines.len(), |(next, _)| *next);
         let content: String = lines[*line_idx..end].join("\n");
         if !content.trim().is_empty() {
             chunks.push(Chunk {

--- a/src/client.rs
+++ b/src/client.rs
@@ -166,11 +166,7 @@ impl EsaClient {
         self.send(|http| http.get(&url)).await
     }
 
-    pub async fn get_post(
-        &self,
-        team: &str,
-        post_number: u32,
-    ) -> Result<EsaPost, ClientError> {
+    pub async fn get_post(&self, team: &str, post_number: u32) -> Result<EsaPost, ClientError> {
         let url = self
             .build_url(&format!("teams/{team}/posts/{post_number}"))?
             .to_string();
@@ -186,9 +182,7 @@ impl EsaClient {
         tags: Vec<String>,
         wip: bool,
     ) -> Result<EsaPost, ClientError> {
-        let url = self
-            .build_url(&format!("teams/{team}/posts"))?
-            .to_string();
+        let url = self.build_url(&format!("teams/{team}/posts"))?.to_string();
         let body = CreatePostRequest {
             post: CreatePostBody {
                 name: name.to_string(),
@@ -201,6 +195,7 @@ impl EsaClient {
         self.send(|http| http.post(&url).json(&body)).await
     }
 
+    #[allow(clippy::too_many_arguments)] // will be replaced by UpdatePostParams in PR #4
     pub async fn update_post(
         &self,
         team: &str,
@@ -228,8 +223,7 @@ impl EsaClient {
 
     fn build_url(&self, path: &str) -> Result<reqwest::Url, ClientError> {
         let raw = format!("{}/{path}", self.base_url);
-        reqwest::Url::parse(&raw)
-            .map_err(|e| ClientError::Api(format!("invalid URL '{raw}': {e}")))
+        reqwest::Url::parse(&raw).map_err(|e| ClientError::Api(format!("invalid URL '{raw}': {e}")))
     }
 
     async fn throttle(&self) {
@@ -306,9 +300,7 @@ impl EsaClient {
 fn retry_wait(status: u16, retry_after: Option<&str>, attempt: u32) -> Option<Duration> {
     match status {
         429 => {
-            let secs = retry_after
-                .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(5);
+            let secs = retry_after.and_then(|v| v.parse::<u64>().ok()).unwrap_or(5);
             Some(Duration::from_secs(secs))
         }
         500 | 502 | 503 => Some(Duration::from_millis(500 * 2u64.pow(attempt))),
@@ -469,9 +461,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts/1"))
-            .respond_with(
-                ResponseTemplate::new(429).insert_header("retry-after", "1"),
-            )
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "1"))
             .up_to_n_times(1)
             .mount(&server)
             .await;
@@ -491,8 +481,7 @@ mod tests {
 
     #[test]
     fn from_env_missing_token() {
-        let err =
-            EsaClient::from_env_with(|_| Err(std::env::VarError::NotPresent)).unwrap_err();
+        let err = EsaClient::from_env_with(|_| Err(std::env::VarError::NotPresent)).unwrap_err();
         assert!(matches!(err, ClientError::TokenNotSet));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,8 +25,8 @@ impl Config {
         if !path.exists() {
             return Ok(Self::default());
         }
-        let content = std::fs::read_to_string(&path)
-            .map_err(|e| ConfigError::ReadFailed(path.clone(), e))?;
+        let content =
+            std::fs::read_to_string(&path).map_err(|e| ConfigError::ReadFailed(path.clone(), e))?;
         let config: Self =
             serde_json::from_str(&content).map_err(|e| ConfigError::ParseFailed(path, e))?;
         config.validate()?;
@@ -41,12 +41,12 @@ impl Config {
                 ));
             }
         }
-        if let Some(ref default) = self.default_team {
-            if !self.teams.contains(default) {
-                return Err(ConfigError::InvalidValue(format!(
-                    "default_team '{default}' not found in teams list"
-                )));
-            }
+        if let Some(ref default) = self.default_team
+            && !self.teams.contains(default)
+        {
+            return Err(ConfigError::InvalidValue(format!(
+                "default_team '{default}' not found in teams list"
+            )));
         }
         Ok(())
     }
@@ -80,13 +80,11 @@ pub(crate) fn data_dir() -> Result<PathBuf, ConfigError> {
 fn data_dir_with(
     get_var: impl Fn(&str) -> Result<String, std::env::VarError>,
 ) -> Result<PathBuf, ConfigError> {
-    let base = get_var("XDG_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|_| {
-            get_var("HOME")
-                .map(|h| PathBuf::from(h).join(".local").join("share"))
-                .map_err(|_| ConfigError::HomeDirNotFound)
-        })?;
+    let base = get_var("XDG_DATA_HOME").map(PathBuf::from).or_else(|_| {
+        get_var("HOME")
+            .map(|h| PathBuf::from(h).join(".local").join("share"))
+            .map_err(|_| ConfigError::HomeDirNotFound)
+    })?;
     Ok(base.join("sae"))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,8 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("sae=info".parse()?),
+            tracing_subscriber::EnvFilter::from_default_env().add_directive("sae=info".parse()?),
         )
         .init();
 
@@ -131,11 +130,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let result = sae::sync::harvest(&client, &db, team, full).await?;
             println!("{result}");
         }
-        Command::Search {
-            query,
-            team,
-            limit,
-        } => {
+        Command::Search { query, team, limit } => {
             let team = config.resolve_team(team.as_deref())?;
             let db_path = config.team_db_path(team)?;
             if !db_path.exists() {
@@ -144,21 +139,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             let db = sae::storage::Db::open(&db_path)?;
             let embedder = try_load_embedder();
-            let query_embedding = embedder.as_ref().and_then(|e| {
-                match e.embed_query(&query) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        eprintln!("Warning: embed_query failed: {e}");
-                        None
-                    }
+            let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(&query) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    eprintln!("Warning: embed_query failed: {e}");
+                    None
                 }
             });
-            let results = sae::storage::hybrid_search(
-                db.conn(),
-                &query,
-                query_embedding.as_deref(),
-                limit,
-            )?;
+            let results =
+                sae::storage::hybrid_search(db.conn(), &query, query_embedding.as_deref(), limit)?;
             if results.is_empty() {
                 println!("No results for '{query}'");
             } else {
@@ -184,13 +173,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let post = client.get_post(team, number).await?;
             println!("---");
             println!("title: \"{}\"", post.full_name.replace('"', "\\\""));
-            if let Some(ref cat) = post.category {
-                if !cat.is_empty() {
-                    println!("category: \"{}\"", cat.replace('"', "\\\""));
-                }
+            if let Some(ref cat) = post.category
+                && !cat.is_empty()
+            {
+                println!("category: \"{}\"", cat.replace('"', "\\\""));
             }
             if !post.tags.is_empty() {
-                let tags: Vec<String> = post.tags.iter().map(|t| format!("\"{}\"", t.replace('"', "\\\""))).collect();
+                let tags: Vec<String> = post
+                    .tags
+                    .iter()
+                    .map(|t| format!("\"{}\"", t.replace('"', "\\\"")))
+                    .collect();
                 println!("tags: [{}]", tags.join(", "));
             }
             println!("author: \"@{}\"", post.created_by.screen_name);
@@ -258,8 +251,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("Checking model...");
             let paths = rurico::embed::download_model()
                 .map_err(|e| format!("Failed to download model: {e}"))?;
-            let embedder = Embedder::new(&paths)
-                .map_err(|e| format!("Failed to load model: {e}"))?;
+            let embedder =
+                Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
             eprintln!("Model ready");
 
             const BATCH_SIZE: u32 = 500;
@@ -277,11 +270,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let batch_len = batch.len() as u32;
                 match embedder.embed_documents_batch(&texts) {
                     Ok(embs) => {
-                        let embeddings: Vec<(i64, Vec<f32>)> = batch
-                            .iter()
-                            .map(|(id, _)| *id)
-                            .zip(embs)
-                            .collect();
+                        let embeddings: Vec<(i64, Vec<f32>)> =
+                            batch.iter().map(|(id, _)| *id).zip(embs).collect();
                         total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
                     }
                     Err(e) => {
@@ -304,7 +294,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let post = client.get_post(team, number).await?;
             let current_category = post.category.as_deref().unwrap_or("");
             if current_category.starts_with("Archived/") || current_category == "Archived" {
-                println!("Already archived: {} (#{}) {}", post.name, post.number, post.url);
+                println!(
+                    "Already archived: {} (#{}) {}",
+                    post.name, post.number, post.url
+                );
             } else {
                 let archived_category = if current_category.is_empty() {
                     "Archived".to_string()
@@ -312,7 +305,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     format!("Archived/{current_category}")
                 };
                 let post = client
-                    .update_post(team, number, None, None, Some(&archived_category), None, None)
+                    .update_post(
+                        team,
+                        number,
+                        None,
+                        None,
+                        Some(&archived_category),
+                        None,
+                        None,
+                    )
                     .await?;
                 println!("Archived: {} (#{}) {}", post.name, post.number, post.url);
             }
@@ -370,7 +371,9 @@ fn try_load_embedder() -> Option<Embedder> {
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(error = %e, "embedding model not available");
-            eprintln!("Note: embedding model not available. Run `sae embed <team>` to enable semantic search.");
+            eprintln!(
+                "Note: embedding model not available. Run `sae embed <team>` to enable semantic search."
+            );
             return None;
         }
     };

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -6,7 +6,9 @@ pub fn add_embeddings(
     conn: &Connection,
     embeddings: &[(i64, Vec<f32>)],
 ) -> Result<u32, StorageError> {
-    let tx = conn.unchecked_transaction().map_err(super::StorageError::Db)?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(super::StorageError::Db)?;
     let mut count = 0u32;
     for (chunk_id, embedding) in embeddings {
         let exists: bool = tx.query_row(
@@ -54,8 +56,8 @@ pub fn has_embeddings(conn: &Connection) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rurico::embed::EMBEDDING_DIMS;
     use crate::storage::Db;
+    use rurico::embed::EMBEDDING_DIMS;
 
     fn make_embedding(val: f32) -> Vec<f32> {
         vec![val; EMBEDDING_DIMS as usize]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,7 +2,7 @@ pub mod embed;
 pub mod search;
 pub mod types;
 pub use embed::{add_embeddings, get_unembedded_chunks, has_embeddings};
-pub use search::{hybrid_search, SearchResult};
+pub use search::{SearchResult, hybrid_search};
 pub use types::*;
 
 use std::path::Path;
@@ -73,8 +73,7 @@ impl Db {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ =
-                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
             }
         }
         let conn = open_with_wal_recovery(path)?;
@@ -86,8 +85,7 @@ impl Db {
 
     pub fn open_memory() -> Result<Self, StorageError> {
         ensure_sqlite_vec()?;
-        let conn =
-            Connection::open_in_memory().map_err(|e| StorageError::Open(e.to_string()))?;
+        let conn = Connection::open_in_memory().map_err(|e| StorageError::Open(e.to_string()))?;
         let db = Self { conn };
         db.init_schema()?;
         Ok(db)
@@ -157,9 +155,7 @@ fn is_recoverable_open_error(err: &rusqlite::Error) -> bool {
         err,
         rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error {
-                code: ErrorCode::DatabaseCorrupt
-                    | ErrorCode::CannotOpen
-                    | ErrorCode::NotADatabase,
+                code: ErrorCode::DatabaseCorrupt | ErrorCode::CannotOpen | ErrorCode::NotADatabase,
                 ..
             },
             _,
@@ -226,7 +222,14 @@ pub fn save_sync_state(
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock before epoch")
         .as_secs() as i64;
-    save_sync_state_at(conn, latest_updated_at, total_count, local_count, last_page, epoch)
+    save_sync_state_at(
+        conn,
+        latest_updated_at,
+        total_count,
+        local_count,
+        last_page,
+        epoch,
+    )
 }
 
 pub(crate) fn save_sync_state_at(
@@ -241,20 +244,24 @@ pub(crate) fn save_sync_state_at(
         "INSERT OR REPLACE INTO sync_state \
          (id, latest_updated_at, total_count, local_count, last_page, updated_at) \
          VALUES (1, ?1, ?2, ?3, ?4, datetime(?5, 'unixepoch'))",
-        rusqlite::params![latest_updated_at, total_count, local_count, last_page, epoch_secs],
+        rusqlite::params![
+            latest_updated_at,
+            total_count,
+            local_count,
+            last_page,
+            epoch_secs
+        ],
     )?;
     Ok(())
 }
 
 pub fn count_posts(conn: &Connection) -> Result<u32, StorageError> {
-    let count: u32 =
-        conn.query_row("SELECT COUNT(*) FROM posts", [], |row| row.get(0))?;
+    let count: u32 = conn.query_row("SELECT COUNT(*) FROM posts", [], |row| row.get(0))?;
     Ok(count)
 }
 
 pub fn count_chunks(conn: &Connection) -> Result<u32, StorageError> {
-    let count: u32 =
-        conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
+    let count: u32 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
     Ok(count)
 }
 
@@ -409,11 +416,13 @@ mod tests {
         );
 
         save_sync_state(db.conn(), None, 10, 10, None).unwrap();
-        assert!(get_sync_state(db.conn())
-            .unwrap()
-            .unwrap()
-            .last_page
-            .is_none());
+        assert!(
+            get_sync_state(db.conn())
+                .unwrap()
+                .unwrap()
+                .last_page
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -16,11 +16,7 @@ pub struct SearchResult {
 }
 
 /// FTS5 trigram search with fts5vocab short-term expansion.
-pub fn fts_search(
-    conn: &Connection,
-    query: &str,
-    limit: u32,
-) -> Result<Vec<FtsHit>, StorageError> {
+pub fn fts_search(conn: &Connection, query: &str, limit: u32) -> Result<Vec<FtsHit>, StorageError> {
     let sanitized = sanitize_fts(query);
     let expanded = rurico::storage::fts_expand_short_terms(conn, &sanitized);
 
@@ -168,10 +164,17 @@ fn batch_fetch_post_meta(
         .collect();
     let rows = stmt
         .query_map(params.as_slice(), |row| {
-            Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+            Ok((
+                row.get::<_, u32>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(rows.into_iter().map(|(n, name, url)| (n, (name, url))).collect())
+    Ok(rows
+        .into_iter()
+        .map(|(n, name, url)| (n, (name, url)))
+        .collect())
 }
 
 #[derive(Debug, Clone)]
@@ -213,8 +216,16 @@ mod tests {
 
     fn setup_db_with_posts(db: &Db) {
         let posts = [
-            (1, "認証ガイド", "# 認証フロー\n認証の仕組みを説明します\n# 実装手順\nコードの書き方"),
-            (2, "API設計", "# エンドポイント\nREST APIの設計方針\n# 認証\nトークン認証の詳細"),
+            (
+                1,
+                "認証ガイド",
+                "# 認証フロー\n認証の仕組みを説明します\n# 実装手順\nコードの書き方",
+            ),
+            (
+                2,
+                "API設計",
+                "# エンドポイント\nREST APIの設計方針\n# 認証\nトークン認証の詳細",
+            ),
             (3, "デプロイ", "# 手順\nデプロイの手順ガイド"),
         ];
         for (num, name, body) in &posts {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -96,7 +96,7 @@ pub async fn harvest(
             Err(e) => return Err(e.into()),
         };
         api_total = resp.total_count;
-        let est_pages = (api_total + 99) / 100;
+        let est_pages = api_total.div_ceil(100);
 
         let tx = db
             .conn()
@@ -127,7 +127,12 @@ pub async fn harvest(
         tx.commit().map_err(StorageError::Db)?;
 
         eprintln!("  page {page}/{est_pages} — {total_fetched} posts fetched");
-        info!(page, fetched = resp.posts.len(), total_fetched, "harvested page");
+        info!(
+            page,
+            fetched = resp.posts.len(),
+            total_fetched,
+            "harvested page"
+        );
 
         match resp.next_page {
             Some(np) => page = np,
@@ -175,10 +180,7 @@ fn build_window_query(base: Option<&str>, boundary: Option<&str>) -> Option<Stri
     }
 }
 
-fn resolve_start(
-    full: bool,
-    state: &Option<storage::SyncState>,
-) -> (u32, Option<String>) {
+fn resolve_start(full: bool, state: &Option<storage::SyncState>) -> (u32, Option<String>) {
     if full {
         return (1, None);
     }


### PR DESCRIPTION
## 概要

- `push` / `pull_request` (対象: `main`) で自動実行される CI ワークフローを追加
- `cargo check` → `cargo test` → `cargo clippy -- -D warnings` → `cargo fmt --check` を順次実行
- `macos-latest` ランナー、タイムアウト 15 分、`rust-cache` によるキャッシュを設定
- アクションは SHA ピン固定でサプライチェーンリスクを低減
- `concurrency` で同一 ref の実行を自動キャンセル

## テスト計画

- [ ] PR を作成してワークフローがトリガーされることを確認
- [ ] 全ステップ (check, test, clippy, fmt) がパスすることを確認
- [ ] clippy 警告がある場合にジョブが失敗することを確認