### PR TITLE
コマンドディスパッチを run_* 関数に分割し API パラメータを構造体に統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .claude/
 workspace/
+.yomu/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# sae
+
+esaのナレッジを手元で検索するCLI。FTS5 trigram + ベクトル検索のハイブリッド検索で、日本語の部分一致にも対応する。
+
+## なぜ sae か
+
+esaの検索は全文検索だが、ローカルで高速に検索したい場面がある。またAIエージェント（Claude Code等）がesaのナレッジを参照・操作するには、構造化出力と安全なプレビュー手段が必要になる。saeはこの両方を1つのCLIで提供する。
+
+## セットアップ
+
+```bash
+cargo install --path .
+```
+
+### 環境変数
+
+```bash
+export ESA_ACCESS_TOKEN="your-token"
+```
+
+### 設定ファイル（任意）
+
+`~/.config/sae/config.json`:
+
+```json
+{
+  "teams": ["myteam"],
+  "default_team": "myteam"
+}
+```
+
+## 使い方
+
+### 投稿の取得・検索
+
+```bash
+# チームの投稿をインデックス
+sae harvest myteam
+
+# 検索（shorthand）
+sae "認証"
+
+# オプション付き検索
+sae search "認証" --team myteam --limit 5
+
+# 投稿を取得
+sae get 42
+```
+
+### 投稿の作成・更新
+
+```bash
+# 作成
+sae create --name "タイトル" --body "本文" --team myteam
+
+# ファイルから本文を読み込み
+sae create --name "タイトル" --body-file draft.md
+
+# stdin から読み込み
+cat body.md | sae create --name "タイトル" --body-file -
+
+# 更新
+sae update 42 --name "新タイトル"
+
+# アーカイブ / Ship
+sae archive 42
+sae ship 42
+```
+
+### エージェント向け機能
+
+```bash
+# JSON 出力（全コマンド共通）
+sae --json search "認証"
+sae --json get 42
+sae --json status
+
+# get の JSON は body_md を省略（--with-body で含める）
+sae --json get 42 --with-body
+
+# dry-run（API を呼ばずにプレビュー）
+sae create --name "タイトル" --body "本文" --dry-run
+sae archive 42 --dry-run
+```
+
+### セマンティック検索
+
+```bash
+# 埋め込みモデルをダウンロード（初回のみ）
+sae model download
+
+# チャンクの埋め込み
+sae embed myteam
+
+# 以降の検索は FTS + ベクトルのハイブリッド
+sae search "認証フローの設計方針"
+```
+
+### 同期状態の確認
+
+```bash
+sae status
+sae --json status
+```
+
+## データ
+
+- DB: `~/.local/share/sae/{team}.db`（SQLite）
+- 設定: `~/.config/sae/config.json`

