### PR TITLE
searchクエリのstdin入力対応とテスト基盤の強化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1642,7 +1642,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2195,12 +2195,13 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=dd1ad45#dd1ad45c6007c3e1114034a435eef8424f977e48"
+source = "git+https://github.com/thkt/rurico?rev=e956a52#e956a52ea049344b3224e92f84fd7602065f6e31"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "log",
  "mlx-rs",
+ "mlx-sys",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2246,7 +2247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2305,7 +2306,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2551,7 +2552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2705,7 +2706,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3344,7 +3345,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd1ad45" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e956a52" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod output;
 
+use std::io::Read;
+
 use clap::{CommandFactory, Parser, Subcommand};
 use rurico::embed::{Embed, Embedder};
 use sae::client::{CreatePostParams, EsaClient, UpdatePostParams};
@@ -503,7 +505,7 @@ fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), AppError> {
     let embedder = Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
     eprintln!("Model ready");
 
-    const BATCH_SIZE: u32 = 256;
+    const BATCH_SIZE: u32 = 64;
     let mut total_added = 0u32;
     let mut done = 0u32;
     loop {
@@ -686,11 +688,20 @@ fn resolve_body(
     body: Option<&str>,
     body_file: Option<&str>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let mut stdin = std::io::stdin();
+    resolve_body_with_reader(body, body_file, &mut stdin)
+}
+
+fn resolve_body_with_reader(
+    body: Option<&str>,
+    body_file: Option<&str>,
+    stdin: &mut impl Read,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
     match (body, body_file) {
         (Some(b), None) => Ok(Some(b.to_string())),
         (None, Some("-")) => {
             let mut buf = String::new();
-            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            stdin.read_to_string(&mut buf)?;
             Ok(Some(buf))
         }
         (None, Some(path)) => {
@@ -742,6 +753,18 @@ fn try_load_embedder() -> Option<Embedder> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
+    use tempfile::tempdir;
+
+    fn subcommand_after_help(name: &str) -> String {
+        let mut command = Cli::command();
+        command
+            .find_subcommand_mut(name)
+            .unwrap()
+            .get_after_help()
+            .map(|help| help.to_string())
+            .unwrap_or_default()
+    }
 
     // T-029: shorthand `sae "認証"` → search
     #[test]
@@ -827,9 +850,8 @@ mod tests {
     // T-039: --body-file <tempfile> with create → file content becomes body
     #[test]
     fn body_file_reads_from_file() {
-        let dir = std::env::temp_dir().join("sae_test_t039");
-        let _ = std::fs::create_dir_all(&dir);
-        let file_path = dir.join("body.md");
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("body.md");
         std::fs::write(&file_path, "# Hello\nBody from file").unwrap();
 
         let result = resolve_body(None, Some(file_path.to_str().unwrap())).unwrap();
@@ -838,14 +860,20 @@ mod tests {
             Some("# Hello\nBody from file"),
             "[T-039] body should contain file contents"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // T-040: --body-file - with create → stdin content becomes body
-    // Note: stdin mocking is non-trivial; test that resolve_body("-") triggers
-    // the stdin path. The function should accept a Read trait for testability.
-    // For now, test the parse side: --body-file "-" parses correctly.
+    #[test]
+    fn body_file_dash_reads_from_stdin() {
+        let mut stdin = Cursor::new("# Hello\nBody from stdin\n");
+        let result = resolve_body_with_reader(None, Some("-"), &mut stdin).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("# Hello\nBody from stdin\n"),
+            "[T-040] body should contain stdin contents as-is"
+        );
+    }
+
     #[test]
     fn body_file_dash_parses_as_stdin() {
         let cli =
@@ -899,19 +927,24 @@ mod tests {
     // T-042: help output contains Examples section
     #[test]
     fn help_output_contains_examples() {
-        use clap::CommandFactory;
         let cmd = Cli::command();
         for sub in cmd.get_subcommands() {
-            let after_help = sub
-                .get_after_help()
-                .map(|h| h.to_string())
-                .unwrap_or_default();
+            let after_help = subcommand_after_help(sub.get_name());
             assert!(
                 after_help.contains("Examples"),
                 "[T-042] subcommand '{}' should have Examples in after_help",
                 sub.get_name()
             );
         }
+    }
+
+    #[test]
+    fn create_help_includes_stdin_example() {
+        let after_help = subcommand_after_help("create");
+        assert!(
+            after_help.contains("cat body.md | sae create --name \"Title\" --body-file -"),
+            "[T-042] create help should include stdin example"
+        );
     }
 
     // TC-008: resolve_body(Some, None) → inline body

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,7 +891,6 @@ mod tests {
         }
     }
 
-    // --- Phase 2: --dry-run, --body-file (FR-004, FR-005, FR-006, FR-007) ---
 
     // T-038: create args + --dry-run → parse succeeds with dry_run=true
     #[test]
@@ -1056,74 +1055,46 @@ mod tests {
         assert_eq!(result.as_deref(), Some(""), "[TC-010b] empty stdin yields empty body string");
     }
 
+    fn resolve_search(value: Option<&str>, stdin: &str, is_terminal: bool) -> Result<String, AppError> {
+        resolve_value_with_reader(
+            value.map(str::to_string),
+            Cursor::new(stdin),
+            is_terminal,
+            "search query",
+            "QUERY",
+        )
+    }
+
     #[test]
     fn resolve_value_reads_piped_stdin_when_missing() {
-        let query =
-            resolve_value_with_reader(None, Cursor::new("認証\n"), false, "search query", "QUERY").unwrap();
-        assert_eq!(query, "認証");
+        assert_eq!(resolve_search(None, "認証\n", false).unwrap(), "認証");
     }
 
     #[test]
     fn resolve_value_reads_stdin_when_dash_is_passed() {
-        let query = resolve_value_with_reader(
-            Some("-".to_string()),
-            Cursor::new("認証\n"),
-            true,
-            "search query",
-            "QUERY",
-        )
-        .unwrap();
-        assert_eq!(query, "認証");
+        assert_eq!(resolve_search(Some("-"), "認証\n", true).unwrap(), "認証");
     }
 
     #[test]
     fn resolve_value_returns_value_when_present() {
-        let query = resolve_value_with_reader(
-            Some("認証".to_string()),
-            Cursor::new("ignored"),
-            true,
-            "search query",
-            "QUERY",
-        )
-        .unwrap();
-        assert_eq!(query, "認証");
+        assert_eq!(resolve_search(Some("認証"), "ignored", true).unwrap(), "認証");
     }
 
     #[test]
     fn resolve_value_rejects_dash_with_empty_stdin() {
-        let err = resolve_value_with_reader(
-            Some("-".to_string()),
-            Cursor::new(""),
-            true,
-            "search query",
-            "QUERY",
-        )
-        .unwrap_err();
-        assert!(
-            err.to_string().contains("No search query provided"),
-            "unexpected error: {err}"
-        );
+        let err = resolve_search(Some("-"), "", true).unwrap_err();
+        assert!(err.to_string().contains("No search query provided"), "unexpected error: {err}");
     }
 
     #[test]
     fn resolve_value_rejects_whitespace_only_piped_stdin() {
-        let err = resolve_value_with_reader(
-            None,
-            Cursor::new("  \n  \t  "),
-            false,
-            "search query",
-            "QUERY",
-        )
-        .unwrap_err();
-        assert!(
-            err.to_string().contains("No search query provided"),
-            "unexpected error: {err}"
-        );
+        let err = resolve_search(None, "  \n  \t  ", false).unwrap_err();
+        assert!(err.to_string().contains("No search query provided"), "unexpected error: {err}");
     }
 
     #[test]
     fn resolve_value_rejects_missing_on_terminal() {
-        let err = resolve_value_with_reader(None, Cursor::new(""), true, "search query", "QUERY").unwrap_err();
+        let err = resolve_search(None, "", true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Missing search query"), "unexpected error: {err}");
         assert!(msg.contains("Pass QUERY"), "error should include placeholder: {err}");
@@ -1139,7 +1110,6 @@ mod tests {
         );
     }
 
-    // --- model subcommand (FR-001, FR-006, FR-007) ---
 
     // T-001: `sae model download` parses to Command::Model { ModelCommand::Download }
     #[test]
@@ -1188,7 +1158,6 @@ mod tests {
         }
     }
 
-    // --- archive_category ---
 
     #[test]
     fn archive_no_category() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,7 +891,6 @@ mod tests {
         }
     }
 
-
     // T-038: create args + --dry-run → parse succeeds with dry_run=true
     #[test]
     fn create_with_dry_run_parses_dry_run_flag() {
@@ -1043,19 +1042,30 @@ mod tests {
     // TC-010: resolve_body_with_reader(`-`) reads from stdin
     #[test]
     fn resolve_body_with_reader_reads_stdin_when_dash() {
-        let result =
-            resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
-        assert_eq!(result.as_deref(), Some("本文\n"), "[TC-010] body from stdin should preserve trailing newline");
+        let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("本文\n"),
+            "[TC-010] body from stdin should preserve trailing newline"
+        );
     }
 
     // TC-010b: resolve_body_with_reader(`-`) with empty stdin → Some("")
     #[test]
     fn resolve_body_with_reader_empty_stdin_returns_empty_body() {
         let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("")).unwrap();
-        assert_eq!(result.as_deref(), Some(""), "[TC-010b] empty stdin yields empty body string");
+        assert_eq!(
+            result.as_deref(),
+            Some(""),
+            "[TC-010b] empty stdin yields empty body string"
+        );
     }
 
-    fn resolve_search(value: Option<&str>, stdin: &str, is_terminal: bool) -> Result<String, AppError> {
+    fn resolve_search(
+        value: Option<&str>,
+        stdin: &str,
+        is_terminal: bool,
+    ) -> Result<String, AppError> {
         resolve_value_with_reader(
             value.map(str::to_string),
             Cursor::new(stdin),
@@ -1077,27 +1087,42 @@ mod tests {
 
     #[test]
     fn resolve_value_returns_value_when_present() {
-        assert_eq!(resolve_search(Some("認証"), "ignored", true).unwrap(), "認証");
+        assert_eq!(
+            resolve_search(Some("認証"), "ignored", true).unwrap(),
+            "認証"
+        );
     }
 
     #[test]
     fn resolve_value_rejects_dash_with_empty_stdin() {
         let err = resolve_search(Some("-"), "", true).unwrap_err();
-        assert!(err.to_string().contains("No search query provided"), "unexpected error: {err}");
+        assert!(
+            err.to_string().contains("No search query provided"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn resolve_value_rejects_whitespace_only_piped_stdin() {
         let err = resolve_search(None, "  \n  \t  ", false).unwrap_err();
-        assert!(err.to_string().contains("No search query provided"), "unexpected error: {err}");
+        assert!(
+            err.to_string().contains("No search query provided"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn resolve_value_rejects_missing_on_terminal() {
         let err = resolve_search(None, "", true).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("Missing search query"), "unexpected error: {err}");
-        assert!(msg.contains("Pass QUERY"), "error should include placeholder: {err}");
+        assert!(
+            msg.contains("Missing search query"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            msg.contains("Pass QUERY"),
+            "error should include placeholder: {err}"
+        );
     }
 
     // TC-011: flag-like argument not treated as shorthand query
@@ -1109,7 +1134,6 @@ mod tests {
             "[TC-011] --unknown should be clap error, not search shorthand"
         );
     }
-
 
     // T-001: `sae model download` parses to Command::Model { ModelCommand::Download }
     #[test]
@@ -1157,7 +1181,6 @@ mod tests {
             other => panic!("[T-005] expected Embed, got {other:?}"),
         }
     }
-
 
     #[test]
     fn archive_no_category() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod output;
 
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 
 use clap::{CommandFactory, Parser, Subcommand};
 use rurico::embed::{Embed, Embedder};
@@ -37,10 +37,11 @@ Examples:
     #[command(after_help = "\
 Examples:
   sae search \"認証\" --team myteam --limit 5
-  sae \"認証\"")]
+  echo \"認証\" | sae search
+  sae search -")]
     Search {
-        /// Search query
-        query: String,
+        /// Search query. Reads piped stdin when omitted, or any stdin with `-`.
+        query: Option<String>,
         /// Team name
         #[arg(long)]
         team: Option<String>,
@@ -285,6 +286,7 @@ async fn main() -> Result<(), AppError> {
     match cli.command {
         Command::Harvest { team, full } => run_harvest(&config, &team, full, json).await,
         Command::Search { query, team, limit } => {
+            let query = resolve_search_query(query)?;
             run_search(&config, &query, team.as_deref(), limit, json)
         }
         Command::Get {
@@ -608,7 +610,13 @@ fn run_status(config: &Config, team: Option<&str>, json: bool) -> Result<(), App
         config
             .teams
             .iter()
-            .filter(|t| sae::config::validate_team_name(t).is_ok())
+            .filter(|t| match sae::config::validate_team_name(t) {
+                Ok(_) => true,
+                Err(_) => {
+                    eprintln!("warning: skipping invalid team name: {t}");
+                    false
+                }
+            })
             .map(String::as_str)
             .collect()
     };
@@ -713,6 +721,54 @@ fn resolve_body_with_reader(
     }
 }
 
+fn resolve_search_query(query: Option<String>) -> Result<String, AppError> {
+    let stdin = std::io::stdin();
+    resolve_value_with_reader(
+        query,
+        stdin.lock(),
+        stdin.is_terminal(),
+        "search query",
+        "QUERY",
+    )
+}
+
+fn resolve_value_with_reader(
+    value: Option<String>,
+    mut stdin: impl Read,
+    stdin_is_terminal: bool,
+    label: &str,
+    placeholder: &str,
+) -> Result<String, AppError> {
+    match value {
+        Some(value) if value != "-" => Ok(value),
+        Some(_) => read_stdin_value(&mut stdin, label, placeholder),
+        None if stdin_is_terminal => Err(format!(
+            "Missing {label}. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
+        )
+        .into()),
+        None => read_stdin_value(&mut stdin, label, placeholder),
+    }
+}
+
+fn read_stdin_value(
+    mut stdin: impl Read,
+    label: &str,
+    placeholder: &str,
+) -> Result<String, AppError> {
+    let mut buf = String::new();
+    stdin.read_to_string(&mut buf)?;
+
+    let value = buf.trim();
+    if value.is_empty() {
+        return Err(format!(
+            "No {label} provided. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
+        )
+        .into());
+    }
+
+    Ok(value.to_string())
+}
+
 fn require_embed_model() -> Result<rurico::embed::ModelPaths, Box<dyn std::error::Error>> {
     let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
     if auto_download {
@@ -771,7 +827,7 @@ mod tests {
     fn shorthand_single_query_becomes_search() {
         let cli = parse_cli_args(["sae", "認証"]).unwrap();
         match cli.command {
-            Command::Search { query, .. } => assert_eq!(query, "認証"),
+            Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("認証")),
             other => panic!("expected Search, got {other:?}"),
         }
     }
@@ -781,7 +837,7 @@ mod tests {
     fn explicit_search_not_double_injected() {
         let cli = parse_cli_args(["sae", "search", "認証"]).unwrap();
         match cli.command {
-            Command::Search { query, .. } => assert_eq!(query, "認証"),
+            Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("認証")),
             other => panic!("expected Search, got {other:?}"),
         }
     }
@@ -796,11 +852,14 @@ mod tests {
         }
     }
 
-    // T-033: `sae search` (missing required arg) → clap error via helper
+    // T-033: `sae search` (missing arg) parses to stdin fallback path
     #[test]
-    fn search_missing_arg_is_clap_error() {
-        let result = parse_cli_args(["sae", "search"]);
-        assert!(result.is_err(), "search without query should be clap error");
+    fn search_missing_arg_parses_for_stdin_fallback() {
+        let cli = parse_cli_args(["sae", "search"]).unwrap();
+        match cli.command {
+            Command::Search { query, .. } => assert_eq!(query, None),
+            other => panic!("expected Search, got {other:?}"),
+        }
     }
 
     // T-034: `sae harvest` (missing required arg) → clap error via helper
@@ -816,7 +875,7 @@ mod tests {
         let cli = parse_cli_args(["sae", "--json", "query"]).unwrap();
         assert!(cli.json, "[T-037] global json flag should be true");
         match cli.command {
-            Command::Search { query, .. } => assert_eq!(query, "query"),
+            Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("query")),
             other => panic!("[T-037] expected Search, got {other:?}"),
         }
     }
@@ -827,7 +886,7 @@ mod tests {
         let cli = parse_cli_args(["sae", "query"]).unwrap();
         assert!(!cli.json, "[T-049] json should default to false");
         match cli.command {
-            Command::Search { query, .. } => assert_eq!(query, "query"),
+            Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("query")),
             other => panic!("[T-049] expected Search, got {other:?}"),
         }
     }
@@ -947,6 +1006,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn search_help_includes_stdin_examples() {
+        let after_help = subcommand_after_help("search");
+        for snippet in ["echo \"認証\" | sae search", "sae search -"] {
+            assert!(
+                after_help.contains(snippet),
+                "[T-042] search help should include stdin example '{snippet}'"
+            );
+        }
+    }
+
     // TC-008: resolve_body(Some, None) → inline body
     #[test]
     fn resolve_body_inline_text() {
@@ -969,6 +1039,94 @@ mod tests {
             result.is_err(),
             "[TC-009] nonexistent file should return error"
         );
+    }
+
+    // TC-010: resolve_body_with_reader(`-`) reads from stdin
+    #[test]
+    fn resolve_body_with_reader_reads_stdin_when_dash() {
+        let result =
+            resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
+        assert_eq!(result.as_deref(), Some("本文\n"), "[TC-010] body from stdin should preserve trailing newline");
+    }
+
+    // TC-010b: resolve_body_with_reader(`-`) with empty stdin → Some("")
+    #[test]
+    fn resolve_body_with_reader_empty_stdin_returns_empty_body() {
+        let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("")).unwrap();
+        assert_eq!(result.as_deref(), Some(""), "[TC-010b] empty stdin yields empty body string");
+    }
+
+    #[test]
+    fn resolve_value_reads_piped_stdin_when_missing() {
+        let query =
+            resolve_value_with_reader(None, Cursor::new("認証\n"), false, "search query", "QUERY").unwrap();
+        assert_eq!(query, "認証");
+    }
+
+    #[test]
+    fn resolve_value_reads_stdin_when_dash_is_passed() {
+        let query = resolve_value_with_reader(
+            Some("-".to_string()),
+            Cursor::new("認証\n"),
+            true,
+            "search query",
+            "QUERY",
+        )
+        .unwrap();
+        assert_eq!(query, "認証");
+    }
+
+    #[test]
+    fn resolve_value_returns_value_when_present() {
+        let query = resolve_value_with_reader(
+            Some("認証".to_string()),
+            Cursor::new("ignored"),
+            true,
+            "search query",
+            "QUERY",
+        )
+        .unwrap();
+        assert_eq!(query, "認証");
+    }
+
+    #[test]
+    fn resolve_value_rejects_dash_with_empty_stdin() {
+        let err = resolve_value_with_reader(
+            Some("-".to_string()),
+            Cursor::new(""),
+            true,
+            "search query",
+            "QUERY",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("No search query provided"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_value_rejects_whitespace_only_piped_stdin() {
+        let err = resolve_value_with_reader(
+            None,
+            Cursor::new("  \n  \t  "),
+            false,
+            "search query",
+            "QUERY",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("No search query provided"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_value_rejects_missing_on_terminal() {
+        let err = resolve_value_with_reader(None, Cursor::new(""), true, "search query", "QUERY").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Missing search query"), "unexpected error: {err}");
+        assert!(msg.contains("Pass QUERY"), "error should include placeholder: {err}");
     }
 
     // TC-011: flag-like argument not treated as shorthand query


### PR DESCRIPTION
## 変更内容

- `sae search` now accepts the query via stdin: pipe input is auto-detected with `IsTerminal`, and `-` can be passed as an explicit flag for interactive stdin
- `resolve_body` is refactored to `resolve_body_with_reader(stdin: &mut impl Read)` so both functions are testable via dependency injection without spawning subprocesses
- Invalid team names in `run_status` now print a stderr warning instead of silently dropping the entry
- Embed batch size reduced from 256 to 64
- `search` subcommand `after_help` updated with stdin usage examples (`echo "認証" | sae search`, `sae search -`)
- rurico dependency updated (dd1ad45 → e956a52)

## テスト

36 tests total (up from ~25). New coverage:

- 6 branch tests for `resolve_value_with_reader` (explicit arg, piped stdin, `-` flag, empty stdin, etc.)
- 2 tests for `resolve_body_with_reader` stdin path
- 2 tests verifying help text includes stdin examples
- `resolve_search()` helper extracted to reduce per-test boilerplate
- `subcommand_after_help()` helper added for help text assertions
- `tempdir()` replaces manual temp directory management

## テスト計画

- [ ] `cargo test` passes with all 36 tests green
- [ ] `sae search "query"` works as before (explicit arg path unchanged)
- [ ] `echo "認証" | sae search` returns results (piped stdin path)
- [ ] `sae search -` prompts and reads from interactive stdin
- [ ] Invalid team name in `run_status` prints warning to stderr
- [ ] `sae search --help` shows stdin usage examples in after_help section