### PR TITLE
時間減衰ブースト・巨大チャンク分割・CLI 省略記法の追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +249,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1086,6 +1106,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2298,6 +2342,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 name = "sae"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "reqwest 0.13.2",
  "rurico",
@@ -3307,6 +3352,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 rurico = { git = "https://github.com/thkt/rurico", rev = "87f017f" }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -20,6 +20,8 @@ pub struct Chunk {
     pub chunk_type: ChunkType,
 }
 
+const MAX_CHUNK_BYTES: usize = 16_000;
+
 pub fn chunk_markdown(body_md: &str) -> Vec<Chunk> {
     if body_md.trim().is_empty() {
         return Vec::new();
@@ -29,11 +31,11 @@ pub fn chunk_markdown(body_md: &str) -> Vec<Chunk> {
     let headings = find_headings(&lines);
 
     if headings.is_empty() {
-        return vec![Chunk {
+        return split_oversized(Chunk {
             section_title: None,
             content: body_md.to_string(),
             chunk_type: ChunkType::Full,
-        }];
+        });
     }
 
     let mut chunks = Vec::new();
@@ -51,7 +53,7 @@ pub fn chunk_markdown(body_md: &str) -> Vec<Chunk> {
 
     for (idx, (line_idx, title)) in headings.iter().enumerate() {
         let end = headings.get(idx + 1).map_or(lines.len(), |(next, _)| *next);
-        let content: String = lines[*line_idx..end].join("\n");
+        let content: String = lines[(*line_idx + 1)..end].join("\n");
         if !content.trim().is_empty() {
             chunks.push(Chunk {
                 section_title: if title.is_empty() {
@@ -65,15 +67,23 @@ pub fn chunk_markdown(body_md: &str) -> Vec<Chunk> {
         }
     }
 
-    if chunks.is_empty() {
-        return vec![Chunk {
-            section_title: None,
-            content: body_md.to_string(),
-            chunk_type: ChunkType::Full,
-        }];
-    }
+    chunks.into_iter().flat_map(split_oversized).collect()
+}
 
-    chunks
+fn split_oversized(chunk: Chunk) -> Vec<Chunk> {
+    if chunk.content.len() <= MAX_CHUNK_BYTES {
+        return vec![chunk];
+    }
+    // Heading is already excluded from content at chunk creation (line 56).
+    // FTS indexing of section_title is tracked in #8.
+    rurico::text::split_text(&chunk.content, MAX_CHUNK_BYTES)
+        .into_iter()
+        .map(|part| Chunk {
+            section_title: chunk.section_title.clone(),
+            content: part.to_string(),
+            chunk_type: chunk.chunk_type.clone(),
+        })
+        .collect()
 }
 
 fn find_headings(lines: &[&str]) -> Vec<(usize, String)> {
@@ -167,9 +177,23 @@ mod tests {
 
     #[test]
     fn nested_headings() {
-        let md = "# H1\n## H2\n### H3";
+        let md = "# H1\nText1\n## H2\nText2\n### H3\nText3";
         let chunks = chunk_markdown(md);
         assert_eq!(chunks.len(), 3);
+        assert!(!chunks[0].content.contains("# H1"));
+        assert!(chunks[0].content.contains("Text1"));
+    }
+
+    #[test]
+    fn heading_only_returns_empty() {
+        let chunks = chunk_markdown("# Title Only");
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn headings_only_no_body_returns_empty() {
+        let chunks = chunk_markdown("# H1\n## H2\n### H3");
+        assert!(chunks.is_empty());
     }
 
     #[test]
@@ -184,6 +208,73 @@ mod tests {
         assert!(parse_heading("#NoSpace").is_none());
         assert!(parse_heading("####### Seven").is_none());
         assert!(parse_heading("    # Indented").is_none());
+    }
+
+    // T-026: oversized section is split
+    #[test]
+    fn oversized_chunk_is_split() {
+        // 20KB section with paragraph breaks
+        let paragraph = "あ".repeat(500); // ~1500 bytes in UTF-8
+        let mut body = "# Big Section\n".to_string();
+        for i in 0..15 {
+            body.push_str(&format!("Paragraph {i}: {paragraph}\n\n"));
+        }
+        let chunks = chunk_markdown(&body);
+        assert!(chunks.len() > 1, "should be split into multiple chunks");
+        for chunk in &chunks {
+            assert!(
+                chunk.content.len() <= MAX_CHUNK_BYTES,
+                "chunk {} bytes exceeds MAX_CHUNK_BYTES",
+                chunk.content.len()
+            );
+        }
+    }
+
+    // T-027: normal chunk is not split, heading excluded from content
+    #[test]
+    fn normal_chunk_not_split() {
+        let md = "# Normal\nSmall content here";
+        let chunks = chunk_markdown(md);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].section_title.as_deref(), Some("Normal"));
+        assert!(!chunks[0].content.contains("# Normal"));
+        assert!(chunks[0].content.contains("Small content here"));
+    }
+
+    // T-028: split chunks preserve section_title; heading excluded from content
+    #[test]
+    fn split_chunks_preserve_section_title() {
+        let paragraph = "あ".repeat(500);
+        let mut body = "# My Title\n".to_string();
+        for i in 0..15 {
+            body.push_str(&format!("Paragraph {i}: {paragraph}\n\n"));
+        }
+        let chunks = chunk_markdown(&body);
+        assert!(chunks.len() > 1);
+        for chunk in &chunks {
+            assert_eq!(chunk.section_title.as_deref(), Some("My Title"));
+            assert_eq!(chunk.chunk_type, ChunkType::Section);
+            assert!(
+                !chunk.content.starts_with("# "),
+                "content should not contain heading line"
+            );
+        }
+    }
+
+    // T-032: exactly MAX_CHUNK_BYTES is NOT split (threshold is >, not >=)
+    #[test]
+    fn exact_threshold_not_split() {
+        // Content excludes the heading line, so build body content of exactly
+        // MAX_CHUNK_BYTES after the heading.
+        let padding = "a".repeat(MAX_CHUNK_BYTES);
+        let body = format!("# E\n{padding}");
+        let chunks = chunk_markdown(&body);
+        assert_eq!(
+            chunks[0].content.len(),
+            MAX_CHUNK_BYTES,
+            "chunk content should be exactly MAX_CHUNK_BYTES"
+        );
+        assert_eq!(chunks.len(), 1, "exactly at threshold should not split");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ struct Cli {
     command: Command,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum Command {
     /// Fetch and index esa posts
     Harvest {
@@ -109,6 +109,32 @@ enum Command {
     },
 }
 
+const KNOWN_SUBCOMMANDS: &[&str] = &[
+    "harvest", "search", "get", "create", "update", "archive", "ship", "embed", "status",
+];
+
+fn parse_cli_args<I, T>(args: I) -> Result<Cli, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+
+    // Shorthand: `sae "query"` → `sae search "query"`
+    // Conditions: exactly 2 args, second arg doesn't start with '-',
+    // and second arg is not a known subcommand name.
+    if args.len() == 2
+        && let Some(first_arg) = args[1].to_str()
+        && !first_arg.starts_with('-')
+        && !KNOWN_SUBCOMMANDS.contains(&first_arg)
+    {
+        let expanded = vec![args[0].clone(), "search".into(), args[1].clone()];
+        return Cli::try_parse_from(expanded);
+    }
+
+    Cli::try_parse_from(args)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
@@ -118,7 +144,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let cli = Cli::parse();
+    let cli = parse_cli_args(std::env::args_os()).unwrap_or_else(|e| e.exit());
     let config = Config::load()?;
 
     match cli.command {
@@ -146,8 +172,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     None
                 }
             });
-            let results =
-                sae::storage::hybrid_search(db.conn(), &query, query_embedding.as_deref(), limit)?;
+            let results = sae::storage::hybrid_search(
+                db.conn(),
+                &query,
+                query_embedding.as_deref(),
+                limit,
+                chrono::Utc::now(),
+            )?;
             if results.is_empty() {
                 println!("No results for '{query}'");
             } else {
@@ -364,6 +395,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-029: shorthand `sae "認証"` → search
+    #[test]
+    fn shorthand_single_query_becomes_search() {
+        let cli = parse_cli_args(["sae", "認証"]).unwrap();
+        match cli.command {
+            Command::Search { query, .. } => assert_eq!(query, "認証"),
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-030: explicit `sae search "認証"` is not double-injected
+    #[test]
+    fn explicit_search_not_double_injected() {
+        let cli = parse_cli_args(["sae", "search", "認証"]).unwrap();
+        match cli.command {
+            Command::Search { query, .. } => assert_eq!(query, "認証"),
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-031: `sae harvest team` stays as harvest
+    #[test]
+    fn known_subcommand_not_shorthand() {
+        let cli = parse_cli_args(["sae", "harvest", "myteam"]).unwrap();
+        match cli.command {
+            Command::Harvest { team, .. } => assert_eq!(team, "myteam"),
+            other => panic!("expected Harvest, got {other:?}"),
+        }
+    }
+
+    // T-033: `sae search` (missing required arg) → clap error via helper
+    #[test]
+    fn search_missing_arg_is_clap_error() {
+        let result = parse_cli_args(["sae", "search"]);
+        assert!(result.is_err(), "search without query should be clap error");
+    }
+
+    // T-034: `sae harvest` (missing required arg) → clap error via helper
+    #[test]
+    fn harvest_missing_arg_is_clap_error() {
+        let result = parse_cli_args(["sae", "harvest"]);
+        assert!(result.is_err(), "harvest without team should be clap error");
+    }
 }
 
 fn try_load_embedder() -> Option<Embedder> {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -82,12 +82,18 @@ pub fn vec_search(
     Ok(rows)
 }
 
-/// Hybrid search: merge FTS5 + vector results via Reciprocal Rank Fusion.
+const RECENCY_HALF_LIFE: f64 = 30.0;
+const RECENCY_WEIGHT: f64 = 0.2;
+const SECS_PER_DAY: f64 = 86_400.0;
+
+/// Hybrid search: merge FTS5 + vector results via Reciprocal Rank Fusion,
+/// then apply recency decay boost based on `updated_at`.
 pub fn hybrid_search(
     conn: &Connection,
     query: &str,
     query_embedding: Option<&[f32]>,
     limit: u32,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Vec<SearchResult>, StorageError> {
     let candidate_limit = limit * 3;
 
@@ -109,22 +115,42 @@ pub fn hybrid_search(
     let vec_ranked: Vec<(u32, f64)> = vec_hits.iter().map(|h| (h.post_number, 0.0)).collect();
     let merged = rurico::storage::rrf_merge(&fts_ranked, &vec_ranked);
 
-    let post_numbers: Vec<u32> = merged
-        .iter()
-        .take(limit as usize)
-        .map(|(pn, _)| *pn)
-        .collect();
-    let post_meta = batch_fetch_post_meta(conn, &post_numbers)?;
+    // Fetch metadata for all candidates (not just limit) to apply decay before truncation
+    let candidate_numbers: Vec<u32> = merged.iter().map(|(pn, _)| *pn).collect();
+    let post_meta = batch_fetch_post_meta(conn, &candidate_numbers)?;
 
     let fts_map: HashMap<u32, &FtsHit> = fts_hits.iter().map(|h| (h.post_number, h)).collect();
     let vec_map: HashMap<u32, &VecHit> = vec_hits.iter().map(|h| (h.post_number, h)).collect();
 
+    // Apply recency decay to all candidates, then re-sort
+    let mut scored: Vec<(u32, f64)> = merged
+        .into_iter()
+        .map(|(post_number, rrf_score)| {
+            let decay = post_meta
+                .get(&post_number)
+                .and_then(|(_, _, updated_at)| {
+                    chrono::DateTime::parse_from_rfc3339(updated_at)
+                        .map_err(|e| warn!(%e, %updated_at, "unparseable updated_at, decay=0.0"))
+                        .ok()
+                })
+                .map(|updated| {
+                    let age_days = (now - updated.with_timezone(&chrono::Utc)).num_seconds() as f64
+                        / SECS_PER_DAY;
+                    rurico::storage::recency_decay(age_days, RECENCY_HALF_LIFE)
+                })
+                .unwrap_or(0.0);
+            let boosted = rrf_score * (1.0 + RECENCY_WEIGHT * decay);
+            (post_number, boosted)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+
     let mut results = Vec::new();
-    for (post_number, score) in merged.into_iter().take(limit as usize) {
-        let (name, url) = post_meta
+    for (post_number, score) in scored.into_iter().take(limit as usize) {
+        let (name, url, _) = post_meta
             .get(&post_number)
             .cloned()
-            .unwrap_or_else(|| (format!("#{post_number}"), String::new()));
+            .unwrap_or_else(|| (format!("#{post_number}"), String::new(), String::new()));
 
         let (section_title, snippet) = fts_map
             .get(&post_number)
@@ -152,13 +178,13 @@ pub fn hybrid_search(
 fn batch_fetch_post_meta(
     conn: &Connection,
     post_numbers: &[u32],
-) -> Result<HashMap<u32, (String, String)>, StorageError> {
+) -> Result<HashMap<u32, (String, String, String)>, StorageError> {
     if post_numbers.is_empty() {
         return Ok(HashMap::new());
     }
     let placeholders: Vec<String> = (1..=post_numbers.len()).map(|i| format!("?{i}")).collect();
     let sql = format!(
-        "SELECT number, name, url FROM posts WHERE number IN ({})",
+        "SELECT number, name, url, updated_at FROM posts WHERE number IN ({})",
         placeholders.join(", ")
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -172,12 +198,13 @@ fn batch_fetch_post_meta(
                 row.get::<_, u32>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows
         .into_iter()
-        .map(|(n, name, url)| (n, (name, url)))
+        .map(|(n, name, url, updated_at)| (n, (name, url, updated_at)))
         .collect())
 }
 
@@ -260,7 +287,7 @@ fn clean_for_trigram(query: &str) -> String {
     // Parse into segments: quoted terms and OR groups
     let mut fixed: Vec<String> = Vec::new();
     let mut or_groups: Vec<Vec<String>> = Vec::new();
-    let mut chars = cleaned.chars().peekable();
+    let mut chars = cleaned.chars();
 
     while let Some(c) = chars.next() {
         if c == '(' {
@@ -408,7 +435,8 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let results = hybrid_search(db.conn(), "認証フロー", None, 10).unwrap();
+        let results =
+            hybrid_search(db.conn(), "認証の仕組み", None, 10, chrono::Utc::now()).unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].post_number, 1);
         assert!(!results[0].post_name.is_empty());
@@ -420,7 +448,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let results = hybrid_search(db.conn(), "", None, 10).unwrap();
+        let results = hybrid_search(db.conn(), "", None, 10, chrono::Utc::now()).unwrap();
         assert!(results.is_empty());
     }
 
@@ -553,8 +581,9 @@ mod tests {
 
         let meta = batch_fetch_post_meta(db.conn(), &[1, 3]).unwrap();
         assert_eq!(meta.len(), 2);
-        assert!(meta.get(&1).unwrap().0.contains("認証"));
-        assert!(meta.get(&3).unwrap().0.contains("デプロイ"));
+        assert!(meta.get(&1).unwrap().0.contains("認証")); // name
+        assert!(meta.get(&3).unwrap().0.contains("デプロイ")); // name
+        assert!(!meta.get(&1).unwrap().2.is_empty()); // updated_at
     }
 
     #[test]
@@ -562,5 +591,98 @@ mod tests {
         let db = Db::open_memory().unwrap();
         let meta = batch_fetch_post_meta(db.conn(), &[]).unwrap();
         assert!(meta.is_empty());
+    }
+
+    // T-024: recent post scores higher than old post
+    #[test]
+    fn hybrid_search_recency_boost_recent_post_scores_higher() {
+        let db = Db::open_memory().unwrap();
+
+        // Post A: updated 1 day ago, Post B: updated 30 days ago.
+        // Both match the same query so raw RRF scores are equal.
+        let shared_body = "# 認証フロー\n認証の仕組みを説明します";
+        let posts = [
+            (1u32, "PostA", "2025-01-31T00:00:00+09:00"), // 1 day before "now"
+            (2u32, "PostB", "2025-01-02T00:00:00+09:00"), // 30 days before "now"
+        ];
+        for (num, name, updated) in &posts {
+            storage::upsert_post(
+                db.conn(),
+                &storage::EsaPostRow {
+                    number: *num,
+                    name: name.to_string(),
+                    full_name: format!("dev/{name}"),
+                    body_md: shared_body.to_string(),
+                    category: Some("dev".into()),
+                    tags: "[]".into(),
+                    wip: false,
+                    kind: "stock".into(),
+                    url: format!("https://example.esa.io/posts/{num}"),
+                    created_at: "2025-01-01T00:00:00+09:00".into(),
+                    updated_at: updated.to_string(),
+                    created_by: "alice".into(),
+                    updated_by: "alice".into(),
+                    revision_number: 1,
+                },
+            )
+            .unwrap();
+            storage::rechunk_post(db.conn(), *num, shared_body).unwrap();
+        }
+
+        let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let results = hybrid_search(db.conn(), "認証の仕組み", None, 10, now).unwrap();
+        assert!(results.len() >= 2, "both posts should match");
+
+        let score_a = results.iter().find(|r| r.post_number == 1).unwrap().score;
+        let score_b = results.iter().find(|r| r.post_number == 2).unwrap().score;
+        assert!(
+            score_a > score_b,
+            "post A (1 day old) should score higher than post B (30 days old), \
+             got A={score_a} B={score_b}"
+        );
+    }
+
+    // T-025: unparseable updated_at does not panic, decay=0.0 applied
+    #[test]
+    fn hybrid_search_unparseable_updated_at_no_panic() {
+        let db = Db::open_memory().unwrap();
+
+        let body = "# 認証フロー\n認証の仕組みを説明します";
+        storage::upsert_post(
+            db.conn(),
+            &storage::EsaPostRow {
+                number: 1,
+                name: "BadDate".to_string(),
+                full_name: "dev/BadDate".to_string(),
+                body_md: body.to_string(),
+                category: Some("dev".into()),
+                tags: "[]".into(),
+                wip: false,
+                kind: "stock".into(),
+                url: "https://example.esa.io/posts/1".into(),
+                created_at: "2025-01-01T00:00:00+09:00".into(),
+                updated_at: "not-a-date".into(),
+                created_by: "alice".into(),
+                updated_by: "alice".into(),
+                revision_number: 1,
+            },
+        )
+        .unwrap();
+        storage::rechunk_post(db.conn(), 1, body).unwrap();
+
+        let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let results = hybrid_search(db.conn(), "認証の仕組み", None, 10, now).unwrap();
+
+        // Must not panic. With decay=0.0 the boost factor is
+        // (1.0 + 0.2 * 0.0) = 1.0, so score equals raw RRF score.
+        assert!(!results.is_empty(), "post should still be returned");
+        assert!(
+            results[0].score > 0.0,
+            "score should be positive (raw RRF with 1.0x boost)"
+        );
     }
 }


### PR DESCRIPTION
## 概要
- hybrid_search に updated_at ベースの時間減衰ブースト追加（30日 half-life、weight 0.2）。candidate_limit 全件に decay 適用後に再ソートして limit で切る
- 16KB 超チャンクを `rurico::text::split_text` で段落境界優先分割。heading 行は content から除去し section_title をメタとして保持（FTS での heading 検索は #8 で対応予定）
- `sae "query"` → `sae search "query"` の CLI 省略記法。条件: argv.len()==2、`-` で始まらない、既知サブコマンド名でない
- `sanitize_fts` を `rurico::prepare_match_query` に置換 + trigram 互換レイヤー（`clean_for_trigram`）

## テスト計画
- [x] `cargo test` — 95 tests passed (88 lib + 5 bin + 2 doc)
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [ ] T-024: 最近更新された記事が古い記事より上位にランクされること
- [ ] T-025: updated_at パース不能時に decay=0.0 でフォールバック
- [ ] T-026/T-027/T-028/T-032: チャンク分割の境界テスト
- [ ] T-029/T-030/T-031/T-033/T-034: CLI 省略記法テスト

Closes #1