--- a/src/client.rs
+++ b/src/client.rs
@@ -208,7 +208,6 @@ impl EsaClient {
         self.send(|http| http.post(&url).json(&body)).await
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn update_post(
         &self,
         team: &str,
@@ -422,13 +421,16 @@ mod tests {
 
         let post = test_client(&server)
             .await
-            .create_post("myteam", &CreatePostParams {
-                name: "Test",
-                body_md: Some("# Body"),
-                category: None,
-                tags: vec![],
-                wip: true,
-            })
+            .create_post(
+                "myteam",
+                &CreatePostParams {
+                    name: "Test",
+                    body_md: Some("# Body"),
+                    category: None,
+                    tags: vec![],
+                    wip: true,
+                },
+            )
             .await
             .unwrap();
         assert_eq!(post.name, "Getting Started");
@@ -445,7 +447,14 @@ mod tests {
 
         let post = test_client(&server)
             .await
-            .update_post("myteam", 1, &UpdatePostParams { name: Some("New Name"), ..Default::default() })
+            .update_post(
+                "myteam",
+                1,
+                &UpdatePostParams {
+                    name: Some("New Name"),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         assert_eq!(post.name, "Getting Started");
@@ -541,6 +550,31 @@ mod tests {
         assert!(retry_wait(404, None, 0).is_none());
     }
 
+    #[test]
+    fn retry_wait_429_non_numeric_header_defaults() {
+        assert_eq!(
+            retry_wait(429, Some("Thu, 01 Jan 2026 00:00:00 GMT"), 0),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_json_on_success_returns_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/myteam/posts/1"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server)
+            .await
+            .get_post("myteam", 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ClientError::Network(_)));
+    }
+
     fn test_esa_post(body_md: Option<String>) -> EsaPost {
         EsaPost {
             number: 42,
@@ -631,13 +665,16 @@ mod tests {
 
         test_client(&server)
             .await
-            .create_post("myteam", &CreatePostParams {
-                name: "My Title",
-                body_md: Some("# Content"),
-                category: Some("docs"),
-                tags: vec!["rust".into(), "api".into()],
-                wip: true,
-            })
+            .create_post(
+                "myteam",
+                &CreatePostParams {
+                    name: "My Title",
+                    body_md: Some("# Content"),
+                    category: Some("docs"),
+                    tags: vec!["rust".into(), "api".into()],
+                    wip: true,
+                },
+            )
             .await
             .unwrap();
     }
@@ -660,13 +697,16 @@ mod tests {
 
         test_client(&server)
             .await
-            .create_post("myteam", &CreatePostParams {
-                name: "Minimal",
-                body_md: None,
-                category: None,
-                tags: vec![],
-                wip: false,
-            })
+            .create_post(
+                "myteam",
+                &CreatePostParams {
+                    name: "Minimal",
+                    body_md: None,
+                    category: None,
+                    tags: vec![],
+                    wip: false,
+                },
+            )
             .await
             .unwrap();
     }
@@ -676,9 +716,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts/1"))
-            .respond_with(
-                ResponseTemplate::new(429).insert_header("retry-after", "0"),
-            )
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
             .mount(&server)
             .await;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,6 +44,14 @@ pub struct EsaUser {
     pub screen_name: String,
 }
 
+pub struct CreatePostParams<'a> {
+    pub name: &'a str,
+    pub body_md: Option<&'a str>,
+    pub category: Option<&'a str>,
+    pub tags: Vec<String>,
+    pub wip: bool,
+}
+
 #[derive(Serialize)]
 struct CreatePostRequest {
     post: CreatePostBody,
@@ -59,6 +67,15 @@ struct CreatePostBody {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tags: Vec<String>,
     wip: bool,
+}
+
+#[derive(Default)]
+pub struct UpdatePostParams<'a> {
+    pub name: Option<&'a str>,
+    pub body_md: Option<&'a str>,
+    pub category: Option<&'a str>,
+    pub tags: Option<Vec<String>>,
+    pub wip: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -176,20 +193,16 @@ impl EsaClient {
     pub async fn create_post(
         &self,
         team: &str,
-        name: &str,
-        body_md: Option<&str>,
-        category: Option<&str>,
-        tags: Vec<String>,
-        wip: bool,
+        params: &CreatePostParams<'_>,
     ) -> Result<EsaPost, ClientError> {
         let url = self.build_url(&format!("teams/{team}/posts"))?.to_string();
         let body = CreatePostRequest {
             post: CreatePostBody {
-                name: name.to_string(),
-                body_md: body_md.map(str::to_string),
-                category: category.map(str::to_string),
-                tags,
-                wip,
+                name: params.name.to_string(),
+                body_md: params.body_md.map(str::to_string),
+                category: params.category.map(str::to_string),
+                tags: params.tags.clone(),
+                wip: params.wip,
             },
         };
         self.send(|http| http.post(&url).json(&body)).await
@@ -200,22 +213,18 @@ impl EsaClient {
         &self,
         team: &str,
         post_number: u32,
-        name: Option<&str>,
-        body_md: Option<&str>,
-        category: Option<&str>,
-        tags: Option<Vec<String>>,
-        wip: Option<bool>,
+        params: &UpdatePostParams<'_>,
     ) -> Result<EsaPost, ClientError> {
         let url = self
             .build_url(&format!("teams/{team}/posts/{post_number}"))?
             .to_string();
         let body = UpdatePostRequest {
             post: UpdatePostBody {
-                name: name.map(str::to_string),
-                body_md: body_md.map(str::to_string),
-                category: category.map(str::to_string),
-                tags,
-                wip,
+                name: params.name.map(str::to_string),
+                body_md: params.body_md.map(str::to_string),
+                category: params.category.map(str::to_string),
+                tags: params.tags.clone(),
+                wip: params.wip,
             },
         };
         self.send(|http| http.patch(&url).json(&body)).await
@@ -311,12 +320,12 @@ fn retry_wait(status: u16, retry_after: Option<&str>, attempt: u32) -> Option<Du
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{body_json, method, path};
+    use wiremock::matchers::{body_json, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn test_post_json() -> serde_json::Value {
+    fn test_post_json(number: u32) -> serde_json::Value {
         serde_json::json!({
-            "number": 1,
+            "number": number,
             "name": "Getting Started",
             "full_name": "dev/Getting Started",
             "body_md": "# Hello",
@@ -343,7 +352,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "posts": [test_post_json()],
+                "posts": [test_post_json(1)],
                 "next_page": null,
                 "total_count": 1
             })))
@@ -368,7 +377,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "posts": [test_post_json()],
+                "posts": [test_post_json(1)],
                 "next_page": 2,
                 "total_count": 150
             })))
@@ -389,7 +398,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts/42"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json(42)))
             .mount(&server)
             .await;
 
@@ -398,7 +407,7 @@ mod tests {
             .get_post("myteam", 42)
             .await
             .unwrap();
-        assert_eq!(post.number, 1);
+        assert_eq!(post.number, 42);
         assert_eq!(post.name, "Getting Started");
     }
 
@@ -407,13 +416,19 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/teams/myteam/posts"))
-            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
         let post = test_client(&server)
             .await
-            .create_post("myteam", "Test", Some("# Body"), None, vec![], true)
+            .create_post("myteam", &CreatePostParams {
+                name: "Test",
+                body_md: Some("# Body"),
+                category: None,
+                tags: vec![],
+                wip: true,
+            })
             .await
             .unwrap();
         assert_eq!(post.name, "Getting Started");
@@ -424,13 +439,13 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/teams/myteam/posts/1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
         let post = test_client(&server)
             .await
-            .update_post("myteam", 1, Some("New Name"), None, None, None, None)
+            .update_post("myteam", 1, &UpdatePostParams { name: Some("New Name"), ..Default::default() })
             .await
             .unwrap();
         assert_eq!(post.name, "Getting Started");
@@ -467,7 +482,7 @@ mod tests {
             .await;
         Mock::given(method("GET"))
             .and(path("/teams/myteam/posts/1"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
@@ -582,7 +597,6 @@ mod tests {
     // All share the same serialization contract: EsaPost → JSON with name, number, url.
     #[test]
     fn esa_post_json_has_name_number_url() {
-        // [T-048, T-050, T-051, T-052] All mutation commands output EsaPost JSON
         let post = test_esa_post(Some("body".to_string()));
         let json_str = serde_json::to_string(&post).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
@@ -611,20 +625,19 @@ mod tests {
                     "wip": true,
                 }
             })))
-            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
         test_client(&server)
             .await
-            .create_post(
-                "myteam",
-                "My Title",
-                Some("# Content"),
-                Some("docs"),
-                vec!["rust".into(), "api".into()],
-                true,
-            )
+            .create_post("myteam", &CreatePostParams {
+                name: "My Title",
+                body_md: Some("# Content"),
+                category: Some("docs"),
+                tags: vec!["rust".into(), "api".into()],
+                wip: true,
+            })
             .await
             .unwrap();
     }
@@ -641,14 +654,61 @@ mod tests {
                     "wip": false,
                 }
             })))
-            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(test_post_json(1)))
             .mount(&server)
             .await;
 
         test_client(&server)
             .await
-            .create_post("myteam", "Minimal", None, None, vec![], false)
+            .create_post("myteam", &CreatePostParams {
+                name: "Minimal",
+                body_md: None,
+                category: None,
+                tags: vec![],
+                wip: false,
+            })
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn max_retries_exhausted() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/myteam/posts/1"))
+            .respond_with(
+                ResponseTemplate::new(429).insert_header("retry-after", "0"),
+            )
+            .mount(&server)
+            .await;
+
+        let err = test_client(&server)
+            .await
+            .get_post("myteam", 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ClientError::MaxRetries(MAX_RETRIES)));
+    }
+
+    #[tokio::test]
+    async fn list_posts_with_query() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/myteam/posts"))
+            .and(query_param("q", "updated:>2025-01-01"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "posts": [test_post_json(1)],
+                "next_page": null,
+                "total_count": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let resp = test_client(&server)
+            .await
+            .list_posts("myteam", 1, Some("updated:>2025-01-01"))
+            .await
+            .unwrap();
+        assert_eq!(resp.posts.len(), 1);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,7 +100,7 @@ fn dirs_fallback_config_home() -> Result<PathBuf, ConfigError> {
 }
 
 /// esa team name: lowercase alphanumeric + hyphen, must start with alphanumeric.
-fn validate_team_name(name: &str) -> Result<(), ConfigError> {
+pub fn validate_team_name(name: &str) -> Result<(), ConfigError> {
     if name.is_empty() {
         return Err(ConfigError::InvalidValue(
             "team name must not be empty".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,10 @@ where
 
 type AppError = Box<dyn std::error::Error>;
 
-fn resolve_client<'a>(config: &'a Config, team: Option<&'a str>) -> Result<(&'a str, EsaClient), AppError> {
+fn resolve_client<'a>(
+    config: &'a Config,
+    team: Option<&'a str>,
+) -> Result<(&'a str, EsaClient), AppError> {
     let team = config.resolve_team(team)?;
     let client = EsaClient::from_env()?;
     Ok((team, client))
@@ -278,42 +281,15 @@ async fn main() -> Result<(), AppError> {
     let json = cli.json;
 
     match cli.command {
-        Command::Harvest { team, full } => {
-            let (team, client) = resolve_client(&config, Some(&team))?;
-            let db_path = config.team_db_path(team)?;
-            let db = sae::storage::Db::open(&db_path)?;
-            let result = sae::sync::harvest(&client, &db, team, full).await?;
-            output::harvest(&result, json)?;
-        }
+        Command::Harvest { team, full } => run_harvest(&config, &team, full, json).await,
         Command::Search { query, team, limit } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let db = require_db(&config, team)?;
-            let embedder = try_load_embedder();
-            let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(&query) {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    tracing::warn!(error = %e, "embed_query failed, falling back to FTS");
-                    None
-                }
-            });
-            let results = sae::storage::hybrid_search(
-                db.conn(),
-                &query,
-                query_embedding.as_deref(),
-                limit,
-                chrono::Utc::now(),
-            )?;
-            output::search(&results, &query, json)?;
+            run_search(&config, &query, team.as_deref(), limit, json)
         }
         Command::Get {
             number,
             team,
             with_body,
-        } => {
-            let (team, client) = resolve_client(&config, team.as_deref())?;
-            let post = client.get_post(team, number).await?;
-            output::get(&post, json, with_body)?;
-        }
+        } => run_get(&config, number, team.as_deref(), with_body, json).await,
         Command::Create {
             name,
             body,
@@ -324,28 +300,21 @@ async fn main() -> Result<(), AppError> {
             team,
             dry_run,
         } => {
-            let resolved_body = resolve_body(body.as_deref(), body_file.as_deref())?;
-            if dry_run {
-                let payload = serde_json::json!({
-                    "name": name,
-                    "body_md": resolved_body,
-                    "category": category,
-                    "tags": tag,
-                    "wip": wip,
-                });
-                println!("{}", serde_json::to_string(&payload)?);
-            } else {
-                let (team, client) = resolve_client(&config, team.as_deref())?;
-                let params = CreatePostParams {
-                    name: &name,
-                    body_md: resolved_body.as_deref(),
-                    category: category.as_deref(),
-                    tags: tag,
+            run_create(
+                &config,
+                CreateArgs {
+                    name,
+                    body,
+                    body_file,
+                    category,
+                    tag,
                     wip,
-                };
-                let post = client.create_post(team, &params).await?;
-                output::post("Created", &post, json)?;
-            }
+                    team,
+                    dry_run,
+                },
+                json,
+            )
+            .await
         }
         Command::Update {
             number,
@@ -357,156 +326,313 @@ async fn main() -> Result<(), AppError> {
             team,
             dry_run,
         } => {
-            let resolved_body = resolve_body(body.as_deref(), body_file.as_deref())?;
-            if dry_run {
-                let tags = if tag.is_empty() { None } else { Some(&tag) };
-                let payload = serde_json::json!({
-                    "number": number,
-                    "name": name,
-                    "body_md": resolved_body,
-                    "category": category,
-                    "tags": tags,
-                });
-                println!("{}", serde_json::to_string(&payload)?);
-            } else {
-                let (team, client) = resolve_client(&config, team.as_deref())?;
-                let tags = if tag.is_empty() { None } else { Some(tag) };
-                let params = UpdatePostParams {
-                    name: name.as_deref(),
-                    body_md: resolved_body.as_deref(),
-                    category: category.as_deref(),
-                    tags,
-                    ..Default::default()
-                };
-                let post = client.update_post(team, number, &params).await?;
-                output::post("Updated", &post, json)?;
-            }
+            run_update(
+                &config,
+                UpdateArgs {
+                    number,
+                    name,
+                    body,
+                    body_file,
+                    category,
+                    tag,
+                    team,
+                    dry_run,
+                },
+                json,
+            )
+            .await
         }
-        Command::Embed { team } => {
-            let team = config.resolve_team(Some(&team))?;
-            let db = require_db(&config, team)?;
-
-            let paths = require_embed_model()?;
-            eprintln!("Loading model...");
-            let embedder =
-                Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
-            eprintln!("Model ready");
-
-            const BATCH_SIZE: u32 = 500;
-            let mut total_added = 0u32;
-            let mut done = 0u32;
-            loop {
-                let batch = sae::storage::get_unembedded_chunks(db.conn(), BATCH_SIZE)?;
-                if batch.is_empty() {
-                    break;
-                }
-                if done == 0 {
-                    eprintln!("Embedding chunks...");
-                }
-                let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
-                let batch_len = batch.len() as u32;
-                let embs = embedder
-                    .embed_documents_batch(&texts)
-                    .map_err(|e| format!("Batch embedding failed: {e}"))?;
-                let embeddings: Vec<(i64, Vec<f32>)> =
-                    batch.iter().map(|(id, _)| *id).zip(embs).collect();
-                total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
-                done += batch_len;
-                eprintln!("  {done} chunks processed");
-            }
-            let result = sae::storage::EmbedResult {
-                chunks_embedded: total_added,
-            };
-            output::embed(&result, done, json)?;
-        }
+        Command::Embed { team } => run_embed(&config, &team, json),
         Command::Archive {
             number,
             team,
             dry_run,
-        } => {
-            let (team, client) = resolve_client(&config, team.as_deref())?;
-            let post = client.get_post(team, number).await?;
-            match archive_category(post.category.as_deref()) {
-                None => {
-                    if dry_run {
-                        let payload = serde_json::json!({
-                            "number": number,
-                            "already_archived": true,
-                            "category": post.category.as_deref().unwrap_or(""),
-                        });
-                        println!("{}", serde_json::to_string(&payload)?);
-                    } else {
-                        output::post("Already archived", &post, json)?;
-                    }
-                }
-                Some(new_category) => {
-                    if dry_run {
-                        let payload = serde_json::json!({
-                            "number": number,
-                            "from_category": post.category.as_deref().unwrap_or(""),
-                            "to_category": new_category,
-                        });
-                        println!("{}", serde_json::to_string(&payload)?);
-                    } else {
-                        let params = UpdatePostParams {
-                            category: Some(&new_category),
-                            ..Default::default()
-                        };
-                        let post = client.update_post(team, number, &params).await?;
-                        output::post("Archived", &post, json)?;
-                    }
-                }
-            }
-        }
+        } => run_archive(&config, number, team.as_deref(), dry_run, json).await,
         Command::Ship {
             number,
             team,
             dry_run,
-        } => {
-            if dry_run {
-                let payload = serde_json::json!({
-                    "number": number,
-                    "wip": false,
-                });
-                println!("{}", serde_json::to_string(&payload)?);
-            } else {
-                let (team, client) = resolve_client(&config, team.as_deref())?;
-                let params = UpdatePostParams {
-                    wip: Some(false),
-                    ..Default::default()
-                };
-                let post = client.update_post(team, number, &params).await?;
-                output::post("Shipped", &post, json)?;
-            }
-        }
-        Command::Status { team } => {
-            let target_teams: Vec<&str> = if let Some(ref t) = team {
-                vec![config.resolve_team(Some(t))?]
-            } else {
-                config
-                    .teams
-                    .iter()
-                    .filter(|t| sae::config::validate_team_name(t).is_ok())
-                    .map(String::as_str)
-                    .collect()
-            };
-            let statuses = collect_team_statuses(&config, &target_teams)?;
-            output::status(&statuses, json)?;
-        }
+        } => run_ship(&config, number, team.as_deref(), dry_run, json).await,
+        Command::Status { team } => run_status(&config, team.as_deref(), json),
         Command::Model { command } => match command {
-            ModelCommand::Download => {
-                eprintln!("Downloading model...");
-                let paths = rurico::embed::download_model()
-                    .map_err(|e| format!("Failed to download model: {e}"))?;
-                // Verify model files are loadable (catches corrupt downloads)
-                let _embedder =
-                    Embedder::new(&paths).map_err(|e| format!("Failed to verify model: {e}"))?;
-                output::model_download(json)?;
-            }
+            ModelCommand::Download => run_model_download(json),
         },
     }
+}
 
+async fn run_harvest(config: &Config, team: &str, full: bool, json: bool) -> Result<(), AppError> {
+    let (team, client) = resolve_client(config, Some(team))?;
+    let db_path = config.team_db_path(team)?;
+    let db = sae::storage::Db::open(&db_path)?;
+    let result = sae::sync::harvest(&client, &db, team, full).await?;
+    output::harvest(&result, json)?;
     Ok(())
+}
+
+fn run_search(
+    config: &Config,
+    query: &str,
+    team: Option<&str>,
+    limit: u32,
+    json: bool,
+) -> Result<(), AppError> {
+    let team = config.resolve_team(team)?;
+    let db = require_db(config, team)?;
+    let embedder = try_load_embedder();
+    let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(query) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(error = %e, "embed_query failed, falling back to FTS");
+            None
+        }
+    });
+    let results = sae::storage::hybrid_search(
+        db.conn(),
+        query,
+        query_embedding.as_deref(),
+        limit,
+        chrono::Utc::now(),
+    )?;
+    output::search(&results, query, json)?;
+    Ok(())
+}
+
+async fn run_get(
+    config: &Config,
+    number: u32,
+    team: Option<&str>,
+    with_body: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    let (team, client) = resolve_client(config, team)?;
+    let post = client.get_post(team, number).await?;
+    output::get(&post, json, with_body)?;
+    Ok(())
+}
+
+struct CreateArgs {
+    name: String,
+    body: Option<String>,
+    body_file: Option<String>,
+    category: Option<String>,
+    tag: Vec<String>,
+    wip: bool,
+    team: Option<String>,
+    dry_run: bool,
+}
+
+async fn run_create(config: &Config, args: CreateArgs, json: bool) -> Result<(), AppError> {
+    let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
+    if args.dry_run {
+        let payload = serde_json::json!({
+            "name": args.name,
+            "body_md": resolved_body,
+            "category": args.category,
+            "tags": args.tag,
+            "wip": args.wip,
+        });
+        println!("{}", serde_json::to_string(&payload)?);
+        return Ok(());
+    }
+    let (team, client) = resolve_client(config, args.team.as_deref())?;
+    let params = CreatePostParams {
+        name: &args.name,
+        body_md: resolved_body.as_deref(),
+        category: args.category.as_deref(),
+        tags: args.tag,
+        wip: args.wip,
+    };
+    let post = client.create_post(team, &params).await?;
+    output::post("Created", &post, json)?;
+    Ok(())
+}
+
+struct UpdateArgs {
+    number: u32,
+    name: Option<String>,
+    body: Option<String>,
+    body_file: Option<String>,
+    category: Option<String>,
+    tag: Vec<String>,
+    team: Option<String>,
+    dry_run: bool,
+}
+
+async fn run_update(config: &Config, args: UpdateArgs, json: bool) -> Result<(), AppError> {
+    let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
+    if args.dry_run {
+        let tags = if args.tag.is_empty() {
+            None
+        } else {
+            Some(&args.tag)
+        };
+        let payload = serde_json::json!({
+            "number": args.number,
+            "name": args.name,
+            "body_md": resolved_body,
+            "category": args.category,
+            "tags": tags,
+        });
+        println!("{}", serde_json::to_string(&payload)?);
+        return Ok(());
+    }
+    let (team, client) = resolve_client(config, args.team.as_deref())?;
+    let tags = if args.tag.is_empty() {
+        None
+    } else {
+        Some(args.tag)
+    };
+    let params = UpdatePostParams {
+        name: args.name.as_deref(),
+        body_md: resolved_body.as_deref(),
+        category: args.category.as_deref(),
+        tags,
+        ..Default::default()
+    };
+    let post = client.update_post(team, args.number, &params).await?;
+    output::post("Updated", &post, json)?;
+    Ok(())
+}
+
+fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), AppError> {
+    let team = config.resolve_team(Some(team))?;
+    let db = require_db(config, team)?;
+
+    let paths = require_embed_model()?;
+    eprintln!("Loading model...");
+    let embedder = Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
+    eprintln!("Model ready");
+
+    const BATCH_SIZE: u32 = 500;
+    let mut total_added = 0u32;
+    let mut done = 0u32;
+    loop {
+        let batch = sae::storage::get_unembedded_chunks(db.conn(), BATCH_SIZE)?;
+        if batch.is_empty() {
+            break;
+        }
+        if done == 0 {
+            eprintln!("Embedding chunks...");
+        }
+        let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
+        let batch_len = batch.len() as u32;
+        let embs = embedder
+            .embed_documents_batch(&texts)
+            .map_err(|e| format!("Batch embedding failed: {e}"))?;
+        let embeddings: Vec<(i64, Vec<f32>)> = batch.iter().map(|(id, _)| *id).zip(embs).collect();
+        total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
+        done += batch_len;
+        eprintln!("  {done} chunks processed");
+    }
+    let result = sae::storage::EmbedResult {
+        chunks_embedded: total_added,
+    };
+    output::embed(&result, done, json)?;
+    Ok(())
+}
+
+async fn run_archive(
+    config: &Config,
+    number: u32,
+    team: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    let (team, client) = resolve_client(config, team)?;
+    let post = client.get_post(team, number).await?;
+    let new_category = match archive_category(post.category.as_deref()) {
+        Some(c) => c,
+        None if dry_run => {
+            let payload = serde_json::json!({
+                "number": number,
+                "already_archived": true,
+                "category": post.category.as_deref().unwrap_or(""),
+            });
+            println!("{}", serde_json::to_string(&payload)?);
+            return Ok(());
+        }
+        None => {
+            output::post("Already archived", &post, json)?;
+            return Ok(());
+        }
+    };
+    if dry_run {
+        let payload = serde_json::json!({
+            "number": number,
+            "from_category": post.category.as_deref().unwrap_or(""),
+            "to_category": new_category,
+        });
+        println!("{}", serde_json::to_string(&payload)?);
+        return Ok(());
+    }
+    let params = UpdatePostParams {
+        category: Some(&new_category),
+        ..Default::default()
+    };
+    let post = client.update_post(team, number, &params).await?;
+    output::post("Archived", &post, json)?;
+    Ok(())
+}
+
+async fn run_ship(
+    config: &Config,
+    number: u32,
+    team: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    if dry_run {
+        let payload = serde_json::json!({
+            "number": number,
+            "wip": false,
+        });
+        println!("{}", serde_json::to_string(&payload)?);
+        return Ok(());
+    }
+    let (team, client) = resolve_client(config, team)?;
+    let params = UpdatePostParams {
+        wip: Some(false),
+        ..Default::default()
+    };
+    let post = client.update_post(team, number, &params).await?;
+    output::post("Shipped", &post, json)?;
+    Ok(())
+}
+
+fn run_status(config: &Config, team: Option<&str>, json: bool) -> Result<(), AppError> {
+    let target_teams: Vec<&str> = if let Some(t) = team {
+        vec![config.resolve_team(Some(t))?]
+    } else {
+        config
+            .teams
+            .iter()
+            .filter(|t| sae::config::validate_team_name(t).is_ok())
+            .map(String::as_str)
+            .collect()
+    };
+    let statuses = collect_team_statuses(config, &target_teams)?;
+    output::status(&statuses, json)?;
+    Ok(())
+}
+
+fn run_model_download(json: bool) -> Result<(), AppError> {
+    eprintln!("Downloading model...");
+    let paths =
+        rurico::embed::download_model().map_err(|e| format!("Failed to download model: {e}"))?;
+    let _embedder = Embedder::new(&paths).map_err(|e| format!("Failed to verify model: {e}"))?;
+    output::model_download(json)?;
+    Ok(())
+}
+
+fn team_error(team: &str, error: impl ToString) -> sae::storage::TeamStatus {
+    sae::storage::TeamStatus {
+        team: team.to_string(),
+        status: sae::storage::SyncStatus::Error,
+        posts: 0,
+        sync_state: None,
+        error: Some(error.to_string()),
+        db_path: None,
+    }
 }
 
 fn collect_team_statuses(
@@ -518,14 +644,7 @@ fn collect_team_statuses(
         let ts = match config.team_db_path(t) {
             Ok(path) if path.exists() => match query_team_status(t, &path) {
                 Ok(ts) => ts,
-                Err(e) => sae::storage::TeamStatus {
-                    team: t.to_string(),
-                    status: sae::storage::SyncStatus::Error,
-                    posts: 0,
-                    sync_state: None,
-                    error: Some(e.to_string()),
-                    db_path: None,
-                },
+                Err(e) => team_error(t, e),
             },
             Ok(path) => sae::storage::TeamStatus {
                 team: t.to_string(),
@@ -535,14 +654,7 @@ fn collect_team_statuses(
                 error: None,
                 db_path: Some(path.display().to_string()),
             },
-            Err(e) => sae::storage::TeamStatus {
-                team: t.to_string(),
-                status: sae::storage::SyncStatus::Error,
-                posts: 0,
-                sync_state: None,
-                error: Some(e.to_string()),
-                db_path: None,
-            },
+            Err(e) => team_error(t, e),
         };
         statuses.push(ts);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod output;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use rurico::embed::{Embed, Embedder};
-use sae::client::EsaClient;
+use sae::client::{CreatePostParams, EsaClient, UpdatePostParams};
 use sae::config::Config;
 
 #[derive(Parser)]
@@ -236,8 +236,36 @@ where
     Cli::try_parse_from(args)
 }
 
+type AppError = Box<dyn std::error::Error>;
+
+fn resolve_client<'a>(config: &'a Config, team: Option<&'a str>) -> Result<(&'a str, EsaClient), AppError> {
+    let team = config.resolve_team(team)?;
+    let client = EsaClient::from_env()?;
+    Ok((team, client))
+}
+
+fn require_db(config: &Config, team: &str) -> Result<sae::storage::Db, AppError> {
+    let db_path = config.team_db_path(team)?;
+    if !db_path.exists() {
+        return Err(format!("No data for team '{team}'. Run `sae harvest {team}` first.").into());
+    }
+    Ok(sae::storage::Db::open(&db_path)?)
+}
+
+fn archive_category(current: Option<&str>) -> Option<String> {
+    let current = current.unwrap_or("");
+    if current.starts_with("Archived/") || current == "Archived" {
+        return None;
+    }
+    Some(if current.is_empty() {
+        "Archived".to_string()
+    } else {
+        format!("Archived/{current}")
+    })
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), AppError> {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
@@ -251,8 +279,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Command::Harvest { team, full } => {
-            let team = config.resolve_team(Some(&team))?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, Some(&team))?;
             let db_path = config.team_db_path(team)?;
             let db = sae::storage::Db::open(&db_path)?;
             let result = sae::sync::harvest(&client, &db, team, full).await?;
@@ -260,14 +287,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Search { query, team, limit } => {
             let team = config.resolve_team(team.as_deref())?;
-            let db_path = config.team_db_path(team)?;
-            require_db(&db_path, team);
-            let db = sae::storage::Db::open(&db_path)?;
+            let db = require_db(&config, team)?;
             let embedder = try_load_embedder();
             let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(&query) {
                 Ok(v) => Some(v),
                 Err(e) => {
-                    eprintln!("Warning: embed_query failed: {e}");
+                    tracing::warn!(error = %e, "embed_query failed, falling back to FTS");
                     None
                 }
             });
@@ -285,8 +310,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             team,
             with_body,
         } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
             let post = client.get_post(team, number).await?;
             output::get(&post, json, with_body)?;
         }
