### PR TITLE
FTSチャンクにsection_titleを追加し、エージェント親和性のCLIフラグを実装

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -555,7 +555,10 @@ mod tests {
         let post = test_esa_post(None);
         let json_str = serde_json::to_string(&post).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
-        assert!(v["body_md"].is_null(), "[T-036] body_md should be null when None");
+        assert!(
+            v["body_md"].is_null(),
+            "[T-036] body_md should be null when None"
+        );
         assert_eq!(v["number"], 42);
         assert_eq!(v["name"], "Test Post");
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -195,7 +195,7 @@ impl EsaClient {
         self.send(|http| http.post(&url).json(&body)).await
     }
 
-    #[allow(clippy::too_many_arguments)] // will be replaced by UpdatePostParams in PR #4
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_post(
         &self,
         team: &str,
@@ -311,7 +311,7 @@ fn retry_wait(status: u16, retry_after: Option<&str>, attempt: u32) -> Option<Du
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_post_json() -> serde_json::Value {
@@ -524,5 +524,128 @@ mod tests {
     fn retry_wait_non_retryable() {
         assert!(retry_wait(400, None, 0).is_none());
         assert!(retry_wait(404, None, 0).is_none());
+    }
+
+    fn test_esa_post(body_md: Option<String>) -> EsaPost {
+        EsaPost {
+            number: 42,
+            name: "Test Post".to_string(),
+            full_name: "dev/Test Post".to_string(),
+            body_md,
+            category: Some("dev".to_string()),
+            tags: vec!["rust".to_string()],
+            wip: false,
+            kind: "stock".to_string(),
+            url: "https://example.esa.io/posts/42".to_string(),
+            created_at: "2025-01-01T00:00:00+09:00".to_string(),
+            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
+            created_by: EsaUser {
+                screen_name: "alice".to_string(),
+            },
+            updated_by: EsaUser {
+                screen_name: "bob".to_string(),
+            },
+            revision_number: 3,
+        }
+    }
+
+    // T-036: get --json → body_md field is null
+    #[test]
+    fn esa_post_json_body_md_null_when_none() {
+        let post = test_esa_post(None);
+        let json_str = serde_json::to_string(&post).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(v["body_md"].is_null(), "[T-036] body_md should be null when None");
+        assert_eq!(v["number"], 42);
+        assert_eq!(v["name"], "Test Post");
+    }
+
+    // T-043: get --json --with-body → body_md is string value
+    #[test]
+    fn esa_post_json_body_md_present_when_some() {
+        let post = test_esa_post(Some("# Hello\nWorld".to_string()));
+        let json_str = serde_json::to_string(&post).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(
+            v["body_md"], "# Hello\nWorld",
+            "[T-043] body_md should be the string value"
+        );
+    }
+
+    // T-048: create --json → EsaPost JSON (name, number, url)
+    // T-050: update --json → EsaPost JSON
+    // T-051: archive --json → EsaPost JSON
+    // T-052: ship --json → EsaPost JSON
+    // All share the same serialization contract: EsaPost → JSON with name, number, url.
+    #[test]
+    fn esa_post_json_has_name_number_url() {
+        // [T-048, T-050, T-051, T-052] All mutation commands output EsaPost JSON
+        let post = test_esa_post(Some("body".to_string()));
+        let json_str = serde_json::to_string(&post).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["number"], 42, "[T-048] number field");
+        assert_eq!(v["name"], "Test Post", "[T-048] name field");
+        assert_eq!(
+            v["url"], "https://example.esa.io/posts/42",
+            "[T-048] url field"
+        );
+        assert_eq!(v["wip"], false, "[T-048] wip field");
+        assert_eq!(v["tags"][0], "rust", "[T-048] tags field");
+    }
+
+    // TC-007: create_post sends correct request body
+    #[tokio::test]
+    async fn create_post_sends_correct_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/teams/myteam/posts"))
+            .and(body_json(serde_json::json!({
+                "post": {
+                    "name": "My Title",
+                    "body_md": "# Content",
+                    "category": "docs",
+                    "tags": ["rust", "api"],
+                    "wip": true,
+                }
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json()))
+            .mount(&server)
+            .await;
+
+        test_client(&server)
+            .await
+            .create_post(
+                "myteam",
+                "My Title",
+                Some("# Content"),
+                Some("docs"),
+                vec!["rust".into(), "api".into()],
+                true,
+            )
+            .await
+            .unwrap();
+    }
+
+    // TC-007: create_post omits None fields via skip_serializing_if
+    #[tokio::test]
+    async fn create_post_omits_none_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/teams/myteam/posts"))
+            .and(body_json(serde_json::json!({
+                "post": {
+                    "name": "Minimal",
+                    "wip": false,
+                }
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json()))
+            .mount(&server)
+            .await;
+
+        test_client(&server)
+            .await
+            .create_post("myteam", "Minimal", None, None, vec![], false)
+            .await
+            .unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,7 +487,7 @@ fn collect_team_statuses(
                     error: Some(e.to_string()),
                     db_path: None,
                 },
-            }
+            },
             Ok(path) => sae::storage::TeamStatus {
                 team: t.to_string(),
                 status: sae::storage::SyncStatus::NotSynced,
@@ -633,14 +633,9 @@ mod tests {
     // T-038: create args + --dry-run → parse succeeds with dry_run=true
     #[test]
     fn create_with_dry_run_parses_dry_run_flag() {
-        let cli = parse_cli_args([
-            "sae", "create", "--name", "Test Post", "--dry-run",
-        ])
-        .unwrap();
+        let cli = parse_cli_args(["sae", "create", "--name", "Test Post", "--dry-run"]).unwrap();
         match cli.command {
-            Command::Create {
-                name, dry_run, ..
-            } => {
+            Command::Create { name, dry_run, .. } => {
                 assert_eq!(name, "Test Post", "[T-038] name should match");
                 assert!(dry_run, "[T-038] dry_run should be true");
             }
@@ -672,10 +667,8 @@ mod tests {
     // For now, test the parse side: --body-file "-" parses correctly.
     #[test]
     fn body_file_dash_parses_as_stdin() {
-        let cli = parse_cli_args([
-            "sae", "create", "--name", "Stdin Post", "--body-file", "-",
-        ])
-        .unwrap();
+        let cli =
+            parse_cli_args(["sae", "create", "--name", "Stdin Post", "--body-file", "-"]).unwrap();
         match cli.command {
             Command::Create { body_file, .. } => {
                 assert_eq!(
@@ -728,7 +721,10 @@ mod tests {
         use clap::CommandFactory;
         let cmd = Cli::command();
         for sub in cmd.get_subcommands() {
-            let after_help = sub.get_after_help().map(|h| h.to_string()).unwrap_or_default();
+            let after_help = sub
+                .get_after_help()
+                .map(|h| h.to_string())
+                .unwrap_or_default();
             assert!(
                 after_help.contains("Examples"),
                 "[T-042] subcommand '{}' should have Examples in after_help",
@@ -755,14 +751,20 @@ mod tests {
     #[test]
     fn resolve_body_nonexistent_file_is_error() {
         let result = resolve_body(None, Some("/nonexistent/path.md"));
-        assert!(result.is_err(), "[TC-009] nonexistent file should return error");
+        assert!(
+            result.is_err(),
+            "[TC-009] nonexistent file should return error"
+        );
     }
 
     // TC-011: flag-like argument not treated as shorthand query
     #[test]
     fn flag_like_arg_not_shorthand() {
         let result = parse_cli_args(["sae", "--unknown"]);
-        assert!(result.is_err(), "[TC-011] --unknown should be clap error, not search shorthand");
+        assert!(
+            result.is_err(),
+            "[TC-011] --unknown should be clap error, not search shorthand"
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod output;
+
 use clap::{Parser, Subcommand};
 use rurico::embed::{Embed, Embedder};
 use sae::client::EsaClient;
@@ -6,6 +8,9 @@ use sae::config::Config;
 #[derive(Parser)]
 #[command(name = "sae", about = "esa semantic search CLI")]
 struct Cli {
+    /// Output as JSON
+    #[arg(long, global = true)]
+    json: bool,
     #[command(subcommand)]
     command: Command,
 }
@@ -13,6 +18,10 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Fetch and index esa posts
+    #[command(after_help = "\
+Examples:
+  sae harvest myteam
+  sae harvest myteam --full")]
     Harvest {
         /// Team name
         team: String,
@@ -21,6 +30,10 @@ enum Command {
         full: bool,
     },
     /// Semantic search over indexed posts
+    #[command(after_help = "\
+Examples:
+  sae search \"認証\" --team myteam --limit 5
+  sae \"認証\"")]
     Search {
         /// Search query
         query: String,
@@ -32,21 +45,38 @@ enum Command {
         limit: u32,
     },
     /// Get a post by number
+    #[command(after_help = "\
+Examples:
+  sae get 42 --team myteam
+  sae --json get 42
+  sae --json get 42 --with-body")]
     Get {
         /// Post number
         number: u32,
         /// Team name
         #[arg(long)]
         team: Option<String>,
+        /// Include body_md in JSON output (ignored without --json)
+        #[arg(long)]
+        with_body: bool,
     },
     /// Create a new post
+    #[command(after_help = "\
+Examples:
+  sae create --name \"Title\" --body \"Content\" --team myteam
+  sae create --name \"Title\" --body-file draft.md
+  cat body.md | sae create --name \"Title\" --body-file -
+  sae create --name \"Title\" --dry-run")]
     Create {
         /// Post title
         #[arg(long)]
         name: String,
         /// Post body (Markdown)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "body_file")]
         body: Option<String>,
+        /// Read body from file (use "-" for stdin)
+        #[arg(long, conflicts_with = "body")]
+        body_file: Option<String>,
         /// Category path
         #[arg(long)]
         category: Option<String>,
@@ -59,8 +89,16 @@ enum Command {
         /// Team name
         #[arg(long)]
         team: Option<String>,
+        /// Preview without creating (no mutation API calls)
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Update a post
+    #[command(after_help = "\
+Examples:
+  sae update 42 --name \"New Title\" --team myteam
+  sae update 42 --body-file updated.md
+  sae update 42 --name \"New Title\" --dry-run")]
     Update {
         /// Post number
         number: u32,
@@ -68,8 +106,11 @@ enum Command {
         #[arg(long)]
         name: Option<String>,
         /// New body (Markdown)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "body_file")]
         body: Option<String>,
+        /// Read body from file (use "-" for stdin)
+        #[arg(long, conflicts_with = "body")]
+        body_file: Option<String>,
         /// New category path
         #[arg(long)]
         category: Option<String>,
@@ -79,29 +120,54 @@ enum Command {
         /// Team name
         #[arg(long)]
         team: Option<String>,
+        /// Preview without updating (no mutation API calls)
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Archive a post
+    #[command(after_help = "\
+Examples:
+  sae archive 42 --team myteam
+  sae archive 42 --dry-run")]
     Archive {
         /// Post number
         number: u32,
         /// Team name
         #[arg(long)]
         team: Option<String>,
+        /// Preview without archiving (reads current post, no mutation)
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Ship a WIP post (set wip=false)
+    #[command(after_help = "\
+Examples:
+  sae ship 42 --team myteam
+  sae ship 42 --dry-run")]
     Ship {
         /// Post number
         number: u32,
         /// Team name
         #[arg(long)]
         team: Option<String>,
+        /// Preview without shipping (no mutation API calls)
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Download model and embed all chunks
+    #[command(after_help = "\
+Examples:
+  sae embed myteam")]
     Embed {
         /// Team name
         team: String,
     },
     /// Show sync status
+    #[command(after_help = "\
+Examples:
+  sae status
+  sae status --team myteam
+  sae --json status")]
     Status {
         /// Team name (omit to show all teams)
         #[arg(long)]
@@ -113,6 +179,8 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "harvest", "search", "get", "create", "update", "archive", "ship", "embed", "status",
 ];
 
+const GLOBAL_FLAGS: &[&str] = &["--json"];
+
 fn parse_cli_args<I, T>(args: I) -> Result<Cli, clap::Error>
 where
     I: IntoIterator<Item = T>,
@@ -120,15 +188,25 @@ where
 {
     let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
 
-    // Shorthand: `sae "query"` → `sae search "query"`
-    // Conditions: exactly 2 args, second arg doesn't start with '-',
-    // and second arg is not a known subcommand name.
-    if args.len() == 2
-        && let Some(first_arg) = args[1].to_str()
+    // Shorthand: `sae "query"` or `sae --json "query"` → `sae [flags] search "query"`
+    // Strip global flags, check if remaining is [binary, query], then re-inject.
+    let (flags, rest): (Vec<_>, Vec<_>) = args
+        .iter()
+        .enumerate()
+        .partition(|(i, a)| *i > 0 && a.to_str().is_some_and(|s| GLOBAL_FLAGS.contains(&s)));
+    let rest: Vec<&std::ffi::OsString> = rest.into_iter().map(|(_, a)| a).collect();
+
+    if rest.len() == 2
+        && let Some(first_arg) = rest[1].to_str()
         && !first_arg.starts_with('-')
         && !KNOWN_SUBCOMMANDS.contains(&first_arg)
     {
-        let expanded = vec![args[0].clone(), "search".into(), args[1].clone()];
+        let mut expanded: Vec<std::ffi::OsString> = vec![rest[0].clone()];
+        for (_, f) in &flags {
+            expanded.push((*f).clone());
+        }
+        expanded.push("search".into());
+        expanded.push(rest[1].clone());
         return Cli::try_parse_from(expanded);
     }
 
@@ -146,6 +224,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = parse_cli_args(std::env::args_os()).unwrap_or_else(|e| e.exit());
     let config = Config::load()?;
+    let json = cli.json;
 
     match cli.command {
         Command::Harvest { team, full } => {
@@ -154,15 +233,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let db_path = config.team_db_path(team)?;
             let db = sae::storage::Db::open(&db_path)?;
             let result = sae::sync::harvest(&client, &db, team, full).await?;
-            println!("{result}");
+            output::harvest(&result, json)?;
         }
         Command::Search { query, team, limit } => {
             let team = config.resolve_team(team.as_deref())?;
             let db_path = config.team_db_path(team)?;
-            if !db_path.exists() {
-                eprintln!("No data for team '{team}'. Run `sae harvest {team}` first.");
-                std::process::exit(1);
-            }
+            require_db(&db_path, team);
             let db = sae::storage::Db::open(&db_path)?;
             let embedder = try_load_embedder();
             let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(&query) {
@@ -179,104 +255,97 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 limit,
                 chrono::Utc::now(),
             )?;
-            if results.is_empty() {
-                println!("No results for '{query}'");
-            } else {
-                for r in &results {
-                    let section = r
-                        .section_title
-                        .as_deref()
-                        .map(|s| format!(" > {s}"))
-                        .unwrap_or_default();
-                    println!(
-                        "[{:.4}] {}{} (#{})  {}",
-                        r.score, r.post_name, section, r.post_number, r.post_url
-                    );
-                    if !r.snippet.is_empty() {
-                        println!("  {}", r.snippet.replace('\n', " "));
-                    }
-                }
-            }
+            output::search(&results, &query, json)?;
         }
-        Command::Get { number, team } => {
+        Command::Get {
+            number,
+            team,
+            with_body,
+        } => {
             let team = config.resolve_team(team.as_deref())?;
             let client = EsaClient::from_env()?;
             let post = client.get_post(team, number).await?;
-            println!("---");
-            println!("title: \"{}\"", post.full_name.replace('"', "\\\""));
-            if let Some(ref cat) = post.category
-                && !cat.is_empty()
-            {
-                println!("category: \"{}\"", cat.replace('"', "\\\""));
-            }
-            if !post.tags.is_empty() {
-                let tags: Vec<String> = post
-                    .tags
-                    .iter()
-                    .map(|t| format!("\"{}\"", t.replace('"', "\\\"")))
-                    .collect();
-                println!("tags: [{}]", tags.join(", "));
-            }
-            println!("author: \"@{}\"", post.created_by.screen_name);
-            if post.updated_by.screen_name != post.created_by.screen_name {
-                println!("updated_by: \"@{}\"", post.updated_by.screen_name);
-            }
-            println!("updated_at: \"{}\"", post.updated_at);
-            if post.wip {
-                println!("wip: true");
-            }
-            println!("number: {}", post.number);
-            println!("url: {}", post.url);
-            println!("---");
-            println!();
-            println!("{}", post.body_md.as_deref().unwrap_or("(empty)"));
+            output::get(&post, json, with_body)?;
         }
         Command::Create {
             name,
             body,
+            body_file,
             category,
             tag,
             wip,
             team,
+            dry_run,
         } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
-            let post = client
-                .create_post(team, &name, body.as_deref(), category.as_deref(), tag, wip)
-                .await?;
-            println!("Created: {} (#{}) {}", post.name, post.number, post.url);
+            let resolved_body = resolve_body(body.as_deref(), body_file.as_deref())?;
+            if dry_run {
+                let payload = serde_json::json!({
+                    "name": name,
+                    "body_md": resolved_body,
+                    "category": category,
+                    "tags": tag,
+                    "wip": wip,
+                });
+                println!("{}", serde_json::to_string(&payload)?);
+            } else {
+                let team = config.resolve_team(team.as_deref())?;
+                let client = EsaClient::from_env()?;
+                let post = client
+                    .create_post(
+                        team,
+                        &name,
+                        resolved_body.as_deref(),
+                        category.as_deref(),
+                        tag,
+                        wip,
+                    )
+                    .await?;
+                output::post("Created", &post, json)?;
+            }
         }
         Command::Update {
             number,
             name,
             body,
+            body_file,
             category,
             tag,
             team,
+            dry_run,
         } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
-            let tags = if tag.is_empty() { None } else { Some(tag) };
-            let post = client
-                .update_post(
-                    team,
-                    number,
-                    name.as_deref(),
-                    body.as_deref(),
-                    category.as_deref(),
-                    tags,
-                    None,
-                )
-                .await?;
-            println!("Updated: {} (#{}) {}", post.name, post.number, post.url);
+            let resolved_body = resolve_body(body.as_deref(), body_file.as_deref())?;
+            if dry_run {
+                let tags = if tag.is_empty() { None } else { Some(&tag) };
+                let payload = serde_json::json!({
+                    "number": number,
+                    "name": name,
+                    "body_md": resolved_body,
+                    "category": category,
+                    "tags": tags,
+                });
+                println!("{}", serde_json::to_string(&payload)?);
+            } else {
+                let team = config.resolve_team(team.as_deref())?;
+                let client = EsaClient::from_env()?;
+                let tags = if tag.is_empty() { None } else { Some(tag) };
+                let post = client
+                    .update_post(
+                        team,
+                        number,
+                        name.as_deref(),
+                        resolved_body.as_deref(),
+                        category.as_deref(),
+                        tags,
+                        None,
+                    )
+                    .await?;
+                output::post("Updated", &post, json)?;
+            }
         }
         Command::Embed { team } => {
             let team = config.resolve_team(Some(&team))?;
             let db_path = config.team_db_path(team)?;
-            if !db_path.exists() {
-                eprintln!("No data for team '{team}'. Run `sae harvest {team}` first.");
-                std::process::exit(1);
-            }
+            require_db(&db_path, team);
             let db = sae::storage::Db::open(&db_path)?;
 
             eprintln!("Checking model...");
@@ -313,49 +382,79 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 done += batch_len;
                 eprintln!("  {done} chunks processed");
             }
-            if done == 0 {
-                println!("All chunks already embedded");
-            } else {
-                println!("Embedded {total_added} chunks");
-            }
+            let result = sae::storage::EmbedResult {
+                chunks_embedded: total_added,
+            };
+            output::embed(&result, done, json)?;
         }
-        Command::Archive { number, team } => {
+        Command::Archive {
+            number,
+            team,
+            dry_run,
+        } => {
             let team = config.resolve_team(team.as_deref())?;
             let client = EsaClient::from_env()?;
             let post = client.get_post(team, number).await?;
             let current_category = post.category.as_deref().unwrap_or("");
             if current_category.starts_with("Archived/") || current_category == "Archived" {
-                println!(
-                    "Already archived: {} (#{}) {}",
-                    post.name, post.number, post.url
-                );
+                if dry_run {
+                    let payload = serde_json::json!({
+                        "number": number,
+                        "already_archived": true,
+                        "category": current_category,
+                    });
+                    println!("{}", serde_json::to_string(&payload)?);
+                } else {
+                    output::post("Already archived", &post, json)?;
+                }
             } else {
                 let archived_category = if current_category.is_empty() {
                     "Archived".to_string()
                 } else {
                     format!("Archived/{current_category}")
                 };
-                let post = client
-                    .update_post(
-                        team,
-                        number,
-                        None,
-                        None,
-                        Some(&archived_category),
-                        None,
-                        None,
-                    )
-                    .await?;
-                println!("Archived: {} (#{}) {}", post.name, post.number, post.url);
+                if dry_run {
+                    let payload = serde_json::json!({
+                        "number": number,
+                        "from_category": current_category,
+                        "to_category": archived_category,
+                    });
+                    println!("{}", serde_json::to_string(&payload)?);
+                } else {
+                    let post = client
+                        .update_post(
+                            team,
+                            number,
+                            None,
+                            None,
+                            Some(&archived_category),
+                            None,
+                            None,
+                        )
+                        .await?;
+                    output::post("Archived", &post, json)?;
+                }
             }
         }
-        Command::Ship { number, team } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
-            let post = client
-                .update_post(team, number, None, None, None, None, Some(false))
-                .await?;
-            println!("Shipped: {} (#{}) {}", post.name, post.number, post.url);
+        Command::Ship {
+            number,
+            team,
+            dry_run,
+        } => {
+            if dry_run {
+                let payload = serde_json::json!({
+                    "number": number,
+                    "wip": false,
+                });
+                println!("{}", serde_json::to_string(&payload)?);
+            } else {
+                let team = config.resolve_team(team.as_deref())?;
+                let client = EsaClient::from_env()?;
+                let post = client
+                    .update_post(team, number, None, None, None, None, Some(false))
+                    .await?;
+                output::post("Shipped", &post, json)?;
+            }
         }
         Command::Status { team } => {
             let teams: Vec<&str> = if let Some(ref t) = team {
@@ -363,38 +462,100 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 config.teams.iter().map(String::as_str).collect()
             };
-            for t in &teams {
-                println!("--- {t} ---");
-                match config.team_db_path(t) {
-                    Ok(path) if path.exists() => {
-                        let db = sae::storage::Db::open(&path)?;
-                        let count = sae::storage::count_posts(db.conn())?;
-                        let state = sae::storage::get_sync_state(db.conn())?;
-                        println!("  Posts: {count}");
-                        if let Some(s) = state {
-                            println!(
-                                "  Last sync: {} (total: {}, local: {})",
-                                s.updated_at, s.total_count, s.local_count
-                            );
-                            if let Some(pg) = s.last_page {
-                                println!("  Checkpoint: page {pg} (interrupted)");
-                            }
-                        } else {
-                            println!("  Not yet synced");
-                        }
-                    }
-                    Ok(path) => {
-                        println!("  Not yet synced (no DB at {})", path.display());
-                    }
-                    Err(e) => {
-                        println!("  Error: {e}");
-                    }
-                }
-            }
+            let statuses = collect_team_statuses(&config, &teams)?;
+            output::status(&statuses, json)?;
         }
     }
 
     Ok(())
+}
+
+fn collect_team_statuses(
+    config: &Config,
+    teams: &[&str],
+) -> Result<Vec<sae::storage::TeamStatus>, Box<dyn std::error::Error>> {
+    let mut statuses = Vec::new();
+    for t in teams {
+        let ts = match config.team_db_path(t) {
+            Ok(path) if path.exists() => match query_team_status(t, &path) {
+                Ok(ts) => ts,
+                Err(e) => sae::storage::TeamStatus {
+                    team: t.to_string(),
+                    status: sae::storage::SyncStatus::Error,
+                    posts: 0,
+                    sync_state: None,
+                    error: Some(e.to_string()),
+                    db_path: None,
+                },
+            }
+            Ok(path) => sae::storage::TeamStatus {
+                team: t.to_string(),
+                status: sae::storage::SyncStatus::NotSynced,
+                posts: 0,
+                sync_state: None,
+                error: None,
+                db_path: Some(path.display().to_string()),
+            },
+            Err(e) => sae::storage::TeamStatus {
+                team: t.to_string(),
+                status: sae::storage::SyncStatus::Error,
+                posts: 0,
+                sync_state: None,
+                error: Some(e.to_string()),
+                db_path: None,
+            },
+        };
+        statuses.push(ts);
+    }
+    Ok(statuses)
+}
+
+fn require_db(db_path: &std::path::Path, team: &str) {
+    if !db_path.exists() {
+        eprintln!("No data for team '{team}'. Run `sae harvest {team}` first.");
+        std::process::exit(1);
+    }
+}
+
+fn query_team_status(
+    team: &str,
+    path: &std::path::Path,
+) -> Result<sae::storage::TeamStatus, Box<dyn std::error::Error>> {
+    let db = sae::storage::Db::open(path)?;
+    let count = sae::storage::count_posts(db.conn())?;
+    let state = sae::storage::get_sync_state(db.conn())?;
+    Ok(sae::storage::TeamStatus {
+        team: team.to_string(),
+        status: if state.is_some() {
+            sae::storage::SyncStatus::Synced
+        } else {
+            sae::storage::SyncStatus::NotSynced
+        },
+        posts: count,
+        sync_state: state,
+        error: None,
+        db_path: None,
+    })
+}
+
+fn resolve_body(
+    body: Option<&str>,
+    body_file: Option<&str>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    match (body, body_file) {
+        (Some(b), None) => Ok(Some(b.to_string())),
+        (None, Some("-")) => {
+            let mut buf = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            Ok(Some(buf))
+        }
+        (None, Some(path)) => {
+            let content = std::fs::read_to_string(path)?;
+            Ok(Some(content))
+        }
+        (None, None) => Ok(None),
+        (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
+    }
 }
 
 #[cfg(test)]
@@ -443,6 +604,165 @@ mod tests {
     fn harvest_missing_arg_is_clap_error() {
         let result = parse_cli_args(["sae", "harvest"]);
         assert!(result.is_err(), "harvest without team should be clap error");
+    }
+
+    // T-037: parse_cli_args(["sae", "--json", "query"]) → Command::Search + json=true
+    #[test]
+    fn shorthand_with_json_flag_becomes_search_with_json() {
+        let cli = parse_cli_args(["sae", "--json", "query"]).unwrap();
+        assert!(cli.json, "[T-037] global json flag should be true");
+        match cli.command {
+            Command::Search { query, .. } => assert_eq!(query, "query"),
+            other => panic!("[T-037] expected Search, got {other:?}"),
+        }
+    }
+
+    // T-049: parse_cli_args(["sae", "query"]) → Command::Search (json=false) - regression
+    #[test]
+    fn shorthand_without_flags_has_json_false() {
+        let cli = parse_cli_args(["sae", "query"]).unwrap();
+        assert!(!cli.json, "[T-049] json should default to false");
+        match cli.command {
+            Command::Search { query, .. } => assert_eq!(query, "query"),
+            other => panic!("[T-049] expected Search, got {other:?}"),
+        }
+    }
+
+    // --- Phase 2: --dry-run, --body-file (FR-004, FR-005, FR-006, FR-007) ---
+
+    // T-038: create args + --dry-run → parse succeeds with dry_run=true
+    #[test]
+    fn create_with_dry_run_parses_dry_run_flag() {
+        let cli = parse_cli_args([
+            "sae", "create", "--name", "Test Post", "--dry-run",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Create {
+                name, dry_run, ..
+            } => {
+                assert_eq!(name, "Test Post", "[T-038] name should match");
+                assert!(dry_run, "[T-038] dry_run should be true");
+            }
+            other => panic!("[T-038] expected Create, got {other:?}"),
+        }
+    }
+
+    // T-039: --body-file <tempfile> with create → file content becomes body
+    #[test]
+    fn body_file_reads_from_file() {
+        let dir = std::env::temp_dir().join("sae_test_t039");
+        let _ = std::fs::create_dir_all(&dir);
+        let file_path = dir.join("body.md");
+        std::fs::write(&file_path, "# Hello\nBody from file").unwrap();
+
+        let result = resolve_body(None, Some(file_path.to_str().unwrap())).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("# Hello\nBody from file"),
+            "[T-039] body should contain file contents"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // T-040: --body-file - with create → stdin content becomes body
+    // Note: stdin mocking is non-trivial; test that resolve_body("-") triggers
+    // the stdin path. The function should accept a Read trait for testability.
+    // For now, test the parse side: --body-file "-" parses correctly.
+    #[test]
+    fn body_file_dash_parses_as_stdin() {
+        let cli = parse_cli_args([
+            "sae", "create", "--name", "Stdin Post", "--body-file", "-",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Create { body_file, .. } => {
+                assert_eq!(
+                    body_file.as_deref(),
+                    Some("-"),
+                    "[T-040] body_file should be \"-\" for stdin"
+                );
+            }
+            other => panic!("[T-040] expected Create, got {other:?}"),
+        }
+    }
+
+    // T-041: --body and --body-file both specified → clap error
+    #[test]
+    fn body_and_body_file_conflict_is_clap_error() {
+        let result = parse_cli_args([
+            "sae",
+            "create",
+            "--name",
+            "Conflict Post",
+            "--body",
+            "inline body",
+            "--body-file",
+            "some_file.md",
+        ]);
+        assert!(
+            result.is_err(),
+            "[T-041] --body and --body-file together should be a clap error"
+        );
+    }
+
+    // T-046: archive args + --dry-run → parse succeeds with dry_run=true
+    #[test]
+    fn archive_with_dry_run_parses_dry_run_flag() {
+        let cli = parse_cli_args(["sae", "archive", "42", "--dry-run"]).unwrap();
+        match cli.command {
+            Command::Archive {
+                number, dry_run, ..
+            } => {
+                assert_eq!(number, 42, "[T-046] post number should be 42");
+                assert!(dry_run, "[T-046] dry_run should be true");
+            }
+            other => panic!("[T-046] expected Archive, got {other:?}"),
+        }
+    }
+
+    // T-042: help output contains Examples section
+    #[test]
+    fn help_output_contains_examples() {
+        use clap::CommandFactory;
+        let cmd = Cli::command();
+        for sub in cmd.get_subcommands() {
+            let after_help = sub.get_after_help().map(|h| h.to_string()).unwrap_or_default();
+            assert!(
+                after_help.contains("Examples"),
+                "[T-042] subcommand '{}' should have Examples in after_help",
+                sub.get_name()
+            );
+        }
+    }
+
+    // TC-008: resolve_body(Some, None) → inline body
+    #[test]
+    fn resolve_body_inline_text() {
+        let result = resolve_body(Some("inline text"), None).unwrap();
+        assert_eq!(result.as_deref(), Some("inline text"));
+    }
+
+    // TC-008: resolve_body(None, None) → no body
+    #[test]
+    fn resolve_body_none_returns_none() {
+        let result = resolve_body(None, None).unwrap();
+        assert_eq!(result, None);
+    }
+
+    // TC-009: resolve_body with nonexistent file → error
+    #[test]
+    fn resolve_body_nonexistent_file_is_error() {
+        let result = resolve_body(None, Some("/nonexistent/path.md"));
+        assert!(result.is_err(), "[TC-009] nonexistent file should return error");
+    }
+
+    // TC-011: flag-like argument not treated as shorthand query
+    #[test]
+    fn flag_like_arg_not_shorthand() {
+        let result = parse_cli_args(["sae", "--unknown"]);
+        assert!(result.is_err(), "[TC-011] --unknown should be clap error, not search shorthand");
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -39,11 +39,7 @@ pub fn search(
     Ok(())
 }
 
-pub fn get(
-    post: &EsaPost,
-    json: bool,
-    with_body: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<(), Box<dyn std::error::Error>> {
     if json {
         let mut post = post.clone();
         if !with_body {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,146 @@
+use sae::client::EsaPost;
+use sae::storage::{EmbedResult, SearchResult, SyncStatus, TeamStatus};
+use sae::sync::HarvestResult;
+
+pub fn harvest(result: &HarvestResult, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        println!("{}", serde_json::to_string(result)?);
+    } else {
+        println!("{result}");
+    }
+    Ok(())
+}
+
+pub fn search(
+    results: &[SearchResult],
+    query: &str,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        println!("{}", serde_json::to_string(results)?);
+    } else if results.is_empty() {
+        println!("No results for '{query}'");
+    } else {
+        for r in results {
+            let section = r
+                .section_title
+                .as_deref()
+                .map(|s| format!(" > {s}"))
+                .unwrap_or_default();
+            println!(
+                "[{:.4}] {}{} (#{})  {}",
+                r.score, r.post_name, section, r.post_number, r.post_url
+            );
+            if !r.snippet.is_empty() {
+                println!("  {}", r.snippet.replace('\n', " "));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn get(
+    post: &EsaPost,
+    json: bool,
+    with_body: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        let mut post = post.clone();
+        if !with_body {
+            post.body_md = None;
+        }
+        println!("{}", serde_json::to_string(&post)?);
+    } else {
+        println!("---");
+        println!("title: \"{}\"", post.full_name.replace('"', "\\\""));
+        if let Some(ref cat) = post.category
+            && !cat.is_empty()
+        {
+            println!("category: \"{}\"", cat.replace('"', "\\\""));
+        }
+        if !post.tags.is_empty() {
+            let tags: Vec<String> = post
+                .tags
+                .iter()
+                .map(|t| format!("\"{}\"", t.replace('"', "\\\"")))
+                .collect();
+            println!("tags: [{}]", tags.join(", "));
+        }
+        println!("author: \"@{}\"", post.created_by.screen_name);
+        if post.updated_by.screen_name != post.created_by.screen_name {
+            println!("updated_by: \"@{}\"", post.updated_by.screen_name);
+        }
+        println!("updated_at: \"{}\"", post.updated_at);
+        if post.wip {
+            println!("wip: true");
+        }
+        println!("number: {}", post.number);
+        println!("url: {}", post.url);
+        println!("---");
+        println!();
+        println!("{}", post.body_md.as_deref().unwrap_or("(empty)"));
+    }
+    Ok(())
+}
+
+pub fn post(action: &str, post: &EsaPost, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        println!("{}", serde_json::to_string(post)?);
+    } else {
+        println!("{action}: {} (#{}) {}", post.name, post.number, post.url);
+    }
+    Ok(())
+}
+
+pub fn embed(
+    result: &EmbedResult,
+    done: u32,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        println!("{}", serde_json::to_string(result)?);
+    } else if done == 0 {
+        println!("All chunks already embedded");
+    } else {
+        println!("Embedded {} chunks", result.chunks_embedded);
+    }
+    Ok(())
+}
+
+pub fn status(statuses: &[TeamStatus], json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        println!("{}", serde_json::to_string(statuses)?);
+    } else {
+        for ts in statuses {
+            println!("--- {} ---", ts.team);
+            match ts.status {
+                SyncStatus::Error => {
+                    println!(
+                        "  Error: {}",
+                        ts.error.as_deref().unwrap_or("unknown error")
+                    );
+                }
+                SyncStatus::NotSynced => {
+                    if let Some(ref path) = ts.db_path {
+                        println!("  Not yet synced (no DB at {path})");
+                    } else {
+                        println!("  Not yet synced");
+                    }
+                }
+                SyncStatus::Synced => {
+                    println!("  Posts: {}", ts.posts);
+                    if let Some(ref s) = ts.sync_state {
+                        println!(
+                            "  Last sync: {} (total: {}, local: {})",
+                            s.updated_at, s.total_count, s.local_count
+                        );
+                        if let Some(pg) = s.last_page {
+                            println!("  Checkpoint: page {pg} (interrupted)");
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -6,9 +6,7 @@ pub fn add_embeddings(
     conn: &Connection,
     embeddings: &[(i64, Vec<f32>)],
 ) -> Result<u32, StorageError> {
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(super::StorageError::Db)?;
+    let tx = conn.unchecked_transaction()?;
     let mut count = 0u32;
     for (chunk_id, embedding) in embeddings {
         let exists: bool = tx.query_row(
@@ -26,7 +24,7 @@ pub fn add_embeddings(
         )?;
         count += 1;
     }
-    tx.commit().map_err(super::StorageError::Db)?;
+    tx.commit()?;
     Ok(count)
 }
 
@@ -67,26 +65,9 @@ mod tests {
     fn add_and_query_embeddings() {
         let db = Db::open_memory().unwrap();
 
-        crate::storage::upsert_post(
-            db.conn(),
-            &crate::storage::EsaPostRow {
-                number: 1,
-                name: "Test".into(),
-                full_name: "dev/Test".into(),
-                body_md: "# Hello\nWorld".into(),
-                category: None,
-                tags: "[]".into(),
-                wip: false,
-                kind: "stock".into(),
-                url: "https://example.esa.io/posts/1".into(),
-                created_at: "2025-01-01T00:00:00+09:00".into(),
-                updated_at: "2025-01-01T00:00:00+09:00".into(),
-                created_by: "alice".into(),
-                updated_by: "alice".into(),
-                revision_number: 1,
-            },
-        )
-        .unwrap();
+        let mut row = crate::storage::test_post_row(1);
+        row.body_md = "# Hello\nWorld".into();
+        crate::storage::upsert_post(db.conn(), &row).unwrap();
         crate::storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
 
         let unembedded = get_unembedded_chunks(db.conn(), 100).unwrap();
@@ -103,26 +84,9 @@ mod tests {
     #[test]
     fn skip_already_embedded() {
         let db = Db::open_memory().unwrap();
-        crate::storage::upsert_post(
-            db.conn(),
-            &crate::storage::EsaPostRow {
-                number: 1,
-                name: "T".into(),
-                full_name: "T".into(),
-                body_md: "# A\nB".into(),
-                category: None,
-                tags: "[]".into(),
-                wip: false,
-                kind: "stock".into(),
-                url: "u".into(),
-                created_at: "t".into(),
-                updated_at: "t".into(),
-                created_by: "a".into(),
-                updated_by: "a".into(),
-                revision_number: 1,
-            },
-        )
-        .unwrap();
+        let mut row = crate::storage::test_post_row(1);
+        row.body_md = "# A\nB".into();
+        crate::storage::upsert_post(db.conn(), &row).unwrap();
         crate::storage::rechunk_post(db.conn(), 1, "# A\nB").unwrap();
 
         let chunks = get_unembedded_chunks(db.conn(), 100).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -66,7 +66,6 @@ pub(crate) fn ensure_sqlite_vec() -> Result<(), StorageError> {
 }
 
 /// Migrate FTS schema from v3 (1-column) to v4 (2-column with section_title).
-/// Runs DROP + recreate + rebuild within a single transaction.
 pub(crate) fn migrate_fts_v4(conn: &Connection) -> Result<(), StorageError> {
     let tx = conn.unchecked_transaction()?;
 
@@ -338,27 +337,28 @@ pub fn rechunk_post(
 }
 
 #[cfg(test)]
+pub(crate) fn test_post_row(number: u32) -> EsaPostRow {
+    EsaPostRow {
+        number,
+        name: format!("Post {number}"),
+        full_name: format!("dev/Post {number}"),
+        body_md: format!("# Post {number}"),
+        category: Some("dev".into()),
+        tags: "[]".into(),
+        wip: false,
+        kind: "stock".into(),
+        url: format!("https://example.esa.io/posts/{number}"),
+        created_at: "2025-01-01T00:00:00+09:00".into(),
+        updated_at: "2025-01-02T00:00:00+09:00".into(),
+        created_by: "alice".into(),
+        updated_by: "bob".into(),
+        revision_number: 1,
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-
-    fn test_post(number: u32) -> EsaPostRow {
-        EsaPostRow {
-            number,
-            name: format!("Post {number}"),
-            full_name: format!("dev/Post {number}"),
-            body_md: format!("# Post {number}"),
-            category: Some("dev".into()),
-            tags: r#"["test"]"#.into(),
-            wip: false,
-            kind: "stock".into(),
-            url: format!("https://example.esa.io/posts/{number}"),
-            created_at: "2025-01-01T00:00:00+09:00".into(),
-            updated_at: "2025-01-02T00:00:00+09:00".into(),
-            created_by: "alice".into(),
-            updated_by: "bob".into(),
-            revision_number: 1,
-        }
-    }
 
     #[test]
     fn open_and_init_schema() {
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn upsert_and_count() {
         let db = Db::open_memory().unwrap();
-        upsert_post(db.conn(), &test_post(1)).unwrap();
+        upsert_post(db.conn(), &test_post_row(1)).unwrap();
         assert_eq!(count_posts(db.conn()).unwrap(), 1);
     }
 
@@ -385,7 +385,7 @@ mod tests {
     fn upsert_multiple() {
         let db = Db::open_memory().unwrap();
         for i in 1..=5 {
-            upsert_post(db.conn(), &test_post(i)).unwrap();
+            upsert_post(db.conn(), &test_post_row(i)).unwrap();
         }
         assert_eq!(count_posts(db.conn()).unwrap(), 5);
     }
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn upsert_replaces_on_conflict() {
         let db = Db::open_memory().unwrap();
-        let mut post = test_post(1);
+        let mut post = test_post_row(1);
         upsert_post(db.conn(), &post).unwrap();
 
         post.name = "Updated".into();
@@ -465,7 +465,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.db");
         let db = Db::open(&path).unwrap();
-        upsert_post(db.conn(), &test_post(1)).unwrap();
+        upsert_post(db.conn(), &test_post_row(1)).unwrap();
         assert_eq!(count_posts(db.conn()).unwrap(), 1);
     }
 
@@ -474,7 +474,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         let tx = db.conn().unchecked_transaction().unwrap();
         for i in 1..=10 {
-            upsert_post(&tx, &test_post(i)).unwrap();
+            upsert_post(&tx, &test_post_row(i)).unwrap();
         }
         tx.commit().unwrap();
         assert_eq!(count_posts(db.conn()).unwrap(), 10);
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn rechunk_creates_chunks_and_fts() {
         let db = Db::open_memory().unwrap();
-        let mut post = test_post(1);
+        let mut post = test_post_row(1);
         post.body_md = "# Intro\nHello\n# Details\nWorld".into();
         upsert_post(db.conn(), &post).unwrap();
 
@@ -505,7 +505,7 @@ mod tests {
     #[test]
     fn rechunk_replaces_old_chunks() {
         let db = Db::open_memory().unwrap();
-        let post = test_post(1);
+        let post = test_post_row(1);
         upsert_post(db.conn(), &post).unwrap();
         rechunk_post(db.conn(), 1, "# Old\nContent").unwrap();
         assert_eq!(count_chunks(db.conn()).unwrap(), 1);
@@ -527,7 +527,7 @@ mod tests {
     #[test]
     fn fts_trigram_japanese() {
         let db = Db::open_memory().unwrap();
-        let post = test_post(1);
+        let post = test_post_row(1);
         upsert_post(db.conn(), &post).unwrap();
         rechunk_post(db.conn(), 1, "# 認証ガイド\n認証フローの説明").unwrap();
 
@@ -547,7 +547,7 @@ mod tests {
     fn rechunk_fts_count_matches_chunks_count() {
         let db = Db::open_memory().unwrap();
         let body = "# セクション1\n本文A\n# セクション2\n本文B\n# セクション3\n本文C";
-        let post = test_post(1);
+        let post = test_post_row(1);
         upsert_post(db.conn(), &post).unwrap();
         let n = rechunk_post(db.conn(), 1, body).unwrap();
         assert_eq!(n, 3);

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -147,11 +147,14 @@ pub fn hybrid_search(
 
     let mut results = Vec::new();
     for (post_number, score) in scored.into_iter().take(limit as usize) {
-        let meta = post_meta.get(&post_number).cloned().unwrap_or_else(|| PostMeta {
-            name: format!("#{post_number}"),
-            url: String::new(),
-            updated_at: String::new(),
-        });
+        let meta = post_meta
+            .get(&post_number)
+            .cloned()
+            .unwrap_or_else(|| PostMeta {
+                name: format!("#{post_number}"),
+                url: String::new(),
+                updated_at: String::new(),
+            });
 
         let (section_title, snippet) = fts_map
             .get(&post_number)
@@ -212,7 +215,16 @@ fn batch_fetch_post_meta(
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows
         .into_iter()
-        .map(|(n, name, url, updated_at)| (n, PostMeta { name, url, updated_at }))
+        .map(|(n, name, url, updated_at)| {
+            (
+                n,
+                PostMeta {
+                    name,
+                    url,
+                    updated_at,
+                },
+            )
+        })
         .collect())
 }
 
@@ -696,7 +708,8 @@ mod tests {
             snippet: "snippet text".to_string(),
             score: 0.85,
         };
-        let json_str = serde_json::to_string(&result).expect("[T-035] SearchResult should serialize");
+        let json_str =
+            serde_json::to_string(&result).expect("[T-035] SearchResult should serialize");
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v["post_number"], 42);
         assert_eq!(v["post_name"], "Test Post");

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 
 use super::StorageError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchResult {
     pub post_number: u32,
     pub post_name: String,
@@ -122,13 +122,13 @@ pub fn hybrid_search(
     let fts_map: HashMap<u32, &FtsHit> = fts_hits.iter().map(|h| (h.post_number, h)).collect();
     let vec_map: HashMap<u32, &VecHit> = vec_hits.iter().map(|h| (h.post_number, h)).collect();
 
-    // Apply recency decay to all candidates, then re-sort
     let mut scored: Vec<(u32, f64)> = merged
         .into_iter()
         .map(|(post_number, rrf_score)| {
             let decay = post_meta
                 .get(&post_number)
-                .and_then(|(_, _, updated_at)| {
+                .and_then(|meta| {
+                    let updated_at = &meta.updated_at;
                     chrono::DateTime::parse_from_rfc3339(updated_at)
                         .map_err(|e| warn!(%e, %updated_at, "unparseable updated_at, decay=0.0"))
                         .ok()
@@ -147,10 +147,11 @@ pub fn hybrid_search(
 
     let mut results = Vec::new();
     for (post_number, score) in scored.into_iter().take(limit as usize) {
-        let (name, url, _) = post_meta
-            .get(&post_number)
-            .cloned()
-            .unwrap_or_else(|| (format!("#{post_number}"), String::new(), String::new()));
+        let meta = post_meta.get(&post_number).cloned().unwrap_or_else(|| PostMeta {
+            name: format!("#{post_number}"),
+            url: String::new(),
+            updated_at: String::new(),
+        });
 
         let (section_title, snippet) = fts_map
             .get(&post_number)
@@ -164,8 +165,8 @@ pub fn hybrid_search(
 
         results.push(SearchResult {
             post_number,
-            post_name: name,
-            post_url: url,
+            post_name: meta.name,
+            post_url: meta.url,
             section_title,
             snippet: truncate_snippet(&snippet, 200),
             score,
@@ -175,10 +176,17 @@ pub fn hybrid_search(
     Ok(results)
 }
 
+#[derive(Debug, Clone)]
+struct PostMeta {
+    name: String,
+    url: String,
+    updated_at: String,
+}
+
 fn batch_fetch_post_meta(
     conn: &Connection,
     post_numbers: &[u32],
-) -> Result<HashMap<u32, (String, String, String)>, StorageError> {
+) -> Result<HashMap<u32, PostMeta>, StorageError> {
     if post_numbers.is_empty() {
         return Ok(HashMap::new());
     }
@@ -204,7 +212,7 @@ fn batch_fetch_post_meta(
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows
         .into_iter()
-        .map(|(n, name, url, updated_at)| (n, (name, url, updated_at)))
+        .map(|(n, name, url, updated_at)| (n, PostMeta { name, url, updated_at }))
         .collect())
 }
 
@@ -316,16 +324,13 @@ fn clean_for_trigram(query: &str) -> String {
             }
             fixed.push(term);
         }
-        // skip whitespace between segments
     }
 
-    // No OR groups → return fixed terms joined
     if or_groups.is_empty() {
         return fixed.join(" ");
     }
 
-    // Cross-product of all OR groups, then append fixed terms to each combo.
-    // E.g. (A1 OR A2) (B1 OR B2) C → A1 B1 C OR A1 B2 C OR A2 B1 C OR A2 B2 C
+    // (A1 OR A2) (B1 OR B2) C → A1 B1 C OR A1 B2 C OR A2 B1 C OR A2 B2 C
     let combos = cross_product(&or_groups);
     let alternatives: Vec<String> = combos
         .iter()
@@ -351,22 +356,11 @@ mod tests {
     use crate::storage::{self, Db};
 
     fn test_post(number: u32, name: &str, body_md: &str) -> storage::EsaPostRow {
-        storage::EsaPostRow {
-            number,
-            name: name.to_string(),
-            full_name: format!("dev/{name}"),
-            body_md: body_md.to_string(),
-            category: Some("dev".into()),
-            tags: "[]".into(),
-            wip: false,
-            kind: "stock".into(),
-            url: format!("https://example.esa.io/posts/{number}"),
-            created_at: "2025-01-01T00:00:00+09:00".into(),
-            updated_at: "2025-01-01T00:00:00+09:00".into(),
-            created_by: "alice".into(),
-            updated_by: "alice".into(),
-            revision_number: 1,
-        }
+        let mut row = storage::test_post_row(number);
+        row.name = name.to_string();
+        row.full_name = format!("dev/{name}");
+        row.body_md = body_md.to_string();
+        row
     }
 
     fn setup_db_with_posts(db: &Db) {
@@ -384,26 +378,8 @@ mod tests {
             (3, "デプロイ", "# 手順\nデプロイの手順ガイド"),
         ];
         for (num, name, body) in &posts {
-            storage::upsert_post(
-                db.conn(),
-                &storage::EsaPostRow {
-                    number: *num,
-                    name: name.to_string(),
-                    full_name: format!("dev/{name}"),
-                    body_md: body.to_string(),
-                    category: Some("dev".into()),
-                    tags: "[]".into(),
-                    wip: false,
-                    kind: "stock".into(),
-                    url: format!("https://example.esa.io/posts/{num}"),
-                    created_at: "2025-01-01T00:00:00+09:00".into(),
-                    updated_at: "2025-01-01T00:00:00+09:00".into(),
-                    created_by: "alice".into(),
-                    updated_by: "alice".into(),
-                    revision_number: 1,
-                },
-            )
-            .unwrap();
+            let post = test_post(*num, name, body);
+            storage::upsert_post(db.conn(), &post).unwrap();
             storage::rechunk_post(db.conn(), *num, body).unwrap();
         }
     }
@@ -532,8 +508,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "認証、フロー", 10).unwrap();
-        let _ = hits;
+        fts_search(db.conn(), "認証、フロー", 10).unwrap();
     }
 
     #[test]
@@ -552,26 +527,8 @@ mod tests {
             ),
         ];
         for (num, name, body) in &posts {
-            storage::upsert_post(
-                db.conn(),
-                &storage::EsaPostRow {
-                    number: *num,
-                    name: name.to_string(),
-                    full_name: format!("dev/{name}"),
-                    body_md: body.to_string(),
-                    category: Some("dev".into()),
-                    tags: "[]".into(),
-                    wip: false,
-                    kind: "stock".into(),
-                    url: format!("https://example.esa.io/posts/{num}"),
-                    created_at: "2025-01-01T00:00:00+09:00".into(),
-                    updated_at: "2025-01-01T00:00:00+09:00".into(),
-                    created_by: "alice".into(),
-                    updated_by: "alice".into(),
-                    revision_number: 1,
-                },
-            )
-            .unwrap();
+            let post = test_post(*num, name, body);
+            storage::upsert_post(db.conn(), &post).unwrap();
             storage::rechunk_post(db.conn(), *num, body).unwrap();
         }
 
@@ -600,9 +557,9 @@ mod tests {
 
         let meta = batch_fetch_post_meta(db.conn(), &[1, 3]).unwrap();
         assert_eq!(meta.len(), 2);
-        assert!(meta.get(&1).unwrap().0.contains("認証")); // name
-        assert!(meta.get(&3).unwrap().0.contains("デプロイ")); // name
-        assert!(!meta.get(&1).unwrap().2.is_empty()); // updated_at
+        assert!(meta.get(&1).unwrap().name.contains("認証"));
+        assert!(meta.get(&3).unwrap().name.contains("デプロイ"));
+        assert!(!meta.get(&1).unwrap().updated_at.is_empty());
     }
 
     #[test]
@@ -625,26 +582,9 @@ mod tests {
             (2u32, "PostB", "2025-01-02T00:00:00+09:00"), // 30 days before "now"
         ];
         for (num, name, updated) in &posts {
-            storage::upsert_post(
-                db.conn(),
-                &storage::EsaPostRow {
-                    number: *num,
-                    name: name.to_string(),
-                    full_name: format!("dev/{name}"),
-                    body_md: shared_body.to_string(),
-                    category: Some("dev".into()),
-                    tags: "[]".into(),
-                    wip: false,
-                    kind: "stock".into(),
-                    url: format!("https://example.esa.io/posts/{num}"),
-                    created_at: "2025-01-01T00:00:00+09:00".into(),
-                    updated_at: updated.to_string(),
-                    created_by: "alice".into(),
-                    updated_by: "alice".into(),
-                    revision_number: 1,
-                },
-            )
-            .unwrap();
+            let mut post = test_post(*num, name, shared_body);
+            post.updated_at = updated.to_string();
+            storage::upsert_post(db.conn(), &post).unwrap();
             storage::rechunk_post(db.conn(), *num, shared_body).unwrap();
         }
 
@@ -669,26 +609,9 @@ mod tests {
         let db = Db::open_memory().unwrap();
 
         let body = "# 認証フロー\n認証の仕組みを説明します";
-        storage::upsert_post(
-            db.conn(),
-            &storage::EsaPostRow {
-                number: 1,
-                name: "BadDate".to_string(),
-                full_name: "dev/BadDate".to_string(),
-                body_md: body.to_string(),
-                category: Some("dev".into()),
-                tags: "[]".into(),
-                wip: false,
-                kind: "stock".into(),
-                url: "https://example.esa.io/posts/1".into(),
-                created_at: "2025-01-01T00:00:00+09:00".into(),
-                updated_at: "not-a-date".into(),
-                created_by: "alice".into(),
-                updated_by: "alice".into(),
-                revision_number: 1,
-            },
-        )
-        .unwrap();
+        let mut post = test_post(1, "BadDate", body);
+        post.updated_at = "not-a-date".into();
+        storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
         let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
@@ -760,5 +683,45 @@ mod tests {
         );
         assert_eq!(hits[0].post_number, 1);
         assert_eq!(hits[0].section_title.as_deref(), Some("認証ガイド"));
+    }
+
+    // T-035: search --json → JSON array with post_number, post_name, score
+    #[test]
+    fn search_result_serializes_to_json_with_expected_fields() {
+        let result = SearchResult {
+            post_number: 42,
+            post_name: "Test Post".to_string(),
+            post_url: "https://example.esa.io/posts/42".to_string(),
+            section_title: Some("Section".to_string()),
+            snippet: "snippet text".to_string(),
+            score: 0.85,
+        };
+        let json_str = serde_json::to_string(&result).expect("[T-035] SearchResult should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["post_number"], 42);
+        assert_eq!(v["post_name"], "Test Post");
+        assert_eq!(v["score"], 0.85);
+        assert_eq!(v["post_url"], "https://example.esa.io/posts/42");
+        assert_eq!(v["section_title"], "Section");
+        assert_eq!(v["snippet"], "snippet text");
+    }
+
+    // TC-006: truncate_snippet
+    #[test]
+    fn truncate_snippet_short_unchanged() {
+        assert_eq!(truncate_snippet("abc", 5), "abc");
+    }
+
+    #[test]
+    fn truncate_snippet_over_limit_truncated() {
+        assert_eq!(truncate_snippet("abcdef", 3), "abc...");
+    }
+
+    #[test]
+    fn truncate_snippet_multibyte_boundary() {
+        // 3 chars of Japanese = 9 bytes; truncation must be on char boundary
+        let s = "あいうえお";
+        let result = truncate_snippet(s, 3);
+        assert_eq!(result, "あいう...");
     }
 }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -83,13 +83,15 @@ mod tests {
             error: None,
             db_path: None,
         };
-        let json_str =
-            serde_json::to_string(&status).expect("[T-045] TeamStatus should serialize");
+        let json_str = serde_json::to_string(&status).expect("[T-045] TeamStatus should serialize");
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v["team"], "myteam");
         assert_eq!(v["status"], "synced");
         assert_eq!(v["posts"], 42);
-        assert!(v["sync_state"].is_object(), "[T-045] sync_state should be an object");
+        assert!(
+            v["sync_state"].is_object(),
+            "[T-045] sync_state should be an object"
+        );
     }
 
     // T-045: TeamStatus array serialization
@@ -113,8 +115,8 @@ mod tests {
                 db_path: None,
             },
         ];
-        let json_str = serde_json::to_string(&statuses)
-            .expect("[T-045] TeamStatus array should serialize");
+        let json_str =
+            serde_json::to_string(&statuses).expect("[T-045] TeamStatus array should serialize");
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
         assert!(v.is_array(), "[T-045] should be a JSON array");
         assert_eq!(v.as_array().unwrap().len(), 2);
@@ -149,8 +151,7 @@ mod tests {
             last_page: Some(3),
             updated_at: "2025-01-01 00:00:00".to_string(),
         };
-        let json_str =
-            serde_json::to_string(&state).expect("[T-045] SyncState should serialize");
+        let json_str = serde_json::to_string(&state).expect("[T-045] SyncState should serialize");
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
         assert_eq!(v["total_count"], 100);
         assert_eq!(v["local_count"], 50);
@@ -160,7 +161,9 @@ mod tests {
     // T-053: embed --json → EmbedResult JSON (chunks_embedded field)
     #[test]
     fn embed_result_serializes_to_json_with_chunks_embedded() {
-        let result = EmbedResult { chunks_embedded: 150 };
+        let result = EmbedResult {
+            chunks_embedded: 150,
+        };
         let json_str =
             serde_json::to_string(&result).expect("[T-053] EmbedResult should serialize");
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -16,13 +16,38 @@ pub struct EsaPostRow {
     pub revision_number: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SyncState {
     pub latest_updated_at: Option<String>,
     pub total_count: u32,
     pub local_count: u32,
     pub last_page: Option<u32>,
     pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncStatus {
+    Synced,
+    NotSynced,
+    Error,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TeamStatus {
+    pub team: String,
+    pub status: SyncStatus,
+    pub posts: u32,
+    pub sync_state: Option<SyncState>,
+    pub error: Option<String>,
+    /// DB path for human-readable output (not included in JSON)
+    #[serde(skip)]
+    pub db_path: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EmbedResult {
+    pub chunks_embedded: u32,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -35,4 +60,110 @@ pub enum StorageError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-045: status --json → TeamStatus array with team, status, posts fields
+    #[test]
+    fn team_status_serializes_to_json_with_expected_fields() {
+        let status = TeamStatus {
+            team: "myteam".to_string(),
+            status: SyncStatus::Synced,
+            posts: 42,
+            sync_state: Some(SyncState {
+                latest_updated_at: Some("2025-01-01T00:00:00+09:00".to_string()),
+                total_count: 100,
+                local_count: 42,
+                last_page: None,
+                updated_at: "2025-01-01 00:00:00".to_string(),
+            }),
+            error: None,
+            db_path: None,
+        };
+        let json_str =
+            serde_json::to_string(&status).expect("[T-045] TeamStatus should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["team"], "myteam");
+        assert_eq!(v["status"], "synced");
+        assert_eq!(v["posts"], 42);
+        assert!(v["sync_state"].is_object(), "[T-045] sync_state should be an object");
+    }
+
+    // T-045: TeamStatus array serialization
+    #[test]
+    fn team_status_array_serializes_to_json_array() {
+        let statuses = vec![
+            TeamStatus {
+                team: "team-a".to_string(),
+                status: SyncStatus::Synced,
+                posts: 10,
+                sync_state: None,
+                error: None,
+                db_path: None,
+            },
+            TeamStatus {
+                team: "team-b".to_string(),
+                status: SyncStatus::NotSynced,
+                posts: 0,
+                sync_state: None,
+                error: None,
+                db_path: None,
+            },
+        ];
+        let json_str = serde_json::to_string(&statuses)
+            .expect("[T-045] TeamStatus array should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(v.is_array(), "[T-045] should be a JSON array");
+        assert_eq!(v.as_array().unwrap().len(), 2);
+        assert_eq!(v[0]["team"], "team-a");
+        assert_eq!(v[1]["status"], "not_synced");
+    }
+
+    // TC-010: SyncStatus::Error serializes to "error" with error message
+    #[test]
+    fn team_status_error_serializes_correctly() {
+        let status = TeamStatus {
+            team: "broken".to_string(),
+            status: SyncStatus::Error,
+            posts: 0,
+            sync_state: None,
+            error: Some("config missing".to_string()),
+            db_path: None,
+        };
+        let json_str = serde_json::to_string(&status).expect("[TC-010] should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["error"], "config missing");
+    }
+
+    // T-045: SyncState serializes (required by TeamStatus.sync_state)
+    #[test]
+    fn sync_state_serializes_to_json() {
+        let state = SyncState {
+            latest_updated_at: Some("2025-01-01T00:00:00+09:00".to_string()),
+            total_count: 100,
+            local_count: 50,
+            last_page: Some(3),
+            updated_at: "2025-01-01 00:00:00".to_string(),
+        };
+        let json_str =
+            serde_json::to_string(&state).expect("[T-045] SyncState should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["total_count"], 100);
+        assert_eq!(v["local_count"], 50);
+        assert_eq!(v["last_page"], 3);
+    }
+
+    // T-053: embed --json → EmbedResult JSON (chunks_embedded field)
+    #[test]
+    fn embed_result_serializes_to_json_with_chunks_embedded() {
+        let result = EmbedResult { chunks_embedded: 150 };
+        let json_str =
+            serde_json::to_string(&result).expect("[T-053] EmbedResult should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["chunks_embedded"], 150);
+    }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -507,8 +507,12 @@ mod tests {
             url: "https://example.esa.io/posts/1".into(),
             created_at: "2025-01-01T00:00:00+09:00".into(),
             updated_at: "2025-01-02T00:00:00+09:00".into(),
-            created_by: crate::client::EsaUser { screen_name: "alice".into() },
-            updated_by: crate::client::EsaUser { screen_name: "bob".into() },
+            created_by: crate::client::EsaUser {
+                screen_name: "alice".into(),
+            },
+            updated_by: crate::client::EsaUser {
+                screen_name: "bob".into(),
+            },
             revision_number: 1,
         };
         let row = post_to_row(&post);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -3,7 +3,7 @@ use tracing::info;
 use crate::client::{ClientError, EsaClient, EsaPost};
 use crate::storage::{self, Db, EsaPostRow, StorageError};
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub struct HarvestResult {
     pub posts_fetched: u32,
     pub posts_stored: u32,
@@ -453,5 +453,66 @@ mod tests {
         let (page, q) = resolve_start(true, &state);
         assert_eq!(page, 1);
         assert!(q.is_none());
+    }
+
+    // T-044: HarvestResult serialize → posts_fetched, posts_stored, total_count fields
+    #[test]
+    fn harvest_result_serializes_to_json_with_expected_fields() {
+        let result = HarvestResult {
+            posts_fetched: 10,
+            posts_stored: 8,
+            total_count: 100,
+            local_count: 50,
+            gap_detected: true,
+        };
+        let json_str =
+            serde_json::to_string(&result).expect("[T-044] HarvestResult should serialize");
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["posts_fetched"], 10);
+        assert_eq!(v["posts_stored"], 8);
+        assert_eq!(v["total_count"], 100);
+        assert_eq!(v["local_count"], 50);
+        assert_eq!(v["gap_detected"], true);
+    }
+
+    // TC-002: is_pagination_limit
+    #[test]
+    fn is_pagination_limit_detects_comma_format() {
+        assert!(is_pagination_limit("exceeds 10,000 items"));
+    }
+
+    #[test]
+    fn is_pagination_limit_detects_plain_format() {
+        assert!(is_pagination_limit("exceeds 10000 items"));
+    }
+
+    #[test]
+    fn is_pagination_limit_rejects_other_numbers() {
+        assert!(!is_pagination_limit("1000 items"));
+        assert!(!is_pagination_limit(""));
+    }
+
+    // TC-005: post_to_row with body_md: None → empty string
+    #[test]
+    fn post_to_row_none_body_becomes_empty() {
+        let post = EsaPost {
+            number: 1,
+            name: "Test".into(),
+            full_name: "dev/Test".into(),
+            body_md: None,
+            category: Some("dev".into()),
+            tags: vec!["rust".into()],
+            wip: false,
+            kind: "stock".into(),
+            url: "https://example.esa.io/posts/1".into(),
+            created_at: "2025-01-01T00:00:00+09:00".into(),
+            updated_at: "2025-01-02T00:00:00+09:00".into(),
+            created_by: crate::client::EsaUser { screen_name: "alice".into() },
+            updated_by: crate::client::EsaUser { screen_name: "bob".into() },
+            revision_number: 1,
+        };
+        let row = post_to_row(&post);
+        assert_eq!(row.body_md, "");
+        assert_eq!(row.tags, r#"["rust"]"#);
     }
 }


### PR DESCRIPTION
## 概要

- **FTSスキーマv4**: `fts_chunks` FTS5テーブルに `section_title` カラムを追加。見出しテキストを本文と並行してインデックス化。`migrate_fts_v4()` で既存v3 DBをトランザクション内でDROP/再作成/リビルド。
- **エージェント親和CLI** (Closes #2): global `--json`、`--dry-run`、`--body-file`（stdin対応）、`--with-body`、全subcommandの `after_help` 使用例を追加。
- **`output.rs` 分離**: 出力フォーマットロジックを `main.rs` から専用モジュールに抽出。
- **新規型**: `SyncStatus` enum、`TeamStatus`、`EmbedResult`、`PostMeta`。`SearchResult`、`HarvestResult`、`SyncState` に `Serialize` derive追加。`status --json` でチーム単位エラーハンドリング。
- **テスト**: 共有 `test_post_row` fixture追加。全133テスト。
- **依存更新**: `rurico` を `dd1ad45` に更新。

## テスト計画

- [ ] `cargo test` — 全133テストpass
- [ ] `cargo build --release` — クリーンビルド
- [ ] v3 DB上で自動マイグレーションがデータ損失なく完了することを確認
- [ ] `sae search <query>` の結果に `section_title` が含まれることを確認
- [ ] `sae --json get <id>` のJSON出力がスキーマ通りであることを確認
- [ ] `sae create --dry-run --body-file -` でstdin入力し書き込みが発生しないことを確認
- [ ] `sae --json status` でチーム単位のerrorフィールドが正しく返ることを確認