### PR TITLE
投稿メタデータを FTS 検索インデックスに追加

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -503,7 +503,7 @@ fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), AppError> {
     let embedder = Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
     eprintln!("Model ready");
 
-    const BATCH_SIZE: u32 = 500;
+    const BATCH_SIZE: u32 = 256;
     let mut total_added = 0u32;
     let mut done = 0u32;
     loop {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -310,6 +310,20 @@ pub fn count_chunks(conn: &Connection) -> Result<u32, StorageError> {
     Ok(count)
 }
 
+/// Make post metadata searchable via FTS by prepending it to the chunk body.
+pub(crate) fn enrich_body(row: &EsaPostRow) -> String {
+    let mut meta = format!("{}\n{}", row.name, row.created_by);
+    if let Some(cat) = &row.category {
+        meta.push(' ');
+        meta.push_str(cat);
+    }
+    if !row.tags.is_empty() {
+        meta.push(' ');
+        meta.push_str(&row.tags.join(" "));
+    }
+    format!("{meta}\n\n{}", row.body_md)
+}
+
 pub fn rechunk_post(
     conn: &Connection,
     post_number: u32,
@@ -608,6 +622,51 @@ mod tests {
             fts_count, chunks_count,
             "[T-005] fts_chunks count ({fts_count}) must equal chunks count ({chunks_count})"
         );
+    }
+
+    #[test]
+    fn enrich_body_includes_all_metadata() {
+        let mut row = test_post_row(1);
+        row.name = "Daily 振り返り".into();
+        row.body_md = "# やったこと\n実装した".into();
+        row.category = Some("チーム/日報/thkt".into());
+        row.tags = vec!["日報".into(), "振り返り".into()];
+        row.created_by = "thkt".into();
+        let enriched = enrich_body(&row);
+        assert_eq!(
+            enriched,
+            "Daily 振り返り\nthkt チーム/日報/thkt 日報 振り返り\n\n# やったこと\n実装した"
+        );
+    }
+
+    #[test]
+    fn enrich_body_no_category_no_tags() {
+        let mut row = test_post_row(1);
+        row.name = "Untitled".into();
+        row.body_md = "text".into();
+        row.category = None;
+        let enriched = enrich_body(&row);
+        assert_eq!(enriched, "Untitled\nalice\n\ntext");
+    }
+
+    #[test]
+    fn enrich_body_category_only() {
+        let mut row = test_post_row(1);
+        row.name = "Post".into();
+        row.body_md = "body".into();
+        let enriched = enrich_body(&row);
+        assert_eq!(enriched, "Post\nalice dev\n\nbody");
+    }
+
+    #[test]
+    fn enrich_body_tags_only() {
+        let mut row = test_post_row(1);
+        row.name = "Post".into();
+        row.body_md = "body".into();
+        row.category = None;
+        row.tags = vec!["rust".into(), "cli".into()];
+        let enriched = enrich_body(&row);
+        assert_eq!(enriched, "Post\nalice rust cli\n\nbody");
     }
 
     // T-006: fresh DB で fts_chunks に section_title + content カラムあり (FR-001)

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -689,6 +689,37 @@ mod tests {
         assert_eq!(hits[0].section_title.as_deref(), Some("認証ガイド"));
     }
 
+    #[test]
+    fn fts_search_matches_enriched_metadata() {
+        let db = Db::open_memory().unwrap();
+        let mut row = storage::test_post_row(1);
+        row.name = "Daily振り返り".into();
+        row.body_md = "# 作業内容\n実装した".into();
+        row.category = Some("チーム/日報".into());
+        row.tags = vec!["日報".into(), "振り返り".into()];
+        row.created_by = "thkt".into();
+        storage::upsert_post(db.conn(), &row).unwrap();
+
+        let enriched = storage::enrich_body(&row);
+        storage::rechunk_post(db.conn(), 1, &enriched).unwrap();
+
+        // Post name
+        let hits = fts_search(db.conn(), "Daily振り返り", 10).unwrap();
+        assert!(!hits.is_empty(), "post name should be searchable");
+
+        // Author
+        let hits = fts_search(db.conn(), "thkt", 10).unwrap();
+        assert!(!hits.is_empty(), "author should be searchable");
+
+        // Category
+        let hits = fts_search(db.conn(), "日報", 10).unwrap();
+        assert!(!hits.is_empty(), "category/tag should be searchable");
+
+        // Combined query (matching esa web search behavior)
+        let hits = fts_search(db.conn(), "Daily 振り返り thkt", 10).unwrap();
+        assert!(!hits.is_empty(), "combined name + author query should match");
+    }
+
     // T-035: search --json → JSON array with post_number, post_name, score
     #[test]
     fn search_result_serializes_to_json_with_expected_fields() {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -717,7 +717,10 @@ mod tests {
 
         // Combined query (matching esa web search behavior)
         let hits = fts_search(db.conn(), "Daily 振り返り thkt", 10).unwrap();
-        assert!(!hits.is_empty(), "combined name + author query should match");
+        assert!(
+            !hits.is_empty(),
+            "combined name + author query should match"
+        );
     }
 
     // T-035: search --json → JSON array with post_number, post_name, score

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -111,7 +111,8 @@ pub async fn harvest(
                 batch_oldest_ts = Some(row.updated_at.clone());
             }
             storage::upsert_post(&tx, &row)?;
-            storage::rechunk_post(&tx, row.number, &row.body_md)?;
+            let enriched_body = storage::enrich_body(&row);
+            storage::rechunk_post(&tx, row.number, &enriched_body)?;
             total_stored += 1;
         }
         total_fetched += resp.posts.len() as u32;


### PR DESCRIPTION
## 概要

- 投稿の本文だけでなく、タイトル・作成者・カテゴリ・タグを FTS インデックスに含めるよう enrich_body 関数を追加し、名前や著者名での全文検索を可能にした
- sync の harvest 処理で enrich_body を通じたテキストをチャンク化するよう変更した
- embed コマンドのバッチサイズを 500 → 256 に調整した

## テスト計画

- [ ] cargo test がすべてパスすることを確認
- [ ] enrich_body の単体テスト 4 件（全メタあり・カテゴリなし・タグなし・タグのみ）が通ること
- [ ] fts_search_matches_enriched_metadata 統合テストで投稿名・著者・カテゴリ・複合クエリが検索ヒットすること
- [ ] 実際の DB に対して sae harvest --full 後、著者名やカテゴリ名で sae search を実行し結果が返ること