@@ -311,18 +335,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 });
                 println!("{}", serde_json::to_string(&payload)?);
             } else {
-                let team = config.resolve_team(team.as_deref())?;
-                let client = EsaClient::from_env()?;
-                let post = client
-                    .create_post(
-                        team,
-                        &name,
-                        resolved_body.as_deref(),
-                        category.as_deref(),
-                        tag,
-                        wip,
-                    )
-                    .await?;
+                let (team, client) = resolve_client(&config, team.as_deref())?;
+                let params = CreatePostParams {
+                    name: &name,
+                    body_md: resolved_body.as_deref(),
+                    category: category.as_deref(),
+                    tags: tag,
+                    wip,
+                };
+                let post = client.create_post(team, &params).await?;
                 output::post("Created", &post, json)?;
             }
         }
@@ -348,28 +369,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 });
                 println!("{}", serde_json::to_string(&payload)?);
             } else {
-                let team = config.resolve_team(team.as_deref())?;
-                let client = EsaClient::from_env()?;
+                let (team, client) = resolve_client(&config, team.as_deref())?;
                 let tags = if tag.is_empty() { None } else { Some(tag) };
-                let post = client
-                    .update_post(
-                        team,
-                        number,
-                        name.as_deref(),
-                        resolved_body.as_deref(),
-                        category.as_deref(),
-                        tags,
-                        None,
-                    )
-                    .await?;
+                let params = UpdatePostParams {
+                    name: name.as_deref(),
+                    body_md: resolved_body.as_deref(),
+                    category: category.as_deref(),
+                    tags,
+                    ..Default::default()
+                };
+                let post = client.update_post(team, number, &params).await?;
                 output::post("Updated", &post, json)?;
             }
         }
         Command::Embed { team } => {
             let team = config.resolve_team(Some(&team))?;
-            let db_path = config.team_db_path(team)?;
-            require_db(&db_path, team);
-            let db = sae::storage::Db::open(&db_path)?;
+            let db = require_db(&config, team)?;
 
             let paths = require_embed_model()?;
             eprintln!("Loading model...");
@@ -390,17 +405,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
                 let batch_len = batch.len() as u32;
-                match embedder.embed_documents_batch(&texts) {
-                    Ok(embs) => {
-                        let embeddings: Vec<(i64, Vec<f32>)> =
-                            batch.iter().map(|(id, _)| *id).zip(embs).collect();
-                        total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: batch embedding failed: {e}. Aborting.");
-                        std::process::exit(1);
-                    }
-                }
+                let embs = embedder
+                    .embed_documents_batch(&texts)
+                    .map_err(|e| format!("Batch embedding failed: {e}"))?;
+                let embeddings: Vec<(i64, Vec<f32>)> =
+                    batch.iter().map(|(id, _)| *id).zip(embs).collect();
+                total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
                 done += batch_len;
                 eprintln!("  {done} chunks processed");
             }
@@ -414,47 +424,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             team,
             dry_run,
         } => {
-            let team = config.resolve_team(team.as_deref())?;
-            let client = EsaClient::from_env()?;
+            let (team, client) = resolve_client(&config, team.as_deref())?;
             let post = client.get_post(team, number).await?;
-            let current_category = post.category.as_deref().unwrap_or("");
-            if current_category.starts_with("Archived/") || current_category == "Archived" {
-                if dry_run {
-                    let payload = serde_json::json!({
-                        "number": number,
-                        "already_archived": true,
-                        "category": current_category,
-                    });
-                    println!("{}", serde_json::to_string(&payload)?);
-                } else {
-                    output::post("Already archived", &post, json)?;
+            match archive_category(post.category.as_deref()) {
+                None => {
+                    if dry_run {
+                        let payload = serde_json::json!({
+                            "number": number,
+                            "already_archived": true,
+                            "category": post.category.as_deref().unwrap_or(""),
+                        });
+                        println!("{}", serde_json::to_string(&payload)?);
+                    } else {
+                        output::post("Already archived", &post, json)?;
+                    }
                 }
-            } else {
-                let archived_category = if current_category.is_empty() {
-                    "Archived".to_string()
-                } else {
-                    format!("Archived/{current_category}")
-                };
-                if dry_run {
-                    let payload = serde_json::json!({
-                        "number": number,
-                        "from_category": current_category,
-                        "to_category": archived_category,
-                    });
-                    println!("{}", serde_json::to_string(&payload)?);
-                } else {
-                    let post = client
-                        .update_post(
-                            team,
-                            number,
-                            None,
-                            None,
-                            Some(&archived_category),
-                            None,
-                            None,
-                        )
-                        .await?;
-                    output::post("Archived", &post, json)?;
+                Some(new_category) => {
+                    if dry_run {
+                        let payload = serde_json::json!({
+                            "number": number,
+                            "from_category": post.category.as_deref().unwrap_or(""),
+                            "to_category": new_category,
+                        });
+                        println!("{}", serde_json::to_string(&payload)?);
+                    } else {
+                        let params = UpdatePostParams {
+                            category: Some(&new_category),
+                            ..Default::default()
+                        };
+                        let post = client.update_post(team, number, &params).await?;
+                        output::post("Archived", &post, json)?;
+                    }
                 }
             }
         }
@@ -470,21 +470,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 });
                 println!("{}", serde_json::to_string(&payload)?);
             } else {
-                let team = config.resolve_team(team.as_deref())?;
-                let client = EsaClient::from_env()?;
-                let post = client
-                    .update_post(team, number, None, None, None, None, Some(false))
-                    .await?;
+                let (team, client) = resolve_client(&config, team.as_deref())?;
+                let params = UpdatePostParams {
+                    wip: Some(false),
+                    ..Default::default()
+                };
+                let post = client.update_post(team, number, &params).await?;
                 output::post("Shipped", &post, json)?;
             }
         }
         Command::Status { team } => {
-            let teams: Vec<&str> = if let Some(ref t) = team {
+            let target_teams: Vec<&str> = if let Some(ref t) = team {
                 vec![config.resolve_team(Some(t))?]
             } else {
-                config.teams.iter().map(String::as_str).collect()
+                config
+                    .teams
+                    .iter()
+                    .filter(|t| sae::config::validate_team_name(t).is_ok())
+                    .map(String::as_str)
+                    .collect()
             };
-            let statuses = collect_team_statuses(&config, &teams)?;
+            let statuses = collect_team_statuses(&config, &target_teams)?;
             output::status(&statuses, json)?;
         }
         Command::Model { command } => match command {
@@ -543,13 +549,6 @@ fn collect_team_statuses(
     Ok(statuses)
 }
 
-fn require_db(db_path: &std::path::Path, team: &str) {
-    if !db_path.exists() {
-        eprintln!("No data for team '{team}'. Run `sae harvest {team}` first.");
-        std::process::exit(1);
-    }
-}
-
 fn query_team_status(
     team: &str,
     path: &std::path::Path,
@@ -588,6 +587,43 @@ fn resolve_body(
         }
         (None, None) => Ok(None),
         (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
+    }
+}
+
+fn require_embed_model() -> Result<rurico::embed::ModelPaths, Box<dyn std::error::Error>> {
+    let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
+    if auto_download {
+        eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
+        return rurico::embed::download_model()
+            .map_err(|e| format!("Failed to download model: {e}").into());
+    }
+    match rurico::embed::model_paths_if_cached() {
+        Ok(Some(p)) => Ok(p),
+        Ok(None) => Err("Model not found. Run 'sae model download' first.".into()),
+        Err(e) => Err(format!("Failed to check model cache: {e}").into()),
+    }
+}
+
+fn try_load_embedder() -> Option<Embedder> {
+    let paths = match rurico::embed::model_paths_if_cached() {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            eprintln!(
+                "Hint: run 'sae model download && sae embed <team>' to enable semantic search"
+            );
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "embedding model not available");
+            return None;
+        }
+    };
+    match Embedder::new(&paths) {
+        Ok(e) => Some(e),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load embedding model");
+            None
+        }
     }
 }
 
@@ -848,41 +884,34 @@ mod tests {
             other => panic!("[T-005] expected Embed, got {other:?}"),
         }
     }
-}
 
-fn require_embed_model() -> Result<rurico::embed::ModelPaths, Box<dyn std::error::Error>> {
-    let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
-    if auto_download {
-        eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
-        return rurico::embed::download_model()
-            .map_err(|e| format!("Failed to download model: {e}").into());
-    }
-    match rurico::embed::model_paths_if_cached() {
-        Ok(Some(p)) => Ok(p),
-        Ok(None) => Err("Model not found. Run 'sae model download' first.".into()),
-        Err(e) => Err(format!("Failed to check model cache: {e}").into()),
-    }
-}
+    // --- archive_category ---
 
-fn try_load_embedder() -> Option<Embedder> {
-    let paths = match rurico::embed::model_paths_if_cached() {
-        Ok(Some(p)) => p,
-        Ok(None) => {
-            eprintln!(
-                "Hint: run 'sae model download && sae embed <team>' to enable semantic search"
-            );
-            return None;
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "embedding model not available");
-            return None;
-        }
-    };
-    match Embedder::new(&paths) {
-        Ok(e) => Some(e),
-        Err(e) => {
-            eprintln!("Warning: failed to load embedding model: {e}");
-            None
-        }
+    #[test]
+    fn archive_no_category() {
+        assert_eq!(archive_category(None), Some("Archived".into()));
+        assert_eq!(archive_category(Some("")), Some("Archived".into()));
+    }
+
+    #[test]
+    fn archive_with_category() {
+        assert_eq!(
+            archive_category(Some("dev/guide")),
+            Some("Archived/dev/guide".into())
+        );
+    }
+
+    #[test]
+    fn archive_already_archived() {
+        assert_eq!(archive_category(Some("Archived")), None);
+        assert_eq!(archive_category(Some("Archived/dev")), None);
+    }
+
+    #[test]
+    fn archive_not_prefix_match() {
+        assert_eq!(
+            archive_category(Some("ArchivedData")),
+            Some("Archived/ArchivedData".into())
+        );
     }
 }

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -66,6 +66,10 @@ pub fn has_embeddings(conn: &Connection) -> bool {
     conn.query_row("SELECT EXISTS(SELECT 1 FROM vec_chunks)", [], |row| {
         row.get(0)
     })
+    .map_err(|e| {
+        tracing::warn!(error = %e, "has_embeddings query failed, assuming no embeddings");
+        e
+    })
     .unwrap_or(false)
 }
 

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -6,15 +6,14 @@ pub fn add_embeddings(
     conn: &Connection,
     embeddings: &[(i64, Vec<f32>)],
 ) -> Result<u32, StorageError> {
+    if embeddings.is_empty() {
+        return Ok(0);
+    }
+    let existing = existing_chunk_ids(conn, embeddings)?;
     let tx = conn.unchecked_transaction()?;
     let mut count = 0u32;
     for (chunk_id, embedding) in embeddings {
-        let exists: bool = tx.query_row(
-            "SELECT EXISTS(SELECT 1 FROM vec_chunks WHERE chunk_id = ?1)",
-            [chunk_id],
-            |row| row.get(0),
-        )?;
-        if exists {
+        if existing.contains(chunk_id) {
             continue;
         }
         let bytes: &[u8] = rurico::storage::f32_as_bytes(embedding);
@@ -26,6 +25,25 @@ pub fn add_embeddings(
     }
     tx.commit()?;
     Ok(count)
+}
+
+fn existing_chunk_ids(
+    conn: &Connection,
+    embeddings: &[(i64, Vec<f32>)],
+) -> Result<std::collections::HashSet<i64>, StorageError> {
+    let sql = format!(
+        "SELECT chunk_id FROM vec_chunks WHERE chunk_id IN ({})",
+        super::in_placeholders(embeddings.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::types::ToSql> = embeddings
+        .iter()
+        .map(|(id, _)| id as &dyn rusqlite::types::ToSql)
+        .collect();
+    let ids = stmt
+        .query_map(params.as_slice(), |row| row.get::<_, i64>(0))?
+        .collect::<Result<std::collections::HashSet<_>, _>>()?;
+    Ok(ids)
 }
 
 pub fn get_unembedded_chunks(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -318,6 +318,11 @@ pub fn rechunk_post(
     use crate::chunker;
 
     conn.execute(
+        "DELETE FROM vec_chunks WHERE chunk_id IN \
+         (SELECT id FROM chunks WHERE post_number = ?1)",
+        [post_number],
+    )?;
+    conn.execute(
         "DELETE FROM fts_chunks WHERE rowid IN \
          (SELECT id FROM chunks WHERE post_number = ?1)",
         [post_number],
@@ -325,23 +330,23 @@ pub fn rechunk_post(
     conn.execute("DELETE FROM chunks WHERE post_number = ?1", [post_number])?;
 
     let chunks = chunker::chunk_markdown(body_md);
+    let mut insert_chunk = conn.prepare_cached(
+        "INSERT INTO chunks (post_number, section_title, content, chunk_type) \
+         VALUES (?1, ?2, ?3, ?4)",
+    )?;
+    let mut insert_fts = conn.prepare_cached(
+        "INSERT INTO fts_chunks(rowid, section_title, content) VALUES (?1, ?2, ?3)",
+    )?;
     let mut count = 0u32;
     for chunk in &chunks {
-        conn.execute(
-            "INSERT INTO chunks (post_number, section_title, content, chunk_type) \
-             VALUES (?1, ?2, ?3, ?4)",
-            rusqlite::params![
-                post_number,
-                chunk.section_title,
-                chunk.content,
-                chunk.chunk_type.as_str(),
-            ],
-        )?;
+        insert_chunk.execute(rusqlite::params![
+            post_number,
+            chunk.section_title,
+            chunk.content,
+            chunk.chunk_type.as_str(),
+        ])?;
         let id = conn.last_insert_rowid();
-        conn.execute(
-            "INSERT INTO fts_chunks(rowid, section_title, content) VALUES (?1, ?2, ?3)",
-            rusqlite::params![id, chunk.section_title, chunk.content],
-        )?;
+        insert_fts.execute(rusqlite::params![id, chunk.section_title, chunk.content])?;
         count += 1;
     }
     Ok(count)
@@ -533,6 +538,30 @@ mod tests {
             )
             .unwrap();
         assert_eq!(hits, 0);
+    }
+
+    #[test]
+    fn rechunk_cleans_orphaned_vec_chunks() {
+        let db = Db::open_memory().unwrap();
+        let post = test_post_row(1);
+        upsert_post(db.conn(), &post).unwrap();
+        rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
+
+        let chunks = embed::get_unembedded_chunks(db.conn(), 100).unwrap();
+        let emb: Vec<(i64, Vec<f32>)> = chunks
+            .iter()
+            .map(|(id, _)| (*id, vec![0.1; rurico::embed::EMBEDDING_DIMS as usize]))
+            .collect();
+        embed::add_embeddings(db.conn(), &emb).unwrap();
+        assert!(embed::has_embeddings(db.conn()));
+
+        rechunk_post(db.conn(), 1, "# New\nContent").unwrap();
+
+        let orphans: u32 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM vec_chunks", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(orphans, 0, "rechunk should clean orphaned vec_chunks");
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -14,6 +14,13 @@ use rurico::embed::EMBEDDING_DIMS;
 
 const SCHEMA_VERSION: &str = "4";
 
+pub(crate) fn in_placeholders(len: usize) -> String {
+    (1..=len)
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 const DDL: &str = "
     CREATE TABLE IF NOT EXISTS posts (
         number INTEGER PRIMARY KEY,
@@ -101,7 +108,11 @@ impl Db {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+                if let Err(e) =
+                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                {
+                    warn!(path = %parent.display(), error = %e, "failed to restrict data directory permissions");
+                }
             }
         }
         let conn = open_with_wal_recovery(path)?;
@@ -209,7 +220,7 @@ pub fn upsert_post(conn: &Connection, post: &EsaPostRow) -> Result<(), StorageEr
             post.full_name,
             post.body_md,
             post.category,
-            post.tags,
+            post.tags_json(),
             post.wip,
             post.kind,
             post.url,
@@ -344,7 +355,7 @@ pub(crate) fn test_post_row(number: u32) -> EsaPostRow {
         full_name: format!("dev/Post {number}"),
         body_md: format!("# Post {number}"),
         category: Some("dev".into()),
-        tags: "[]".into(),
+        tags: vec![],
         wip: false,
         kind: "stock".into(),
         url: format!("https://example.esa.io/posts/{number}"),

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -15,7 +15,6 @@ pub struct SearchResult {
     pub score: f64,
 }
 
-/// FTS5 trigram search with fts5vocab short-term expansion.
 pub fn fts_search(conn: &Connection, query: &str, limit: u32) -> Result<Vec<FtsHit>, StorageError> {
     let normalized = normalize_punctuation(query);
     let matched = match rurico::storage::prepare_match_query(conn, &normalized) {
@@ -86,8 +85,6 @@ const RECENCY_HALF_LIFE: f64 = 30.0;
 const RECENCY_WEIGHT: f64 = 0.2;
 const SECS_PER_DAY: f64 = 86_400.0;
 
-/// Hybrid search: merge FTS5 + vector results via Reciprocal Rank Fusion,
-/// then apply recency decay boost based on `updated_at`.
 pub fn hybrid_search(
     conn: &Connection,
     query: &str,
@@ -110,7 +107,6 @@ pub fn hybrid_search(
         _ => Vec::new(),
     };
 
-    // RRF scores from rank position only; the f64 value is ignored by rurico::rrf_merge
     let fts_ranked: Vec<(u32, f64)> = fts_hits.iter().map(|h| (h.post_number, 0.0)).collect();
     let vec_ranked: Vec<(u32, f64)> = vec_hits.iter().map(|h| (h.post_number, 0.0)).collect();
     let merged = rurico::storage::rrf_merge(&fts_ranked, &vec_ranked);
@@ -193,10 +189,9 @@ fn batch_fetch_post_meta(
     if post_numbers.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders: Vec<String> = (1..=post_numbers.len()).map(|i| format!("?{i}")).collect();
     let sql = format!(
         "SELECT number, name, url, updated_at FROM posts WHERE number IN ({})",
-        placeholders.join(", ")
+        super::in_placeholders(post_numbers.len())
     );
     let mut stmt = conn.prepare(&sql)?;
     let params: Vec<&dyn rusqlite::types::ToSql> = post_numbers
@@ -586,12 +581,10 @@ mod tests {
     fn hybrid_search_recency_boost_recent_post_scores_higher() {
         let db = Db::open_memory().unwrap();
 
-        // Post A: updated 1 day ago, Post B: updated 30 days ago.
-        // Both match the same query so raw RRF scores are equal.
         let shared_body = "# 認証フロー\n認証の仕組みを説明します";
         let posts = [
-            (1u32, "PostA", "2025-01-31T00:00:00+09:00"), // 1 day before "now"
-            (2u32, "PostB", "2025-01-02T00:00:00+09:00"), // 30 days before "now"
+            (1u32, "PostA", "2025-01-31T00:00:00+09:00"),
+            (2u32, "PostB", "2025-01-02T00:00:00+09:00"),
         ];
         for (num, name, updated) in &posts {
             let mut post = test_post(*num, name, shared_body);
@@ -631,8 +624,6 @@ mod tests {
             .with_timezone(&chrono::Utc);
         let results = hybrid_search(db.conn(), "認証の仕組み", None, 10, now).unwrap();
 
-        // Must not panic. With decay=0.0 the boost factor is
-        // (1.0 + 0.2 * 0.0) = 1.0, so score equals raw RRF score.
         assert!(!results.is_empty(), "post should still be returned");
         assert!(
             results[0].score > 0.0,
@@ -687,7 +678,6 @@ mod tests {
         storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
-        // "認証ガイド" は section_title にのみ存在、content には含まれない
         let hits = fts_search(db.conn(), "認証ガイド", 10).unwrap();
         assert!(
             !hits.is_empty(),
@@ -732,9 +722,30 @@ mod tests {
 
     #[test]
     fn truncate_snippet_multibyte_boundary() {
-        // 3 chars of Japanese = 9 bytes; truncation must be on char boundary
         let s = "あいうえお";
         let result = truncate_snippet(s, 3);
         assert_eq!(result, "あいう...");
+    }
+
+    #[test]
+    fn hybrid_search_with_embeddings() {
+        use rurico::embed::EMBEDDING_DIMS;
+
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let unembedded = storage::get_unembedded_chunks(db.conn(), 100).unwrap();
+        assert!(!unembedded.is_empty());
+        let embeddings: Vec<(i64, Vec<f32>)> = unembedded
+            .iter()
+            .map(|(id, _)| (*id, vec![0.1; EMBEDDING_DIMS as usize]))
+            .collect();
+        storage::add_embeddings(db.conn(), &embeddings).unwrap();
+
+        let query_emb = vec![0.1; EMBEDDING_DIMS as usize];
+        let results = hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        assert!(!results.is_empty());
+        assert!(!results[0].post_name.is_empty());
+        assert!(!results[0].post_url.is_empty());
     }
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -118,28 +118,7 @@ pub fn hybrid_search(
     let fts_map: HashMap<u32, &FtsHit> = fts_hits.iter().map(|h| (h.post_number, h)).collect();
     let vec_map: HashMap<u32, &VecHit> = vec_hits.iter().map(|h| (h.post_number, h)).collect();
 
-    let mut scored: Vec<(u32, f64)> = merged
-        .into_iter()
-        .map(|(post_number, rrf_score)| {
-            let decay = post_meta
-                .get(&post_number)
-                .and_then(|meta| {
-                    let updated_at = &meta.updated_at;
-                    chrono::DateTime::parse_from_rfc3339(updated_at)
-                        .map_err(|e| warn!(%e, %updated_at, "unparseable updated_at, decay=0.0"))
-                        .ok()
-                })
-                .map(|updated| {
-                    let age_days = (now - updated.with_timezone(&chrono::Utc)).num_seconds() as f64
-                        / SECS_PER_DAY;
-                    rurico::storage::recency_decay(age_days, RECENCY_HALF_LIFE)
-                })
-                .unwrap_or(0.0);
-            let boosted = rrf_score * (1.0 + RECENCY_WEIGHT * decay);
-            (post_number, boosted)
-        })
-        .collect();
-    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+    let scored = apply_recency_boost(merged, &post_meta, now);
 
     let mut results = Vec::new();
     for (post_number, score) in scored.into_iter().take(limit as usize) {
@@ -173,6 +152,36 @@ pub fn hybrid_search(
     }
 
     Ok(results)
+}
+
+fn apply_recency_boost(
+    merged: Vec<(u32, f64)>,
+    post_meta: &HashMap<u32, PostMeta>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Vec<(u32, f64)> {
+    let mut scored: Vec<(u32, f64)> = merged
+        .into_iter()
+        .map(|(post_number, rrf_score)| {
+            let decay = post_meta
+                .get(&post_number)
+                .and_then(|meta| {
+                    let updated_at = &meta.updated_at;
+                    chrono::DateTime::parse_from_rfc3339(updated_at)
+                        .map_err(|e| warn!(%e, %updated_at, "unparseable updated_at, decay=0.0"))
+                        .ok()
+                })
+                .map(|updated| {
+                    let age_days = (now - updated.with_timezone(&chrono::Utc)).num_seconds() as f64
+                        / SECS_PER_DAY;
+                    rurico::storage::recency_decay(age_days, RECENCY_HALF_LIFE)
+                })
+                .unwrap_or(0.0);
+            let boosted = rrf_score * (1.0 + RECENCY_WEIGHT * decay);
+            (post_number, boosted)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+    scored
 }
 
 #[derive(Debug, Clone)]
@@ -241,20 +250,14 @@ pub struct VecHit {
     pub content: String,
 }
 
-/// Strip general punctuation while preserving technical term characters.
+/// Strip general punctuation while preserving technical term characters
+/// (`+`, `#`, `.`, `/`, `_`, `@`).
 ///
-/// Characters like `+`, `#`, `.`, `/`, `_`, `@` appear in technical terms
-/// (`C++`, `C#`, `.NET`, `/api/v1`) and must survive so that rurico's
-/// `prepare_match_query` can quote or expand them correctly.
-///
-/// `:` and `-` are intentionally stripped because rurico's
-/// `sanitize_fts_query` quotes terms containing them, and
-/// `fts_expand_short_terms` then re-quotes, producing double-quoted
-/// FTS5 queries that match nothing. Until rurico fixes this, terms like
-/// `std::io` and `rate-limit` are split into separate words (`std io`,
-/// `rate limit`) for broader-but-working recall.
+/// `:` and `-` are stripped to work around rurico double-quoting in
+/// `sanitize_fts_query` + `fts_expand_short_terms` (produces FTS5
+/// queries that match nothing).
 fn normalize_punctuation(query: &str) -> String {
-    let result: String = query
+    query
         .chars()
         .map(|c| {
             if c.is_alphanumeric() || c.is_whitespace() || "+#./_@".contains(c) {
@@ -263,23 +266,12 @@ fn normalize_punctuation(query: &str) -> String {
                 ' '
             }
         })
-        .collect();
-    result.split_whitespace().collect::<Vec<_>>().join(" ")
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
-/// Adapt rurico's MatchFtsQuery output for FTS5 trigram tokenizer.
-///
-/// rurico targets standard FTS5 (Unicode61). The trigram tokenizer does
-/// not support parenthesized OR groups combined with other terms via
-/// implicit AND (e.g. `("a" OR "b") "c"` fails). This function:
-///
-/// 1. Strips control characters from vocab-expanded terms (trigram vocab
-///    can include newlines, e.g. "認証\n").
-/// 2. Drops sub-trigram terms (<3 chars) created by step 1.
-/// 3. Distributes OR groups across fixed terms to eliminate parentheses:
-///    `(A OR B) C` → `A C OR B C`.
-///    When the query is a single group with no other terms, the parens
-///    are simply removed (single-group queries work in trigram FTS5).
 fn cross_product(groups: &[Vec<String>]) -> Vec<Vec<String>> {
     if groups.is_empty() {
         return vec![vec![]];
@@ -296,10 +288,7 @@ fn cross_product(groups: &[Vec<String>]) -> Vec<Vec<String>> {
     result
 }
 
-fn clean_for_trigram(query: &str) -> String {
-    let cleaned: String = query.chars().filter(|c| !c.is_control()).collect();
-
-    // Parse into segments: quoted terms and OR groups
+fn parse_fts_segments(cleaned: &str) -> (Vec<String>, Vec<Vec<String>>) {
     let mut fixed: Vec<String> = Vec::new();
     let mut or_groups: Vec<Vec<String>> = Vec::new();
     let mut chars = cleaned.chars();
@@ -332,6 +321,19 @@ fn clean_for_trigram(query: &str) -> String {
             fixed.push(term);
         }
     }
+
+    (fixed, or_groups)
+}
+
+/// Adapt rurico's MatchFtsQuery output for FTS5 trigram tokenizer.
+///
+/// Trigram FTS5 does not support `("a" OR "b") "c"` (parenthesized
+/// OR + implicit AND). This distributes OR groups into flat alternatives:
+/// `(A OR B) C` → `A C OR B C`. Also strips control chars and drops
+/// sub-trigram terms (<3 chars).
+fn clean_for_trigram(query: &str) -> String {
+    let cleaned: String = query.chars().filter(|c| !c.is_control()).collect();
+    let (fixed, or_groups) = parse_fts_segments(&cleaned);
 
     if or_groups.is_empty() {
         return fixed.join(" ");
@@ -743,7 +745,8 @@ mod tests {
         storage::add_embeddings(db.conn(), &embeddings).unwrap();
 
         let query_emb = vec![0.1; EMBEDDING_DIMS as usize];
-        let results = hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        let results =
+            hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
         assert!(!results.is_empty());
         assert!(!results[0].post_name.is_empty());
         assert!(!results[0].post_url.is_empty());

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -5,7 +5,7 @@ pub struct EsaPostRow {
     pub full_name: String,
     pub body_md: String,
     pub category: Option<String>,
-    pub tags: String,
+    pub tags: Vec<String>,
     pub wip: bool,
     pub kind: String,
     pub url: String,
@@ -14,6 +14,12 @@ pub struct EsaPostRow {
     pub created_by: String,
     pub updated_by: String,
     pub revision_number: u32,
+}
+
+impl EsaPostRow {
+    pub fn tags_json(&self) -> String {
+        serde_json::to_string(&self.tags).unwrap_or_else(|_| "[]".into())
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -71,7 +71,7 @@ pub async fn harvest(
     // esa API caps pagination at 10,000 items per query.
     // When hit, we narrow by updated_at window and continue.
     let mut window_boundary: Option<String> = None;
-    let mut batch_oldest: Option<String> = None;
+    let mut batch_oldest_ts: Option<String> = None;
 
     'outer: loop {
         let query = build_window_query(base_query.as_deref(), window_boundary.as_deref());
@@ -79,14 +79,14 @@ pub async fn harvest(
         let resp = match client.list_posts(team, page, query.as_deref()).await {
             Ok(r) => r,
             Err(ClientError::Api(ref msg)) if is_pagination_limit(msg) => {
-                if let Some(ref oldest) = batch_oldest {
+                if let Some(ref oldest) = batch_oldest_ts {
                     if window_boundary.as_ref() == Some(oldest) {
                         eprintln!("  window didn't advance, stopping");
                         break;
                     }
                     eprintln!("  pagination limit — narrowing to updated:<={oldest}");
                     window_boundary = Some(oldest.clone());
-                    batch_oldest = None;
+                    batch_oldest_ts = None;
                     page = 1;
                     continue 'outer;
                 }
@@ -107,8 +107,8 @@ pub async fn harvest(
             if latest.as_ref().is_none_or(|l| row.updated_at > *l) {
                 latest = Some(row.updated_at.clone());
             }
-            if batch_oldest.as_ref().is_none_or(|o| row.updated_at < *o) {
-                batch_oldest = Some(row.updated_at.clone());
+            if batch_oldest_ts.as_ref().is_none_or(|o| row.updated_at < *o) {
+                batch_oldest_ts = Some(row.updated_at.clone());
             }
             storage::upsert_post(&tx, &row)?;
             storage::rechunk_post(&tx, row.number, &row.body_md)?;
@@ -573,5 +573,60 @@ mod tests {
         };
         let s = r.to_string();
         assert!(s.contains("gap detected: 10 missing"));
+    }
+
+    #[tokio::test]
+    async fn pagination_limit_narrows_window() {
+        let server = MockServer::start().await;
+
+        // First request hits 10,000-item pagination limit
+        Mock::given(method("GET"))
+            .and(path("/teams/t/posts"))
+            .and(query_param("page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(posts_response(
+                vec![
+                    api_post(1, "A", "2025-01-03T00:00:00+09:00"),
+                    api_post(2, "B", "2025-01-02T00:00:00+09:00"),
+                ],
+                Some(2),
+                10001,
+            )))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Second request (page 2) returns pagination limit error
+        Mock::given(method("GET"))
+            .and(path("/teams/t/posts"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "bad_request",
+                "message": "Pagination limit: exceeds 10,000 items"
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Narrowed window request succeeds
+        Mock::given(method("GET"))
+            .and(path("/teams/t/posts"))
+            .and(query_param("q", "updated:<=2025-01-02T00:00:00+09:00"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(posts_response(
+                vec![api_post(3, "C", "2025-01-01T00:00:00+09:00")],
+                None,
+                1,
+            )))
+            .mount(&server)
+            .await;
+
+        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let db = Db::open_memory().unwrap();
+
+        let r = harvest(&client, &db, "t", false).await.unwrap();
+        assert!(
+            r.posts_fetched >= 3,
+            "should fetch posts across window narrowing"
+        );
+        assert_eq!(storage::count_posts(db.conn()).unwrap(), 3);
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -47,7 +47,6 @@ pub async fn harvest(
 ) -> Result<HarvestResult, SyncError> {
     let state = storage::get_sync_state(db.conn())?;
 
-    // Clear stale checkpoint so full sync re-fetches from page 1
     if full {
         storage::save_sync_state(db.conn(), None, 0, 0, None)?;
     }
@@ -202,7 +201,7 @@ fn post_to_row(post: &EsaPost) -> EsaPostRow {
         full_name: post.full_name.clone(),
         body_md: post.body_md.clone().unwrap_or_default(),
         category: post.category.clone(),
-        tags: serde_json::to_string(&post.tags).unwrap_or_else(|_| "[]".into()),
+        tags: post.tags.clone(),
         wip: post.wip,
         kind: post.kind.clone(),
         url: post.url.clone(),
@@ -517,6 +516,62 @@ mod tests {
         };
         let row = post_to_row(&post);
         assert_eq!(row.body_md, "");
-        assert_eq!(row.tags, r#"["rust"]"#);
+        assert_eq!(row.tags, vec!["rust".to_string()]);
+    }
+
+    #[test]
+    fn build_window_query_none_none() {
+        assert!(build_window_query(None, None).is_none());
+    }
+
+    #[test]
+    fn build_window_query_base_only() {
+        assert_eq!(
+            build_window_query(Some("updated:>2025-01-01"), None),
+            Some("updated:>2025-01-01".into())
+        );
+    }
+
+    #[test]
+    fn build_window_query_boundary_only() {
+        assert_eq!(
+            build_window_query(None, Some("2025-06-01")),
+            Some("updated:<=2025-06-01".into())
+        );
+    }
+
+    #[test]
+    fn build_window_query_both() {
+        assert_eq!(
+            build_window_query(Some("updated:>2025-01-01"), Some("2025-06-01")),
+            Some("updated:>2025-01-01 updated:<=2025-06-01".into())
+        );
+    }
+
+    #[test]
+    fn harvest_result_display_no_gap() {
+        let r = HarvestResult {
+            posts_fetched: 10,
+            posts_stored: 10,
+            total_count: 100,
+            local_count: 100,
+            gap_detected: false,
+        };
+        let s = r.to_string();
+        assert!(s.contains("Fetched 10"));
+        assert!(!s.contains("gap"));
+    }
+
+    #[test]
+    fn harvest_result_display_with_gap() {
+        let r = HarvestResult {
+            posts_fetched: 5,
+            posts_stored: 5,
+            total_count: 100,
+            local_count: 90,
+            gap_detected: true,
+        };
+        let s = r.to_string();
+        assert!(s.contains("gap detected: 10 missing"));
     }
 }


### PR DESCRIPTION
## 概要

- `EsaClient::create_post` と `update_post` の位置引数を `CreatePostParams` / `UpdatePostParams` 構造体に置換し、`#[allow(clippy::too_many_arguments)]` を不要に
- `main` の各コマンド分岐を `run_*` 関数に抽出（`run_harvest`, `run_search`, `run_create` 等）し、500行の match ブロックをフラットなディスパッチテーブルに
- `EsaPostRow::tags` を `String` → `Vec<String>` に変更し、SQLite 境界でのみ `tags_json()` でシリアライズ
- `rechunk_post` で孤立した `vec_chunks` 行を削除するよう修正、INSERT を `prepare_cached` に変更
- `add_embeddings` の行ごとの `EXISTS` チェックを `IN (...)` バッチクエリ + `HashSet` に置換
- `search.rs` から `apply_recency_boost` と `parse_fts_segments` を関数として抽出
- `README.md` を追加
- テスト追加: `rechunk_cleans_orphaned_vec_chunks`, `hybrid_search_with_embeddings`, `pagination_limit_narrows_window`, `build_window_query_*`, `harvest_result_display_*`

## テスト計画

- [ ] `cargo test` が全件パス
- [ ] `cargo build` が成功
- [ ] `cargo clippy` で新規警告なし
- [ ] `sae harvest <team>` が投稿を取得・保存
- [ ] `sae search "query"` が結果を返す
- [ ] `sae archive <number>` が投稿を移動、再実行で "Already archived" を報告
- [ ] `sae embed <team>` が `sae harvest` 後にエラーなく実行
- [ ] rechunk 後に `vec_chunks` に孤立行が残らない