### PR TITLE
rurico 568eda5 API へ移行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e956a52#e956a52ea049344b3224e92f84fd7602065f6e31"
+source = "git+https://github.com/thkt/rurico?rev=568eda5#568eda54c77b93a56f61179844447974ebbae9c9"
 dependencies = [
  "bytemuck",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "e956a52" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "568eda5" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -1,0 +1,114 @@
+use sae::client::UpdatePostParams;
+use sae::config::Config;
+
+use crate::{resolve_client, AppError};
+
+pub(crate) fn archive_category(current: Option<&str>) -> Option<String> {
+    let current = current.unwrap_or("");
+    if current.starts_with("Archived/") || current == "Archived" {
+        return None;
+    }
+    Some(if current.is_empty() {
+        "Archived".to_string()
+    } else {
+        format!("Archived/{current}")
+    })
+}
+
+pub(crate) async fn run_archive(
+    config: &Config,
+    number: u32,
+    team: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    let (team, client) = resolve_client(config, team)?;
+    let post = client.get_post(team, number).await?;
+    let new_category = match archive_category(post.category.as_deref()) {
+        Some(c) => c,
+        None if dry_run => {
+            crate::output::dry_run(&serde_json::json!({
+                "number": number,
+                "already_archived": true,
+                "category": post.category.as_deref().unwrap_or(""),
+            }))?;
+            return Ok(());
+        }
+        None => {
+            crate::output::action_result("Already archived", &post, json)?;
+            return Ok(());
+        }
+    };
+    if dry_run {
+        crate::output::dry_run(&serde_json::json!({
+            "number": number,
+            "from_category": post.category.as_deref().unwrap_or(""),
+            "to_category": new_category,
+        }))?;
+        return Ok(());
+    }
+    let params = UpdatePostParams {
+        category: Some(&new_category),
+        ..Default::default()
+    };
+    let post = client.update_post(team, number, &params).await?;
+    crate::output::action_result("Archived", &post, json)?;
+    Ok(())
+}
+
+pub(crate) async fn run_ship(
+    config: &Config,
+    number: u32,
+    team: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    if dry_run {
+        crate::output::dry_run(&serde_json::json!({
+            "number": number,
+            "wip": false,
+        }))?;
+        return Ok(());
+    }
+    let (team, client) = resolve_client(config, team)?;
+    let params = UpdatePostParams {
+        wip: Some(false),
+        ..Default::default()
+    };
+    let post = client.update_post(team, number, &params).await?;
+    crate::output::action_result("Shipped", &post, json)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_no_category() {
+        assert_eq!(archive_category(None), Some("Archived".into()));
+        assert_eq!(archive_category(Some("")), Some("Archived".into()));
+    }
+
+    #[test]
+    fn archive_with_category() {
+        assert_eq!(
+            archive_category(Some("dev/guide")),
+            Some("Archived/dev/guide".into())
+        );
+    }
+
+    #[test]
+    fn archive_already_archived() {
+        assert_eq!(archive_category(Some("Archived")), None);
+        assert_eq!(archive_category(Some("Archived/dev")), None);
+    }
+
+    #[test]
+    fn archive_not_prefix_match() {
+        assert_eq!(
+            archive_category(Some("ArchivedData")),
+            Some("Archived/ArchivedData".into())
+        );
+    }
+}

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -1,7 +1,7 @@
 use sae::client::UpdatePostParams;
 use sae::config::Config;
 
-use crate::{resolve_client, AppError};
+use crate::{AppError, resolve_client};
 
 pub(crate) fn archive_category(current: Option<&str>) -> Option<String> {
     let current = current.unwrap_or("");

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -1,0 +1,135 @@
+use rurico::embed::{Embedder, ModelId};
+use sae::config::Config;
+
+use crate::{require_db, resolve_client, AppError};
+
+pub(crate) async fn run_harvest(
+    config: &Config,
+    team: &str,
+    full: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    let (team, client) = resolve_client(config, Some(team))?;
+    let db_path = config.team_db_path(team)?;
+    let db = sae::storage::Db::open(&db_path)?;
+    let result = sae::sync::harvest(&client, &db, team, full).await?;
+    crate::output::harvest(&result, json)?;
+    Ok(())
+}
+
+pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), AppError> {
+    use rurico::embed::Embed;
+
+    let team = config.resolve_team(Some(team))?;
+    let db = require_db(config, team)?;
+
+    let paths = require_embed_model()?;
+    tracing::info!("Loading model...");
+    let embedder = Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
+    tracing::info!("Model ready");
+
+    const BATCH_SIZE: u32 = 64;
+    let mut total_added = 0u32;
+    let mut done = 0u32;
+    loop {
+        let batch = sae::storage::get_unembedded_chunks(db.conn(), BATCH_SIZE)?;
+        if batch.is_empty() {
+            break;
+        }
+        if done == 0 {
+            tracing::info!("Embedding chunks...");
+        }
+        let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
+        let batch_len = batch.len() as u32;
+        let embs = embedder
+            .embed_documents_batch(&texts)
+            .map_err(|e| format!("Batch embedding failed: {e}"))?;
+        let embeddings: Vec<(i64, _)> = batch.iter().map(|(id, _)| *id).zip(embs).collect();
+        total_added += sae::storage::add_chunked_embeddings(db.conn(), &embeddings)?;
+        done += batch_len;
+        tracing::info!("  {done} chunks processed");
+    }
+    let result = sae::storage::EmbedResult {
+        chunks_embedded: total_added,
+    };
+    crate::output::embed(&result, done, json)?;
+    Ok(())
+}
+
+pub(crate) fn run_model_download(json: bool) -> Result<(), AppError> {
+    eprintln!("Downloading model...");
+    let paths = rurico::embed::download_model(ModelId::default())
+        .map_err(|e| format!("Failed to download model: {e}"))?;
+    let _embedder = Embedder::new(&paths).map_err(|e| format!("Failed to verify model: {e}"))?;
+    crate::output::model_download(json)?;
+    Ok(())
+}
+
+pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, Box<dyn std::error::Error>> {
+    let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
+    require_embed_model_with(auto_download, || {
+        rurico::embed::cached_artifacts(ModelId::default())
+    })
+}
+
+fn require_embed_model_with<E: std::fmt::Display>(
+    auto_download: bool,
+    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
+) -> Result<rurico::embed::Artifacts, Box<dyn std::error::Error>> {
+    if auto_download {
+        eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
+        return rurico::embed::download_model(ModelId::default())
+            .map_err(|e| format!("Failed to download model: {e}").into());
+    }
+    match cache_check() {
+        Ok(Some(p)) => Ok(p),
+        Ok(None) => Err("Model not found. Run 'sae model download' first.".into()),
+        Err(e) => Err(format!("Failed to check model cache: {e}").into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-007: model absent → "Model not found" error (deterministic via DI)
+    #[test]
+    fn require_embed_model_err_when_absent() {
+        let result = require_embed_model_with(false, || Ok::<_, &str>(None));
+        assert!(result.is_err(), "should fail when model is not cached");
+        assert!(
+            result.unwrap_err().to_string().contains("Model not found"),
+            "error should indicate model not found"
+        );
+    }
+
+    // T-007: cache check failure → wrapped error
+    #[test]
+    fn require_embed_model_err_on_cache_failure() {
+        let result =
+            require_embed_model_with(false, || Err::<Option<rurico::embed::Artifacts>, _>("cache broken"));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to check model cache"),
+            "error should wrap cache failure"
+        );
+    }
+
+    // T-007: auto_download=true skips cache_check
+    #[test]
+    fn require_embed_model_auto_download_skips_cache() {
+        let called = std::cell::Cell::new(false);
+        // download_model will fail (no network), but cache_check must NOT be invoked
+        let _ = require_embed_model_with(true, || {
+            called.set(true);
+            Ok::<_, &str>(None)
+        });
+        assert!(
+            !called.get(),
+            "cache_check should not be called when auto_download=true"
+        );
+    }
+}

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -1,7 +1,7 @@
 use rurico::embed::{Embedder, ModelId};
 use sae::config::Config;
 
-use crate::{require_db, resolve_client, AppError};
+use crate::{AppError, require_db, resolve_client};
 
 pub(crate) async fn run_harvest(
     config: &Config,
@@ -65,7 +65,8 @@ pub(crate) fn run_model_download(json: bool) -> Result<(), AppError> {
     Ok(())
 }
 
-pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, Box<dyn std::error::Error>> {
+pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, Box<dyn std::error::Error>>
+{
     let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
     require_embed_model_with(auto_download, || {
         rurico::embed::cached_artifacts(ModelId::default())
@@ -106,8 +107,9 @@ mod tests {
     // T-007: cache check failure → wrapped error
     #[test]
     fn require_embed_model_err_on_cache_failure() {
-        let result =
-            require_embed_model_with(false, || Err::<Option<rurico::embed::Artifacts>, _>("cache broken"));
+        let result = require_embed_model_with(false, || {
+            Err::<Option<rurico::embed::Artifacts>, _>("cache broken")
+        });
         assert!(result.is_err());
         assert!(
             result

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,5 @@
+pub(crate) mod archive;
+pub(crate) mod data;
+pub(crate) mod post;
+pub(crate) mod search;
+pub(crate) mod status;

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -1,0 +1,208 @@
+use std::io::Read;
+
+use sae::client::{CreatePostParams, UpdatePostParams};
+use sae::config::Config;
+
+use crate::{resolve_client, AppError};
+
+pub(crate) struct CreateArgs {
+    pub(crate) name: String,
+    pub(crate) body: Option<String>,
+    pub(crate) body_file: Option<String>,
+    pub(crate) category: Option<String>,
+    pub(crate) tag: Vec<String>,
+    pub(crate) wip: bool,
+    pub(crate) team: Option<String>,
+    pub(crate) dry_run: bool,
+}
+
+pub(crate) async fn run_get(
+    config: &Config,
+    number: u32,
+    team: Option<&str>,
+    with_body: bool,
+    json: bool,
+) -> Result<(), AppError> {
+    let (team, client) = resolve_client(config, team)?;
+    let post = client.get_post(team, number).await?;
+    crate::output::get(&post, json, with_body)?;
+    Ok(())
+}
+
+pub(crate) async fn run_create(
+    config: &Config,
+    args: CreateArgs,
+    json: bool,
+) -> Result<(), AppError> {
+    let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
+    if args.dry_run {
+        crate::output::dry_run(&serde_json::json!({
+            "name": args.name,
+            "body_md": resolved_body,
+            "category": args.category,
+            "tags": args.tag,
+            "wip": args.wip,
+        }))?;
+        return Ok(());
+    }
+    let (team, client) = resolve_client(config, args.team.as_deref())?;
+    let params = CreatePostParams {
+        name: &args.name,
+        body_md: resolved_body.as_deref(),
+        category: args.category.as_deref(),
+        tags: args.tag,
+        wip: args.wip,
+    };
+    let post = client.create_post(team, &params).await?;
+    crate::output::action_result("Created", &post, json)?;
+    Ok(())
+}
+
+pub(crate) struct UpdateArgs {
+    pub(crate) number: u32,
+    pub(crate) name: Option<String>,
+    pub(crate) body: Option<String>,
+    pub(crate) body_file: Option<String>,
+    pub(crate) category: Option<String>,
+    pub(crate) tag: Vec<String>,
+    pub(crate) team: Option<String>,
+    pub(crate) dry_run: bool,
+}
+
+pub(crate) async fn run_update(
+    config: &Config,
+    args: UpdateArgs,
+    json: bool,
+) -> Result<(), AppError> {
+    let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
+    let tags: Option<Vec<String>> = if args.tag.is_empty() { None } else { Some(args.tag) };
+    if args.dry_run {
+        crate::output::dry_run(&serde_json::json!({
+            "number": args.number,
+            "name": args.name,
+            "body_md": resolved_body,
+            "category": args.category,
+            "tags": tags.as_deref(),
+        }))?;
+        return Ok(());
+    }
+    let (team, client) = resolve_client(config, args.team.as_deref())?;
+    let params = UpdatePostParams {
+        name: args.name.as_deref(),
+        body_md: resolved_body.as_deref(),
+        category: args.category.as_deref(),
+        tags,
+        ..Default::default()
+    };
+    let post = client.update_post(team, args.number, &params).await?;
+    crate::output::action_result("Updated", &post, json)?;
+    Ok(())
+}
+
+pub(crate) fn resolve_body(
+    body: Option<&str>,
+    body_file: Option<&str>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let mut stdin = std::io::stdin();
+    resolve_body_with_reader(body, body_file, &mut stdin)
+}
+
+pub(crate) fn resolve_body_with_reader(
+    body: Option<&str>,
+    body_file: Option<&str>,
+    stdin: &mut impl Read,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    match (body, body_file) {
+        (Some(b), None) => Ok(Some(b.to_string())),
+        (None, Some("-")) => {
+            let mut buf = String::new();
+            stdin.read_to_string(&mut buf)?;
+            Ok(Some(buf))
+        }
+        (None, Some(path)) => {
+            let content = std::fs::read_to_string(path)?;
+            Ok(Some(content))
+        }
+        (None, None) => Ok(None),
+        (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tempfile::tempdir;
+
+    // TC-008: resolve_body(Some, None) → inline body
+    #[test]
+    fn resolve_body_inline_text() {
+        let result = resolve_body(Some("inline text"), None).unwrap();
+        assert_eq!(result.as_deref(), Some("inline text"));
+    }
+
+    // TC-008: resolve_body(None, None) → no body
+    #[test]
+    fn resolve_body_none_returns_none() {
+        let result = resolve_body(None, None).unwrap();
+        assert_eq!(result, None);
+    }
+
+    // TC-009: resolve_body with nonexistent file → error
+    #[test]
+    fn resolve_body_nonexistent_file_is_error() {
+        let result = resolve_body(None, Some("/nonexistent/path.md"));
+        assert!(result.is_err(), "[TC-009] nonexistent file should return error");
+    }
+
+    // TC-010: resolve_body_with_reader(`-`) reads from stdin
+    #[test]
+    fn resolve_body_with_reader_reads_stdin_when_dash() {
+        let result =
+            resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("本文\n"),
+            "[TC-010] body from stdin should preserve trailing newline"
+        );
+    }
+
+    // TC-010b: resolve_body_with_reader(`-`) with empty stdin → Some("")
+    #[test]
+    fn resolve_body_with_reader_empty_stdin_returns_empty_body() {
+        let result =
+            resolve_body_with_reader(None, Some("-"), &mut Cursor::new("")).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some(""),
+            "[TC-010b] empty stdin yields empty body string"
+        );
+    }
+
+    // T-039: --body-file <tempfile> with create → file content becomes body
+    #[test]
+    fn body_file_reads_from_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("body.md");
+        std::fs::write(&file_path, "# Hello\nBody from file").unwrap();
+
+        let result = resolve_body(None, Some(file_path.to_str().unwrap())).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("# Hello\nBody from file"),
+            "[T-039] body should contain file contents"
+        );
+    }
+
+    // T-040: --body-file - with create → stdin content becomes body
+    #[test]
+    fn body_file_dash_reads_from_stdin() {
+        let mut stdin = Cursor::new("# Hello\nBody from stdin\n");
+        let result = resolve_body_with_reader(None, Some("-"), &mut stdin).unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("# Hello\nBody from stdin\n"),
+            "[T-040] body should contain stdin contents as-is"
+        );
+    }
+}

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use sae::client::{CreatePostParams, UpdatePostParams};
 use sae::config::Config;
 
-use crate::{resolve_client, AppError};
+use crate::{AppError, resolve_client};
 
 pub(crate) struct CreateArgs {
     pub(crate) name: String,
@@ -75,7 +75,11 @@ pub(crate) async fn run_update(
     json: bool,
 ) -> Result<(), AppError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
-    let tags: Option<Vec<String>> = if args.tag.is_empty() { None } else { Some(args.tag) };
+    let tags: Option<Vec<String>> = if args.tag.is_empty() {
+        None
+    } else {
+        Some(args.tag)
+    };
     if args.dry_run {
         crate::output::dry_run(&serde_json::json!({
             "number": args.number,
@@ -152,14 +156,16 @@ mod tests {
     #[test]
     fn resolve_body_nonexistent_file_is_error() {
         let result = resolve_body(None, Some("/nonexistent/path.md"));
-        assert!(result.is_err(), "[TC-009] nonexistent file should return error");
+        assert!(
+            result.is_err(),
+            "[TC-009] nonexistent file should return error"
+        );
     }
 
     // TC-010: resolve_body_with_reader(`-`) reads from stdin
     #[test]
     fn resolve_body_with_reader_reads_stdin_when_dash() {
-        let result =
-            resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
+        let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
         assert_eq!(
             result.as_deref(),
             Some("本文\n"),
@@ -170,8 +176,7 @@ mod tests {
     // TC-010b: resolve_body_with_reader(`-`) with empty stdin → Some("")
     #[test]
     fn resolve_body_with_reader_empty_stdin_returns_empty_body() {
-        let result =
-            resolve_body_with_reader(None, Some("-"), &mut Cursor::new("")).unwrap();
+        let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("")).unwrap();
         assert_eq!(
             result.as_deref(),
             Some(""),

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,0 +1,199 @@
+use std::io::{IsTerminal, Read};
+
+use rurico::embed::{Embed, Embedder, ModelId};
+use sae::config::Config;
+
+use crate::{require_db, AppError};
+
+pub(crate) fn run_search(
+    config: &Config,
+    query: &str,
+    team: Option<&str>,
+    limit: u32,
+    json: bool,
+) -> Result<(), AppError> {
+    let team = config.resolve_team(team)?;
+    let db = require_db(config, team)?;
+    let embedder = try_load_embedder();
+    let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(query) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            eprintln!("Warning: embed_query failed ({e}), falling back to FTS");
+            tracing::warn!(error = %e, %query, "embed_query failed, falling back to FTS");
+            None
+        }
+    });
+    let results = sae::storage::hybrid_search(
+        db.conn(),
+        query,
+        query_embedding.as_deref(),
+        limit,
+        chrono::Utc::now(),
+    )?;
+    crate::output::search(&results, query, json)?;
+    Ok(())
+}
+
+pub(crate) fn try_load_embedder() -> Option<Embedder> {
+    try_load_embedder_with(|| rurico::embed::cached_artifacts(ModelId::default()))
+}
+
+fn try_load_embedder_with<E: std::fmt::Display>(
+    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
+) -> Option<Embedder> {
+    let paths = match cache_check() {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            eprintln!(
+                "Hint: run 'sae model download && sae embed <team>' to enable semantic search"
+            );
+            return None;
+        }
+        Err(e) => {
+            eprintln!("Warning: embedding model not available ({e})");
+            tracing::warn!(error = %e, "embedding model not available");
+            return None;
+        }
+    };
+    match Embedder::new(&paths) {
+        Ok(e) => Some(e),
+        Err(e) => {
+            eprintln!("Warning: failed to load embedding model ({e})");
+            tracing::warn!(error = %e, "failed to load embedding model");
+            None
+        }
+    }
+}
+
+pub(crate) fn resolve_search_query(query: Option<String>) -> Result<String, AppError> {
+    let stdin = std::io::stdin();
+    resolve_value_with_reader(
+        query,
+        stdin.lock(),
+        stdin.is_terminal(),
+        "search query",
+        "QUERY",
+    )
+}
+
+pub(crate) fn resolve_value_with_reader(
+    value: Option<String>,
+    mut stdin: impl Read,
+    stdin_is_terminal: bool,
+    label: &str,
+    placeholder: &str,
+) -> Result<String, AppError> {
+    match value {
+        Some(value) if value != "-" => Ok(value),
+        Some(_) => read_stdin_value(&mut stdin, label, placeholder),
+        None if stdin_is_terminal => Err(format!(
+            "Missing {label}. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
+        )
+        .into()),
+        None => read_stdin_value(&mut stdin, label, placeholder),
+    }
+}
+
+fn read_stdin_value(
+    mut stdin: impl Read,
+    label: &str,
+    placeholder: &str,
+) -> Result<String, AppError> {
+    let mut buf = String::new();
+    stdin.read_to_string(&mut buf)?;
+
+    let value = buf.trim();
+    if value.is_empty() {
+        return Err(format!(
+            "No {label} provided. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
+        )
+        .into());
+    }
+
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // TC-010: try_load_embedder_with returns None when model is not cached
+    #[test]
+    fn try_load_embedder_with_returns_none_when_no_model() {
+        let result = try_load_embedder_with(|| Ok::<_, &str>(None));
+        assert!(result.is_none());
+    }
+
+    // TC-010: try_load_embedder_with returns None on cache check error
+    #[test]
+    fn try_load_embedder_with_returns_none_on_cache_error() {
+        let result =
+            try_load_embedder_with(|| Err::<Option<rurico::embed::Artifacts>, _>("cache error"));
+        assert!(result.is_none());
+    }
+
+    fn resolve_search(
+        value: Option<&str>,
+        stdin: &str,
+        is_terminal: bool,
+    ) -> Result<String, AppError> {
+        resolve_value_with_reader(
+            value.map(str::to_string),
+            Cursor::new(stdin),
+            is_terminal,
+            "search query",
+            "QUERY",
+        )
+    }
+
+    #[test]
+    fn resolve_value_reads_piped_stdin_when_missing() {
+        assert_eq!(resolve_search(None, "認証\n", false).unwrap(), "認証");
+    }
+
+    #[test]
+    fn resolve_value_reads_stdin_when_dash_is_passed() {
+        assert_eq!(resolve_search(Some("-"), "認証\n", true).unwrap(), "認証");
+    }
+
+    #[test]
+    fn resolve_value_returns_value_when_present() {
+        assert_eq!(
+            resolve_search(Some("認証"), "ignored", true).unwrap(),
+            "認証"
+        );
+    }
+
+    #[test]
+    fn resolve_value_rejects_dash_with_empty_stdin() {
+        let err = resolve_search(Some("-"), "", true).unwrap_err();
+        assert!(
+            err.to_string().contains("No search query provided"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_value_rejects_whitespace_only_piped_stdin() {
+        let err = resolve_search(None, "  \n  \t  ", false).unwrap_err();
+        assert!(
+            err.to_string().contains("No search query provided"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_value_rejects_missing_on_terminal() {
+        let err = resolve_search(None, "", true).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Missing search query"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            msg.contains("Pass QUERY"),
+            "error should include placeholder: {err}"
+        );
+    }
+}

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -3,7 +3,7 @@ use std::io::{IsTerminal, Read};
 use rurico::embed::{Embed, Embedder, ModelId};
 use sae::config::Config;
 
-use crate::{require_db, AppError};
+use crate::{AppError, require_db};
 
 pub(crate) fn run_search(
     config: &Config,

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,0 +1,166 @@
+use sae::config::Config;
+use sae::storage::TeamStatus;
+
+use crate::AppError;
+
+pub(crate) fn run_status(config: &Config, team: Option<&str>, json: bool) -> Result<(), AppError> {
+    let target_teams: Vec<&str> = if let Some(t) = team {
+        vec![config.resolve_team(Some(t))?]
+    } else {
+        config
+            .teams
+            .iter()
+            .filter(|t| match sae::config::validate_team_name(t) {
+                Ok(_) => true,
+                Err(_) => {
+                    eprintln!("warning: skipping invalid team name: {t}");
+                    false
+                }
+            })
+            .map(String::as_str)
+            .collect()
+    };
+    let statuses = collect_team_statuses(config, &target_teams)?;
+    crate::output::status(&statuses, json)?;
+    Ok(())
+}
+
+fn collect_team_statuses(
+    config: &Config,
+    teams: &[&str],
+) -> Result<Vec<TeamStatus>, Box<dyn std::error::Error>> {
+    let mut statuses = Vec::new();
+    for t in teams {
+        let ts = match config.team_db_path(t) {
+            Ok(path) if path.exists() => match query_team_status(t, &path) {
+                Ok(ts) => ts,
+                Err(e) => TeamStatus::error(*t, e),
+            },
+            Ok(path) => TeamStatus::not_synced(*t, Some(path.display().to_string())),
+            Err(e) => TeamStatus::error(*t, e),
+        };
+        statuses.push(ts);
+    }
+    Ok(statuses)
+}
+
+fn query_team_status(
+    team: &str,
+    path: &std::path::Path,
+) -> Result<TeamStatus, Box<dyn std::error::Error>> {
+    let db = sae::storage::Db::open(path)?;
+    let count = sae::storage::count_posts(db.conn())?;
+    let state = sae::storage::get_sync_state(db.conn())?;
+    if state.is_some() {
+        Ok(TeamStatus::synced(team, count, state))
+    } else {
+        Ok(TeamStatus::not_synced(team, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-007: at least 1 test co-located with status handlers
+    #[test]
+    fn team_status_error_constructs_correctly() {
+        let ts = TeamStatus::error("myteam", "db error");
+        assert_eq!(ts.team, "myteam");
+        assert_eq!(ts.status, sae::storage::SyncStatus::Error);
+        assert_eq!(ts.error.as_deref(), Some("db error"));
+        assert_eq!(ts.posts, 0);
+    }
+
+    // TC-011: query_team_status with sync state present → TeamStatus::Synced
+    #[test]
+    fn query_team_status_returns_synced_when_state_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        {
+            let db = sae::storage::Db::open(&path).unwrap();
+            sae::storage::upsert_post(
+                db.conn(),
+                &sae::storage::EsaPostRow {
+                    number: 1,
+                    name: "Post 1".into(),
+                    full_name: "dev/Post 1".into(),
+                    body_md: "# Post 1".into(),
+                    category: None,
+                    tags: vec![],
+                    wip: false,
+                    kind: "stock".into(),
+                    url: "https://example.esa.io/posts/1".into(),
+                    created_at: "2025-01-01T00:00:00+09:00".into(),
+                    updated_at: "2025-01-01T00:00:00+09:00".into(),
+                    created_by: "alice".into(),
+                    updated_by: "alice".into(),
+                    revision_number: 1,
+                },
+            )
+            .unwrap();
+            sae::storage::save_sync_state(
+                db.conn(),
+                &sae::storage::SyncStateUpdate {
+                    latest_updated_at: Some("2025-01-01T00:00:00+09:00"),
+                    total_count: 1,
+                    local_count: 1,
+                    last_page: None,
+                },
+            )
+            .unwrap();
+        }
+        let ts = query_team_status("myteam", &path).unwrap();
+        assert_eq!(ts.team, "myteam");
+        assert_eq!(ts.status, sae::storage::SyncStatus::Synced);
+        assert_eq!(ts.posts, 1);
+        assert!(ts.sync_state.is_some());
+    }
+
+    // TC-011: query_team_status with no sync state → TeamStatus::NotSynced
+    #[test]
+    fn query_team_status_returns_not_synced_when_no_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let _db = sae::storage::Db::open(&path).unwrap();
+        let ts = query_team_status("myteam", &path).unwrap();
+        assert_eq!(ts.team, "myteam");
+        assert_eq!(ts.status, sae::storage::SyncStatus::NotSynced);
+        assert!(ts.sync_state.is_none());
+    }
+
+    // TC-009: posts exist but sync_state absent → NotSynced (bug: was reporting Synced)
+    #[test]
+    fn query_team_status_returns_not_synced_when_posts_exist_but_no_sync_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        {
+            let db = sae::storage::Db::open(&path).unwrap();
+            sae::storage::upsert_post(
+                db.conn(),
+                &sae::storage::EsaPostRow {
+                    number: 1,
+                    name: "Post 1".into(),
+                    full_name: "dev/Post 1".into(),
+                    body_md: "# Post 1".into(),
+                    category: None,
+                    tags: vec![],
+                    wip: false,
+                    kind: "stock".into(),
+                    url: "https://example.esa.io/posts/1".into(),
+                    created_at: "2025-01-01T00:00:00+09:00".into(),
+                    updated_at: "2025-01-01T00:00:00+09:00".into(),
+                    created_by: "alice".into(),
+                    updated_by: "alice".into(),
+                    revision_number: 1,
+                },
+            )
+            .unwrap();
+            // sync_state intentionally NOT saved
+        }
+        let ts = query_team_status("myteam", &path).unwrap();
+        assert_eq!(ts.team, "myteam");
+        assert_eq!(ts.status, sae::storage::SyncStatus::NotSynced);
+        assert!(ts.sync_state.is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,8 @@
+mod commands;
 mod output;
 
-use std::io::{IsTerminal, Read};
-
 use clap::{CommandFactory, Parser, Subcommand};
-use rurico::embed::{Embed, Embedder};
-use sae::client::{CreatePostParams, EsaClient, UpdatePostParams};
+use sae::client::EsaClient;
 use sae::config::Config;
 
 #[derive(Parser)]
@@ -206,42 +204,48 @@ where
 {
     let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
 
-    let cmd = Cli::command();
-    let known: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
-    let global_flags: Vec<String> = cmd
-        .get_arguments()
-        .filter(|a| a.is_global_set())
-        .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
-        .collect();
-
     // Shorthand: `sae "query"` or `sae --json "query"` → `sae [flags] search "query"`
-    let (flags, rest): (Vec<_>, Vec<_>) = args.iter().enumerate().partition(|(i, a)| {
-        *i > 0
-            && a.to_str()
-                .is_some_and(|s| global_flags.iter().any(|f| f == s))
-    });
-    let rest: Vec<&std::ffi::OsString> = rest.into_iter().map(|(_, a)| a).collect();
+    // Pre-filter: only build command tree when non-flag arg count suggests shorthand is possible.
+    let positional_count = args
+        .iter()
+        .filter(|a| !a.to_str().is_some_and(|s| s.starts_with('-')))
+        .count();
 
-    if rest.len() == 2
-        && let Some(first_arg) = rest[1].to_str()
-        && !first_arg.starts_with('-')
-        && !known.contains(&first_arg)
-    {
-        let mut expanded: Vec<std::ffi::OsString> = vec![rest[0].clone()];
-        for (_, f) in &flags {
-            expanded.push((*f).clone());
+    if positional_count == 2 {
+        let cmd = Cli::command();
+        let known: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
+        let global_flags: Vec<String> = cmd
+            .get_arguments()
+            .filter(|a| a.is_global_set())
+            .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
+            .collect();
+
+        let (flags, rest): (Vec<_>, Vec<_>) = args.iter().enumerate().partition(|(i, a)| {
+            *i > 0 && a.to_str().is_some_and(|s| global_flags.iter().any(|f| f == s))
+        });
+        let rest: Vec<&std::ffi::OsString> = rest.into_iter().map(|(_, a)| a).collect();
+
+        if rest.len() == 2
+            && let Some(first_arg) = rest[1].to_str()
+            && !first_arg.starts_with('-')
+            && !known.contains(&first_arg)
+        {
+            let mut expanded: Vec<std::ffi::OsString> = vec![rest[0].clone()];
+            for (_, f) in &flags {
+                expanded.push((*f).clone());
+            }
+            expanded.push("search".into());
+            expanded.push(rest[1].clone());
+            return Cli::try_parse_from(expanded);
         }
-        expanded.push("search".into());
-        expanded.push(rest[1].clone());
-        return Cli::try_parse_from(expanded);
     }
 
     Cli::try_parse_from(args)
 }
 
-type AppError = Box<dyn std::error::Error>;
+pub(crate) type AppError = Box<dyn std::error::Error>;
 
-fn resolve_client<'a>(
+pub(crate) fn resolve_client<'a>(
     config: &'a Config,
     team: Option<&'a str>,
 ) -> Result<(&'a str, EsaClient), AppError> {
@@ -250,24 +254,12 @@ fn resolve_client<'a>(
     Ok((team, client))
 }
 
-fn require_db(config: &Config, team: &str) -> Result<sae::storage::Db, AppError> {
+pub(crate) fn require_db(config: &Config, team: &str) -> Result<sae::storage::Db, AppError> {
     let db_path = config.team_db_path(team)?;
     if !db_path.exists() {
         return Err(format!("No data for team '{team}'. Run `sae harvest {team}` first.").into());
     }
     Ok(sae::storage::Db::open(&db_path)?)
-}
-
-fn archive_category(current: Option<&str>) -> Option<String> {
-    let current = current.unwrap_or("");
-    if current.starts_with("Archived/") || current == "Archived" {
-        return None;
-    }
-    Some(if current.is_empty() {
-        "Archived".to_string()
-    } else {
-        format!("Archived/{current}")
-    })
 }
 
 #[tokio::main]
@@ -284,16 +276,18 @@ async fn main() -> Result<(), AppError> {
     let json = cli.json;
 
     match cli.command {
-        Command::Harvest { team, full } => run_harvest(&config, &team, full, json).await,
+        Command::Harvest { team, full } => {
+            commands::data::run_harvest(&config, &team, full, json).await
+        }
         Command::Search { query, team, limit } => {
-            let query = resolve_search_query(query)?;
-            run_search(&config, &query, team.as_deref(), limit, json)
+            let query = commands::search::resolve_search_query(query)?;
+            commands::search::run_search(&config, &query, team.as_deref(), limit, json)
         }
         Command::Get {
             number,
             team,
             with_body,
-        } => run_get(&config, number, team.as_deref(), with_body, json).await,
+        } => commands::post::run_get(&config, number, team.as_deref(), with_body, json).await,
         Command::Create {
             name,
             body,
@@ -304,9 +298,9 @@ async fn main() -> Result<(), AppError> {
             team,
             dry_run,
         } => {
-            run_create(
+            commands::post::run_create(
                 &config,
-                CreateArgs {
+                commands::post::CreateArgs {
                     name,
                     body,
                     body_file,
@@ -330,9 +324,9 @@ async fn main() -> Result<(), AppError> {
             team,
             dry_run,
         } => {
-            run_update(
+            commands::post::run_update(
                 &config,
-                UpdateArgs {
+                commands::post::UpdateArgs {
                     number,
                     name,
                     body,
@@ -346,471 +340,27 @@ async fn main() -> Result<(), AppError> {
             )
             .await
         }
-        Command::Embed { team } => run_embed(&config, &team, json),
+        Command::Embed { team } => commands::data::run_embed(&config, &team, json),
         Command::Archive {
             number,
             team,
             dry_run,
-        } => run_archive(&config, number, team.as_deref(), dry_run, json).await,
+        } => commands::archive::run_archive(&config, number, team.as_deref(), dry_run, json).await,
         Command::Ship {
             number,
             team,
             dry_run,
-        } => run_ship(&config, number, team.as_deref(), dry_run, json).await,
-        Command::Status { team } => run_status(&config, team.as_deref(), json),
+        } => commands::archive::run_ship(&config, number, team.as_deref(), dry_run, json).await,
+        Command::Status { team } => commands::status::run_status(&config, team.as_deref(), json),
         Command::Model { command } => match command {
-            ModelCommand::Download => run_model_download(json),
+            ModelCommand::Download => commands::data::run_model_download(json),
         },
-    }
-}
-
-async fn run_harvest(config: &Config, team: &str, full: bool, json: bool) -> Result<(), AppError> {
-    let (team, client) = resolve_client(config, Some(team))?;
-    let db_path = config.team_db_path(team)?;
-    let db = sae::storage::Db::open(&db_path)?;
-    let result = sae::sync::harvest(&client, &db, team, full).await?;
-    output::harvest(&result, json)?;
-    Ok(())
-}
-
-fn run_search(
-    config: &Config,
-    query: &str,
-    team: Option<&str>,
-    limit: u32,
-    json: bool,
-) -> Result<(), AppError> {
-    let team = config.resolve_team(team)?;
-    let db = require_db(config, team)?;
-    let embedder = try_load_embedder();
-    let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(query) {
-        Ok(v) => Some(v),
-        Err(e) => {
-            tracing::warn!(error = %e, "embed_query failed, falling back to FTS");
-            None
-        }
-    });
-    let results = sae::storage::hybrid_search(
-        db.conn(),
-        query,
-        query_embedding.as_deref(),
-        limit,
-        chrono::Utc::now(),
-    )?;
-    output::search(&results, query, json)?;
-    Ok(())
-}
-
-async fn run_get(
-    config: &Config,
-    number: u32,
-    team: Option<&str>,
-    with_body: bool,
-    json: bool,
-) -> Result<(), AppError> {
-    let (team, client) = resolve_client(config, team)?;
-    let post = client.get_post(team, number).await?;
-    output::get(&post, json, with_body)?;
-    Ok(())
-}
-
-struct CreateArgs {
-    name: String,
-    body: Option<String>,
-    body_file: Option<String>,
-    category: Option<String>,
-    tag: Vec<String>,
-    wip: bool,
-    team: Option<String>,
-    dry_run: bool,
-}
-
-async fn run_create(config: &Config, args: CreateArgs, json: bool) -> Result<(), AppError> {
-    let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
-    if args.dry_run {
-        let payload = serde_json::json!({
-            "name": args.name,
-            "body_md": resolved_body,
-            "category": args.category,
-            "tags": args.tag,
-            "wip": args.wip,
-        });
-        println!("{}", serde_json::to_string(&payload)?);
-        return Ok(());
-    }
-    let (team, client) = resolve_client(config, args.team.as_deref())?;
-    let params = CreatePostParams {
-        name: &args.name,
-        body_md: resolved_body.as_deref(),
-        category: args.category.as_deref(),
-        tags: args.tag,
-        wip: args.wip,
-    };
-    let post = client.create_post(team, &params).await?;
-    output::post("Created", &post, json)?;
-    Ok(())
-}
-
-struct UpdateArgs {
-    number: u32,
-    name: Option<String>,
-    body: Option<String>,
-    body_file: Option<String>,
-    category: Option<String>,
-    tag: Vec<String>,
-    team: Option<String>,
-    dry_run: bool,
-}
-
-async fn run_update(config: &Config, args: UpdateArgs, json: bool) -> Result<(), AppError> {
-    let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
-    if args.dry_run {
-        let tags = if args.tag.is_empty() {
-            None
-        } else {
-            Some(&args.tag)
-        };
-        let payload = serde_json::json!({
-            "number": args.number,
-            "name": args.name,
-            "body_md": resolved_body,
-            "category": args.category,
-            "tags": tags,
-        });
-        println!("{}", serde_json::to_string(&payload)?);
-        return Ok(());
-    }
-    let (team, client) = resolve_client(config, args.team.as_deref())?;
-    let tags = if args.tag.is_empty() {
-        None
-    } else {
-        Some(args.tag)
-    };
-    let params = UpdatePostParams {
-        name: args.name.as_deref(),
-        body_md: resolved_body.as_deref(),
-        category: args.category.as_deref(),
-        tags,
-        ..Default::default()
-    };
-    let post = client.update_post(team, args.number, &params).await?;
-    output::post("Updated", &post, json)?;
-    Ok(())
-}
-
-fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), AppError> {
-    let team = config.resolve_team(Some(team))?;
-    let db = require_db(config, team)?;
-
-    let paths = require_embed_model()?;
-    eprintln!("Loading model...");
-    let embedder = Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
-    eprintln!("Model ready");
-
-    const BATCH_SIZE: u32 = 64;
-    let mut total_added = 0u32;
-    let mut done = 0u32;
-    loop {
-        let batch = sae::storage::get_unembedded_chunks(db.conn(), BATCH_SIZE)?;
-        if batch.is_empty() {
-            break;
-        }
-        if done == 0 {
-            eprintln!("Embedding chunks...");
-        }
-        let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
-        let batch_len = batch.len() as u32;
-        let embs = embedder
-            .embed_documents_batch(&texts)
-            .map_err(|e| format!("Batch embedding failed: {e}"))?;
-        let embeddings: Vec<(i64, Vec<f32>)> = batch.iter().map(|(id, _)| *id).zip(embs).collect();
-        total_added += sae::storage::add_embeddings(db.conn(), &embeddings)?;
-        done += batch_len;
-        eprintln!("  {done} chunks processed");
-    }
-    let result = sae::storage::EmbedResult {
-        chunks_embedded: total_added,
-    };
-    output::embed(&result, done, json)?;
-    Ok(())
-}
-
-async fn run_archive(
-    config: &Config,
-    number: u32,
-    team: Option<&str>,
-    dry_run: bool,
-    json: bool,
-) -> Result<(), AppError> {
-    let (team, client) = resolve_client(config, team)?;
-    let post = client.get_post(team, number).await?;
-    let new_category = match archive_category(post.category.as_deref()) {
-        Some(c) => c,
-        None if dry_run => {
-            let payload = serde_json::json!({
-                "number": number,
-                "already_archived": true,
-                "category": post.category.as_deref().unwrap_or(""),
-            });
-            println!("{}", serde_json::to_string(&payload)?);
-            return Ok(());
-        }
-        None => {
-            output::post("Already archived", &post, json)?;
-            return Ok(());
-        }
-    };
-    if dry_run {
-        let payload = serde_json::json!({
-            "number": number,
-            "from_category": post.category.as_deref().unwrap_or(""),
-            "to_category": new_category,
-        });
-        println!("{}", serde_json::to_string(&payload)?);
-        return Ok(());
-    }
-    let params = UpdatePostParams {
-        category: Some(&new_category),
-        ..Default::default()
-    };
-    let post = client.update_post(team, number, &params).await?;
-    output::post("Archived", &post, json)?;
-    Ok(())
-}
-
-async fn run_ship(
-    config: &Config,
-    number: u32,
-    team: Option<&str>,
-    dry_run: bool,
-    json: bool,
-) -> Result<(), AppError> {
-    if dry_run {
-        let payload = serde_json::json!({
-            "number": number,
-            "wip": false,
-        });
-        println!("{}", serde_json::to_string(&payload)?);
-        return Ok(());
-    }
-    let (team, client) = resolve_client(config, team)?;
-    let params = UpdatePostParams {
-        wip: Some(false),
-        ..Default::default()
-    };
-    let post = client.update_post(team, number, &params).await?;
-    output::post("Shipped", &post, json)?;
-    Ok(())
-}
-
-fn run_status(config: &Config, team: Option<&str>, json: bool) -> Result<(), AppError> {
-    let target_teams: Vec<&str> = if let Some(t) = team {
-        vec![config.resolve_team(Some(t))?]
-    } else {
-        config
-            .teams
-            .iter()
-            .filter(|t| match sae::config::validate_team_name(t) {
-                Ok(_) => true,
-                Err(_) => {
-                    eprintln!("warning: skipping invalid team name: {t}");
-                    false
-                }
-            })
-            .map(String::as_str)
-            .collect()
-    };
-    let statuses = collect_team_statuses(config, &target_teams)?;
-    output::status(&statuses, json)?;
-    Ok(())
-}
-
-fn run_model_download(json: bool) -> Result<(), AppError> {
-    eprintln!("Downloading model...");
-    let paths =
-        rurico::embed::download_model().map_err(|e| format!("Failed to download model: {e}"))?;
-    let _embedder = Embedder::new(&paths).map_err(|e| format!("Failed to verify model: {e}"))?;
-    output::model_download(json)?;
-    Ok(())
-}
-
-fn team_error(team: &str, error: impl ToString) -> sae::storage::TeamStatus {
-    sae::storage::TeamStatus {
-        team: team.to_string(),
-        status: sae::storage::SyncStatus::Error,
-        posts: 0,
-        sync_state: None,
-        error: Some(error.to_string()),
-        db_path: None,
-    }
-}
-
-fn collect_team_statuses(
-    config: &Config,
-    teams: &[&str],
-) -> Result<Vec<sae::storage::TeamStatus>, Box<dyn std::error::Error>> {
-    let mut statuses = Vec::new();
-    for t in teams {
-        let ts = match config.team_db_path(t) {
-            Ok(path) if path.exists() => match query_team_status(t, &path) {
-                Ok(ts) => ts,
-                Err(e) => team_error(t, e),
-            },
-            Ok(path) => sae::storage::TeamStatus {
-                team: t.to_string(),
-                status: sae::storage::SyncStatus::NotSynced,
-                posts: 0,
-                sync_state: None,
-                error: None,
-                db_path: Some(path.display().to_string()),
-            },
-            Err(e) => team_error(t, e),
-        };
-        statuses.push(ts);
-    }
-    Ok(statuses)
-}
-
-fn query_team_status(
-    team: &str,
-    path: &std::path::Path,
-) -> Result<sae::storage::TeamStatus, Box<dyn std::error::Error>> {
-    let db = sae::storage::Db::open(path)?;
-    let count = sae::storage::count_posts(db.conn())?;
-    let state = sae::storage::get_sync_state(db.conn())?;
-    Ok(sae::storage::TeamStatus {
-        team: team.to_string(),
-        status: if state.is_some() {
-            sae::storage::SyncStatus::Synced
-        } else {
-            sae::storage::SyncStatus::NotSynced
-        },
-        posts: count,
-        sync_state: state,
-        error: None,
-        db_path: None,
-    })
-}
-
-fn resolve_body(
-    body: Option<&str>,
-    body_file: Option<&str>,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    let mut stdin = std::io::stdin();
-    resolve_body_with_reader(body, body_file, &mut stdin)
-}
-
-fn resolve_body_with_reader(
-    body: Option<&str>,
-    body_file: Option<&str>,
-    stdin: &mut impl Read,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    match (body, body_file) {
-        (Some(b), None) => Ok(Some(b.to_string())),
-        (None, Some("-")) => {
-            let mut buf = String::new();
-            stdin.read_to_string(&mut buf)?;
-            Ok(Some(buf))
-        }
-        (None, Some(path)) => {
-            let content = std::fs::read_to_string(path)?;
-            Ok(Some(content))
-        }
-        (None, None) => Ok(None),
-        (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
-    }
-}
-
-fn resolve_search_query(query: Option<String>) -> Result<String, AppError> {
-    let stdin = std::io::stdin();
-    resolve_value_with_reader(
-        query,
-        stdin.lock(),
-        stdin.is_terminal(),
-        "search query",
-        "QUERY",
-    )
-}
-
-fn resolve_value_with_reader(
-    value: Option<String>,
-    mut stdin: impl Read,
-    stdin_is_terminal: bool,
-    label: &str,
-    placeholder: &str,
-) -> Result<String, AppError> {
-    match value {
-        Some(value) if value != "-" => Ok(value),
-        Some(_) => read_stdin_value(&mut stdin, label, placeholder),
-        None if stdin_is_terminal => Err(format!(
-            "Missing {label}. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
-        )
-        .into()),
-        None => read_stdin_value(&mut stdin, label, placeholder),
-    }
-}
-
-fn read_stdin_value(
-    mut stdin: impl Read,
-    label: &str,
-    placeholder: &str,
-) -> Result<String, AppError> {
-    let mut buf = String::new();
-    stdin.read_to_string(&mut buf)?;
-
-    let value = buf.trim();
-    if value.is_empty() {
-        return Err(format!(
-            "No {label} provided. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
-        )
-        .into());
-    }
-
-    Ok(value.to_string())
-}
-
-fn require_embed_model() -> Result<rurico::embed::ModelPaths, Box<dyn std::error::Error>> {
-    let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
-    if auto_download {
-        eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
-        return rurico::embed::download_model()
-            .map_err(|e| format!("Failed to download model: {e}").into());
-    }
-    match rurico::embed::model_paths_if_cached() {
-        Ok(Some(p)) => Ok(p),
-        Ok(None) => Err("Model not found. Run 'sae model download' first.".into()),
-        Err(e) => Err(format!("Failed to check model cache: {e}").into()),
-    }
-}
-
-fn try_load_embedder() -> Option<Embedder> {
-    let paths = match rurico::embed::model_paths_if_cached() {
-        Ok(Some(p)) => p,
-        Ok(None) => {
-            eprintln!(
-                "Hint: run 'sae model download && sae embed <team>' to enable semantic search"
-            );
-            return None;
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "embedding model not available");
-            return None;
-        }
-    };
-    match Embedder::new(&paths) {
-        Ok(e) => Some(e),
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to load embedding model");
-            None
-        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
-    use tempfile::tempdir;
 
     fn subcommand_after_help(name: &str) -> String {
         let mut command = Cli::command();
@@ -904,33 +454,6 @@ mod tests {
         }
     }
 
-    // T-039: --body-file <tempfile> with create → file content becomes body
-    #[test]
-    fn body_file_reads_from_file() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("body.md");
-        std::fs::write(&file_path, "# Hello\nBody from file").unwrap();
-
-        let result = resolve_body(None, Some(file_path.to_str().unwrap())).unwrap();
-        assert_eq!(
-            result.as_deref(),
-            Some("# Hello\nBody from file"),
-            "[T-039] body should contain file contents"
-        );
-    }
-
-    // T-040: --body-file - with create → stdin content becomes body
-    #[test]
-    fn body_file_dash_reads_from_stdin() {
-        let mut stdin = Cursor::new("# Hello\nBody from stdin\n");
-        let result = resolve_body_with_reader(None, Some("-"), &mut stdin).unwrap();
-        assert_eq!(
-            result.as_deref(),
-            Some("# Hello\nBody from stdin\n"),
-            "[T-040] body should contain stdin contents as-is"
-        );
-    }
-
     #[test]
     fn body_file_dash_parses_as_stdin() {
         let cli =
@@ -1015,116 +538,6 @@ mod tests {
         }
     }
 
-    // TC-008: resolve_body(Some, None) → inline body
-    #[test]
-    fn resolve_body_inline_text() {
-        let result = resolve_body(Some("inline text"), None).unwrap();
-        assert_eq!(result.as_deref(), Some("inline text"));
-    }
-
-    // TC-008: resolve_body(None, None) → no body
-    #[test]
-    fn resolve_body_none_returns_none() {
-        let result = resolve_body(None, None).unwrap();
-        assert_eq!(result, None);
-    }
-
-    // TC-009: resolve_body with nonexistent file → error
-    #[test]
-    fn resolve_body_nonexistent_file_is_error() {
-        let result = resolve_body(None, Some("/nonexistent/path.md"));
-        assert!(
-            result.is_err(),
-            "[TC-009] nonexistent file should return error"
-        );
-    }
-
-    // TC-010: resolve_body_with_reader(`-`) reads from stdin
-    #[test]
-    fn resolve_body_with_reader_reads_stdin_when_dash() {
-        let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("本文\n")).unwrap();
-        assert_eq!(
-            result.as_deref(),
-            Some("本文\n"),
-            "[TC-010] body from stdin should preserve trailing newline"
-        );
-    }
-
-    // TC-010b: resolve_body_with_reader(`-`) with empty stdin → Some("")
-    #[test]
-    fn resolve_body_with_reader_empty_stdin_returns_empty_body() {
-        let result = resolve_body_with_reader(None, Some("-"), &mut Cursor::new("")).unwrap();
-        assert_eq!(
-            result.as_deref(),
-            Some(""),
-            "[TC-010b] empty stdin yields empty body string"
-        );
-    }
-
-    fn resolve_search(
-        value: Option<&str>,
-        stdin: &str,
-        is_terminal: bool,
-    ) -> Result<String, AppError> {
-        resolve_value_with_reader(
-            value.map(str::to_string),
-            Cursor::new(stdin),
-            is_terminal,
-            "search query",
-            "QUERY",
-        )
-    }
-
-    #[test]
-    fn resolve_value_reads_piped_stdin_when_missing() {
-        assert_eq!(resolve_search(None, "認証\n", false).unwrap(), "認証");
-    }
-
-    #[test]
-    fn resolve_value_reads_stdin_when_dash_is_passed() {
-        assert_eq!(resolve_search(Some("-"), "認証\n", true).unwrap(), "認証");
-    }
-
-    #[test]
-    fn resolve_value_returns_value_when_present() {
-        assert_eq!(
-            resolve_search(Some("認証"), "ignored", true).unwrap(),
-            "認証"
-        );
-    }
-
-    #[test]
-    fn resolve_value_rejects_dash_with_empty_stdin() {
-        let err = resolve_search(Some("-"), "", true).unwrap_err();
-        assert!(
-            err.to_string().contains("No search query provided"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn resolve_value_rejects_whitespace_only_piped_stdin() {
-        let err = resolve_search(None, "  \n  \t  ", false).unwrap_err();
-        assert!(
-            err.to_string().contains("No search query provided"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn resolve_value_rejects_missing_on_terminal() {
-        let err = resolve_search(None, "", true).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Missing search query"),
-            "unexpected error: {err}"
-        );
-        assert!(
-            msg.contains("Pass QUERY"),
-            "error should include placeholder: {err}"
-        );
-    }
-
     // TC-011: flag-like argument not treated as shorthand query
     #[test]
     fn flag_like_arg_not_shorthand() {
@@ -1182,31 +595,33 @@ mod tests {
         }
     }
 
+    // TC-012: multi-positional args are not treated as shorthand
     #[test]
-    fn archive_no_category() {
-        assert_eq!(archive_category(None), Some("Archived".into()));
-        assert_eq!(archive_category(Some("")), Some("Archived".into()));
-    }
-
-    #[test]
-    fn archive_with_category() {
-        assert_eq!(
-            archive_category(Some("dev/guide")),
-            Some("Archived/dev/guide".into())
+    fn multi_positional_args_not_shorthand() {
+        let result = parse_cli_args(["sae", "foo", "bar"]);
+        assert!(
+            result.is_err(),
+            "two positional args should be clap error, not shorthand"
         );
     }
 
+    // TC-013: bare dash is not treated as shorthand
     #[test]
-    fn archive_already_archived() {
-        assert_eq!(archive_category(Some("Archived")), None);
-        assert_eq!(archive_category(Some("Archived/dev")), None);
+    fn bare_dash_not_shorthand() {
+        let result = parse_cli_args(["sae", "-"]);
+        assert!(
+            result.is_err(),
+            "`sae -` should be clap error, not shorthand query"
+        );
     }
 
+    // T-001/FR-001: Compile-time check — fails until Phase 1 extraction is complete
     #[test]
-    fn archive_not_prefix_match() {
-        assert_eq!(
-            archive_category(Some("ArchivedData")),
-            Some("Archived/ArchivedData".into())
-        );
+    fn phase1_commands_extracted() {
+        let _ = &crate::commands::search::run_search;
+        let _ = &crate::commands::post::run_get;
+        let _ = &crate::commands::archive::run_archive;
+        let _ = &crate::commands::data::run_harvest;
+        let _ = &crate::commands::status::run_status;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,9 @@ where
             .collect();
 
         let (flags, rest): (Vec<_>, Vec<_>) = args.iter().enumerate().partition(|(i, a)| {
-            *i > 0 && a.to_str().is_some_and(|s| global_flags.iter().any(|f| f == s))
+            *i > 0
+                && a.to_str()
+                    .is_some_and(|s| global_flags.iter().any(|f| f == s))
         });
         let rest: Vec<&std::ffi::OsString> = rest.into_iter().map(|(_, a)| a).collect();
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,9 +2,14 @@ use sae::client::EsaPost;
 use sae::storage::{EmbedResult, SearchResult, SyncStatus, TeamStatus};
 use sae::sync::HarvestResult;
 
+fn print_json<T: serde::Serialize + ?Sized>(val: &T) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{}", serde_json::to_string(val)?);
+    Ok(())
+}
+
 pub fn harvest(result: &HarvestResult, json: bool) -> Result<(), Box<dyn std::error::Error>> {
     if json {
-        println!("{}", serde_json::to_string(result)?);
+        print_json(result)?;
     } else {
         println!("{result}");
     }
@@ -17,7 +22,7 @@ pub fn search(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if json {
-        println!("{}", serde_json::to_string(results)?);
+        print_json(results)?;
     } else if results.is_empty() {
         println!("No results for '{query}'");
     } else {
@@ -45,7 +50,7 @@ pub fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<(), Box<dyn st
         if !with_body {
             post.body_md = None;
         }
-        println!("{}", serde_json::to_string(&post)?);
+        print_json(&post)?;
     } else {
         println!("---");
         println!("title: \"{}\"", post.full_name.replace('"', "\\\""));
@@ -79,9 +84,13 @@ pub fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<(), Box<dyn st
     Ok(())
 }
 
-pub fn post(action: &str, post: &EsaPost, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn action_result(
+    action: &str,
+    post: &EsaPost,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     if json {
-        println!("{}", serde_json::to_string(post)?);
+        print_json(post)?;
     } else {
         println!("{action}: {} (#{}) {}", post.name, post.number, post.url);
     }
@@ -94,7 +103,7 @@ pub fn embed(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if json {
-        println!("{}", serde_json::to_string(result)?);
+        print_json(result)?;
     } else if done == 0 {
         println!("All chunks already embedded");
     } else {
@@ -103,12 +112,13 @@ pub fn embed(
     Ok(())
 }
 
+pub fn dry_run(payload: &serde_json::Value) -> Result<(), Box<dyn std::error::Error>> {
+    print_json(payload)
+}
+
 pub fn model_download(json: bool) -> Result<(), Box<dyn std::error::Error>> {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string(&serde_json::json!({"status": "ok"}))?
-        );
+        print_json(&serde_json::json!({"status": "ok"}))?;
     } else {
         println!("Model downloaded and verified");
     }
@@ -117,7 +127,7 @@ pub fn model_download(json: bool) -> Result<(), Box<dyn std::error::Error>> {
 
 pub fn status(statuses: &[TeamStatus], json: bool) -> Result<(), Box<dyn std::error::Error>> {
     if json {
-        println!("{}", serde_json::to_string(statuses)?);
+        print_json(statuses)?;
     } else {
         for ts in statuses {
             println!("--- {} ---", ts.team);
@@ -151,4 +161,116 @@ pub fn status(statuses: &[TeamStatus], json: bool) -> Result<(), Box<dyn std::er
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sae::storage::{SyncState, SyncStatus, TeamStatus};
+
+    fn make_synced(team: &str, posts: u32) -> TeamStatus {
+        TeamStatus {
+            team: team.to_string(),
+            status: SyncStatus::Synced,
+            posts,
+            sync_state: Some(SyncState {
+                latest_updated_at: None,
+                total_count: posts,
+                local_count: posts,
+                last_page: None,
+                updated_at: "2025-01-01 00:00:00".to_string(),
+            }),
+            error: None,
+            db_path: None,
+        }
+    }
+
+    fn make_not_synced(team: &str) -> TeamStatus {
+        TeamStatus {
+            team: team.to_string(),
+            status: SyncStatus::NotSynced,
+            posts: 0,
+            sync_state: None,
+            error: None,
+            db_path: Some("/tmp/team.db".to_string()),
+        }
+    }
+
+    fn make_error(team: &str, msg: &str) -> TeamStatus {
+        TeamStatus {
+            team: team.to_string(),
+            status: SyncStatus::Error,
+            posts: 0,
+            sync_state: None,
+            error: Some(msg.to_string()),
+            db_path: None,
+        }
+    }
+
+    // TC-007: status --json → valid JSON array
+    #[test]
+    fn status_json_emits_json_array() {
+        let statuses = vec![make_synced("team-a", 10), make_not_synced("team-b")];
+        // Verify no error and output can be parsed (capture via serde_json directly)
+        let json = serde_json::to_string(&statuses).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(v.is_array());
+        assert_eq!(v[0]["team"], "team-a");
+        assert_eq!(v[0]["status"], "synced");
+        assert_eq!(v[1]["status"], "not_synced");
+    }
+
+    // TC-007: status human-readable empty list — no panic
+    #[test]
+    fn status_human_empty_no_panic() {
+        status(&[], false).unwrap();
+    }
+
+    // TC-007: embed json → chunks_embedded field
+    #[test]
+    fn embed_json_contains_chunks_embedded() {
+        let result = sae::storage::EmbedResult { chunks_embedded: 42 };
+        let json = serde_json::to_string(&result).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["chunks_embedded"], 42);
+    }
+
+    // TC-007: embed human-readable with done=0 → "already embedded" path
+    #[test]
+    fn embed_human_zero_done_no_panic() {
+        let result = sae::storage::EmbedResult { chunks_embedded: 0 };
+        embed(&result, 0, false).unwrap();
+    }
+
+    // TC-007: status error variant — error field displayed
+    #[test]
+    fn status_error_variant_serializes_message() {
+        let statuses = vec![make_error("broken", "db missing")];
+        let json = serde_json::to_string(&statuses).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v[0]["status"], "error");
+        assert_eq!(v[0]["error"], "db missing");
+    }
+
+    // TC-007: status with checkpoint (interrupted sync) — last_page serialized
+    #[test]
+    fn status_synced_with_checkpoint_serializes_last_page() {
+        let ts = TeamStatus {
+            team: "team-c".to_string(),
+            status: SyncStatus::Synced,
+            posts: 5,
+            sync_state: Some(SyncState {
+                latest_updated_at: None,
+                total_count: 100,
+                local_count: 5,
+                last_page: Some(3),
+                updated_at: "2025-06-01 00:00:00".to_string(),
+            }),
+            error: None,
+            db_path: None,
+        };
+        let json = serde_json::to_string(&ts).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["sync_state"]["last_page"], 3);
+    }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -104,8 +104,12 @@ pub fn embed(
 ) -> Result<(), Box<dyn std::error::Error>> {
     if json {
         print_json(result)?;
-    } else if done == 0 {
-        println!("All chunks already embedded");
+    } else if result.chunks_embedded == 0 {
+        if done == 0 {
+            println!("Nothing to embed");
+        } else {
+            println!("All {done} chunks already embedded");
+        }
     } else {
         println!("Embedded {} chunks", result.chunks_embedded);
     }
@@ -229,13 +233,15 @@ mod tests {
     // TC-007: embed json → chunks_embedded field
     #[test]
     fn embed_json_contains_chunks_embedded() {
-        let result = sae::storage::EmbedResult { chunks_embedded: 42 };
+        let result = sae::storage::EmbedResult {
+            chunks_embedded: 42,
+        };
         let json = serde_json::to_string(&result).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["chunks_embedded"], 42);
     }
 
-    // TC-007: embed human-readable with done=0 → "already embedded" path
+    // TC-007: embed human-readable with done=0 → "Nothing to embed"
     #[test]
     fn embed_human_zero_done_no_panic() {
         let result = sae::storage::EmbedResult { chunks_embedded: 0 };

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -1,48 +1,57 @@
+use std::collections::HashSet;
+
+use rurico::embed::ChunkedEmbedding;
 use rusqlite::Connection;
 
 use super::StorageError;
 
-pub fn add_embeddings(
+pub fn add_chunked_embeddings(
     conn: &Connection,
-    embeddings: &[(i64, Vec<f32>)],
+    embeddings: &[(i64, ChunkedEmbedding)],
 ) -> Result<u32, StorageError> {
     if embeddings.is_empty() {
         return Ok(0);
     }
-    let existing = existing_chunk_ids(conn, embeddings)?;
+    let chunk_ids: Vec<i64> = embeddings.iter().map(|(id, _)| *id).collect();
+    let existing = existing_embedded_ids(conn, &chunk_ids)?;
     let tx = conn.unchecked_transaction()?;
     let mut count = 0u32;
-    for (chunk_id, embedding) in embeddings {
+    for (chunk_id, chunked_emb) in embeddings {
         if existing.contains(chunk_id) {
             continue;
         }
-        let bytes: &[u8] = rurico::storage::f32_as_bytes(embedding);
-        tx.execute(
-            "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (?1, ?2)",
-            rusqlite::params![chunk_id, bytes],
-        )?;
+        for (sub_idx, embedding) in chunked_emb.chunks.iter().enumerate() {
+            let bytes: &[u8] = rurico::storage::f32_as_bytes(embedding);
+            tx.execute(
+                "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
+                rusqlite::params![bytes, chunk_id, sub_idx as i64],
+            )?;
+            let vec_rowid = tx.last_insert_rowid();
+            tx.execute(
+                "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) \
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![chunk_id, sub_idx as i64, vec_rowid],
+            )?;
+        }
         count += 1;
     }
     tx.commit()?;
     Ok(count)
 }
 
-fn existing_chunk_ids(
+fn existing_embedded_ids(
     conn: &Connection,
-    embeddings: &[(i64, Vec<f32>)],
-) -> Result<std::collections::HashSet<i64>, StorageError> {
+    chunk_ids: &[i64],
+) -> Result<HashSet<i64>, StorageError> {
     let sql = format!(
-        "SELECT chunk_id FROM vec_chunks WHERE chunk_id IN ({})",
-        super::in_placeholders(embeddings.len())
+        "SELECT DISTINCT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
+        super::in_placeholders(chunk_ids.len())
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = embeddings
-        .iter()
-        .map(|(id, _)| id as &dyn rusqlite::types::ToSql)
-        .collect();
+    let params = super::as_sql_params(chunk_ids);
     let ids = stmt
         .query_map(params.as_slice(), |row| row.get::<_, i64>(0))?
-        .collect::<Result<std::collections::HashSet<_>, _>>()?;
+        .collect::<Result<HashSet<_>, _>>()?;
     Ok(ids)
 }
 
@@ -50,10 +59,10 @@ pub fn get_unembedded_chunks(
     conn: &Connection,
     limit: u32,
 ) -> Result<Vec<(i64, String)>, StorageError> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT c.id, c.content FROM chunks c \
-         LEFT JOIN vec_chunks v ON c.id = v.chunk_id \
-         WHERE v.chunk_id IS NULL \
+         LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id \
+         WHERE e.chunk_id IS NULL \
          LIMIT ?1",
     )?;
     let rows: Vec<(i64, String)> = stmt
@@ -63,9 +72,11 @@ pub fn get_unembedded_chunks(
 }
 
 pub fn has_embeddings(conn: &Connection) -> bool {
-    conn.query_row("SELECT EXISTS(SELECT 1 FROM vec_chunks)", [], |row| {
-        row.get(0)
-    })
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM embedded_chunk_ids)",
+        [],
+        |row| row.get(0),
+    )
     .map_err(|e| {
         tracing::warn!(error = %e, "has_embeddings query failed, assuming no embeddings");
         e
@@ -77,10 +88,18 @@ pub fn has_embeddings(conn: &Connection) -> bool {
 mod tests {
     use super::*;
     use crate::storage::Db;
-    use rurico::embed::EMBEDDING_DIMS;
+    use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
 
-    fn make_embedding(val: f32) -> Vec<f32> {
-        vec![val; EMBEDDING_DIMS as usize]
+    fn make_chunked(val: f32) -> ChunkedEmbedding {
+        ChunkedEmbedding {
+            chunks: vec![vec![val; EMBEDDING_DIMS]],
+        }
+    }
+
+    fn make_multi_chunked(vals: &[f32]) -> ChunkedEmbedding {
+        ChunkedEmbedding {
+            chunks: vals.iter().map(|&v| vec![v; EMBEDDING_DIMS]).collect(),
+        }
     }
 
     #[test]
@@ -95,8 +114,8 @@ mod tests {
         let unembedded = get_unembedded_chunks(db.conn(), 100).unwrap();
         assert_eq!(unembedded.len(), 1);
 
-        let emb = vec![(unembedded[0].0, make_embedding(0.5))];
-        let added = add_embeddings(db.conn(), &emb).unwrap();
+        let emb = vec![(unembedded[0].0, make_chunked(0.5))];
+        let added = add_chunked_embeddings(db.conn(), &emb).unwrap();
         assert_eq!(added, 1);
 
         assert!(get_unembedded_chunks(db.conn(), 100).unwrap().is_empty());
@@ -112,10 +131,29 @@ mod tests {
         crate::storage::rechunk_post(db.conn(), 1, "# A\nB").unwrap();
 
         let chunks = get_unembedded_chunks(db.conn(), 100).unwrap();
-        let emb = vec![(chunks[0].0, make_embedding(1.0))];
-        add_embeddings(db.conn(), &emb).unwrap();
+        let emb = vec![(chunks[0].0, make_chunked(1.0))];
+        add_chunked_embeddings(db.conn(), &emb).unwrap();
 
-        let added = add_embeddings(db.conn(), &emb).unwrap();
+        let added = add_chunked_embeddings(db.conn(), &emb).unwrap();
         assert_eq!(added, 0);
+    }
+
+    #[test]
+    fn multi_chunk_stores_all_sub_embeddings() {
+        let db = Db::open_memory().unwrap();
+        let mut row = crate::storage::test_post_row(1);
+        row.body_md = "# Hello\nWorld".into();
+        crate::storage::upsert_post(db.conn(), &row).unwrap();
+        crate::storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
+
+        let chunks = get_unembedded_chunks(db.conn(), 100).unwrap();
+        let chunk_id = chunks[0].0;
+
+        let emb = vec![(chunk_id, make_multi_chunked(&[0.1, 0.9]))];
+        let added = add_chunked_embeddings(db.conn(), &emb).unwrap();
+        assert_eq!(added, 1);
+
+        assert!(get_unembedded_chunks(db.conn(), 100).unwrap().is_empty());
+        assert!(has_embeddings(db.conn()));
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -24,7 +24,10 @@ pub(crate) fn in_placeholders(len: usize) -> String {
 pub(crate) fn as_sql_params<T: rusqlite::types::ToSql>(
     values: &[T],
 ) -> Vec<&dyn rusqlite::types::ToSql> {
-    values.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect()
+    values
+        .iter()
+        .map(|v| v as &dyn rusqlite::types::ToSql)
+        .collect()
 }
 
 const DDL: &str = "
@@ -367,8 +370,7 @@ pub fn rechunk_post(
     use crate::chunker;
 
     let chunk_ids: Vec<i64> = {
-        let mut stmt =
-            conn.prepare_cached("SELECT id FROM chunks WHERE post_number = ?1")?;
+        let mut stmt = conn.prepare_cached("SELECT id FROM chunks WHERE post_number = ?1")?;
         let rows = stmt.query_map([post_number], |row| row.get(0))?;
         rows.collect::<Result<_, _>>()?
     };
@@ -988,7 +990,10 @@ mod tests {
     fn is_recoverable_for_database_corrupt() {
         use rusqlite::ffi::ErrorCode;
         let err = rusqlite::Error::SqliteFailure(
-            rusqlite::ffi::Error { code: ErrorCode::DatabaseCorrupt, extended_code: 11 },
+            rusqlite::ffi::Error {
+                code: ErrorCode::DatabaseCorrupt,
+                extended_code: 11,
+            },
             None,
         );
         assert!(is_recoverable_open_error(&err));
@@ -999,7 +1004,10 @@ mod tests {
     fn is_recoverable_for_cannot_open() {
         use rusqlite::ffi::ErrorCode;
         let err = rusqlite::Error::SqliteFailure(
-            rusqlite::ffi::Error { code: ErrorCode::CannotOpen, extended_code: 14 },
+            rusqlite::ffi::Error {
+                code: ErrorCode::CannotOpen,
+                extended_code: 14,
+            },
             None,
         );
         assert!(is_recoverable_open_error(&err));
@@ -1078,5 +1086,4 @@ mod tests {
             Err(e) => panic!("[TC-008] expected StorageError::Open, got {e:?}"),
         }
     }
-
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,7 @@
 pub mod embed;
 pub mod search;
 pub mod types;
-pub use embed::{add_embeddings, get_unembedded_chunks, has_embeddings};
+pub use embed::{add_chunked_embeddings, get_unembedded_chunks, has_embeddings};
 pub use search::{SearchResult, hybrid_search};
 pub use types::*;
 
@@ -12,13 +12,19 @@ use tracing::warn;
 
 use rurico::embed::EMBEDDING_DIMS;
 
-const SCHEMA_VERSION: &str = "4";
+const SCHEMA_VERSION: &str = "5";
 
 pub(crate) fn in_placeholders(len: usize) -> String {
     (1..=len)
         .map(|i| format!("?{i}"))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+pub(crate) fn as_sql_params<T: rusqlite::types::ToSql>(
+    values: &[T],
+) -> Vec<&dyn rusqlite::types::ToSql> {
+    values.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect()
 }
 
 const DDL: &str = "
@@ -62,6 +68,13 @@ const DDL: &str = "
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS embedded_chunk_ids (
+        chunk_id INTEGER NOT NULL,
+        sub_idx INTEGER NOT NULL,
+        vec_rowid INTEGER NOT NULL,
+        PRIMARY KEY (chunk_id, sub_idx)
+    );
 ";
 
 pub struct Db {
@@ -72,7 +85,7 @@ pub(crate) fn ensure_sqlite_vec() -> Result<(), StorageError> {
     rurico::storage::ensure_sqlite_vec().map_err(StorageError::Open)
 }
 
-/// Migrate FTS schema from v3 (1-column) to v4 (2-column with section_title).
+/// Migrate FTS schema from v0–v3 (1-column) to v4 (2-column with section_title).
 pub(crate) fn migrate_fts_v4(conn: &Connection) -> Result<(), StorageError> {
     let tx = conn.unchecked_transaction()?;
 
@@ -92,11 +105,41 @@ pub(crate) fn migrate_fts_v4(conn: &Connection) -> Result<(), StorageError> {
     )?;
 
     tx.execute(
-        "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('schema_version', ?1)",
-        [SCHEMA_VERSION],
+        "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('schema_version', '4')",
+        [],
     )?;
 
     tx.commit()?;
+    Ok(())
+}
+
+pub(crate) fn migrate_v5(conn: &Connection) -> Result<(), StorageError> {
+    let tx = conn.unchecked_transaction()?;
+
+    tx.execute_batch(&format!(
+        "DROP TABLE IF EXISTS vec_chunks;\
+         CREATE VIRTUAL TABLE vec_chunks USING vec0(\
+             embedding FLOAT[{EMBEDDING_DIMS}], \
+             +chunk_id INTEGER, \
+             +sub_idx INTEGER\
+         );\
+         CREATE TABLE IF NOT EXISTS embedded_chunk_ids (\
+             chunk_id INTEGER NOT NULL, \
+             sub_idx INTEGER NOT NULL, \
+             vec_rowid INTEGER NOT NULL, \
+             PRIMARY KEY (chunk_id, sub_idx)\
+         );"
+    ))?;
+
+    tx.execute(
+        "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('schema_version', '5')",
+        [],
+    )?;
+
+    tx.commit()?;
+    eprintln!(
+        "Migration complete: schema upgraded to v5 (embeddings cleared, please re-run `sae embed`)"
+    );
     Ok(())
 }
 
@@ -147,8 +190,9 @@ impl Db {
 
         self.conn.execute_batch(&format!(
             "CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(\
-                 chunk_id INTEGER PRIMARY KEY, \
-                 embedding FLOAT[{EMBEDDING_DIMS}]\
+                 embedding FLOAT[{EMBEDDING_DIMS}], \
+                 +chunk_id INTEGER, \
+                 +sub_idx INTEGER\
              )"
         ))?;
 
@@ -167,7 +211,11 @@ impl Db {
                 .parse()
                 .map_err(|_| StorageError::Open(format!("corrupt schema version: {stored:?}")))?;
             match ver {
-                0..=3 => migrate_fts_v4(&self.conn)?,
+                0..=3 => {
+                    migrate_fts_v4(&self.conn)?;
+                    migrate_v5(&self.conn)?;
+                }
+                4 => migrate_v5(&self.conn)?,
                 _ => {
                     return Err(StorageError::Open(format!(
                         "database schema version {stored} is newer than supported version {SCHEMA_VERSION}"
@@ -258,31 +306,18 @@ pub fn get_sync_state(conn: &Connection) -> Result<Option<SyncState>, StorageErr
 
 pub fn save_sync_state(
     conn: &Connection,
-    latest_updated_at: Option<&str>,
-    total_count: u32,
-    local_count: u32,
-    last_page: Option<u32>,
+    update: &SyncStateUpdate<'_>,
 ) -> Result<(), StorageError> {
     let epoch = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock before epoch")
         .as_secs() as i64;
-    save_sync_state_at(
-        conn,
-        latest_updated_at,
-        total_count,
-        local_count,
-        last_page,
-        epoch,
-    )
+    save_sync_state_at(conn, update, epoch)
 }
 
 pub(crate) fn save_sync_state_at(
     conn: &Connection,
-    latest_updated_at: Option<&str>,
-    total_count: u32,
-    local_count: u32,
-    last_page: Option<u32>,
+    update: &SyncStateUpdate<'_>,
     epoch_secs: i64,
 ) -> Result<(), StorageError> {
     conn.execute(
@@ -290,10 +325,10 @@ pub(crate) fn save_sync_state_at(
          (id, latest_updated_at, total_count, local_count, last_page, updated_at) \
          VALUES (1, ?1, ?2, ?3, ?4, datetime(?5, 'unixepoch'))",
         rusqlite::params![
-            latest_updated_at,
-            total_count,
-            local_count,
-            last_page,
+            update.latest_updated_at,
+            update.total_count,
+            update.local_count,
+            update.last_page,
             epoch_secs
         ],
     )?;
@@ -331,39 +366,70 @@ pub fn rechunk_post(
 ) -> Result<u32, StorageError> {
     use crate::chunker;
 
-    conn.execute(
-        "DELETE FROM vec_chunks WHERE chunk_id IN \
-         (SELECT id FROM chunks WHERE post_number = ?1)",
-        [post_number],
-    )?;
-    conn.execute(
-        "DELETE FROM fts_chunks WHERE rowid IN \
-         (SELECT id FROM chunks WHERE post_number = ?1)",
-        [post_number],
-    )?;
-    conn.execute("DELETE FROM chunks WHERE post_number = ?1", [post_number])?;
+    let chunk_ids: Vec<i64> = {
+        let mut stmt =
+            conn.prepare_cached("SELECT id FROM chunks WHERE post_number = ?1")?;
+        let rows = stmt.query_map([post_number], |row| row.get(0))?;
+        rows.collect::<Result<_, _>>()?
+    };
 
-    let chunks = chunker::chunk_markdown(body_md);
-    let mut insert_chunk = conn.prepare_cached(
-        "INSERT INTO chunks (post_number, section_title, content, chunk_type) \
-         VALUES (?1, ?2, ?3, ?4)",
-    )?;
-    let mut insert_fts = conn.prepare_cached(
-        "INSERT INTO fts_chunks(rowid, section_title, content) VALUES (?1, ?2, ?3)",
-    )?;
-    let mut count = 0u32;
-    for chunk in &chunks {
-        insert_chunk.execute(rusqlite::params![
-            post_number,
-            chunk.section_title,
-            chunk.content,
-            chunk.chunk_type.as_str(),
-        ])?;
-        let id = conn.last_insert_rowid();
-        insert_fts.execute(rusqlite::params![id, chunk.section_title, chunk.content])?;
-        count += 1;
+    // SAVEPOINT works both standalone and within an outer transaction (sync).
+    conn.execute_batch("SAVEPOINT rechunk")?;
+    let result: Result<u32, StorageError> = (|| {
+        if !chunk_ids.is_empty() {
+            let ph = in_placeholders(chunk_ids.len());
+            let params = as_sql_params(&chunk_ids);
+            conn.execute(
+                &format!(
+                    "DELETE FROM vec_chunks WHERE rowid IN \
+                     (SELECT vec_rowid FROM embedded_chunk_ids WHERE chunk_id IN ({ph}))"
+                ),
+                params.as_slice(),
+            )?;
+            conn.execute(
+                &format!("DELETE FROM embedded_chunk_ids WHERE chunk_id IN ({ph})"),
+                params.as_slice(),
+            )?;
+            conn.execute(
+                &format!("DELETE FROM fts_chunks WHERE rowid IN ({ph})"),
+                params.as_slice(),
+            )?;
+        }
+        conn.execute("DELETE FROM chunks WHERE post_number = ?1", [post_number])?;
+
+        let chunks = chunker::chunk_markdown(body_md);
+        let mut insert_chunk = conn.prepare_cached(
+            "INSERT INTO chunks (post_number, section_title, content, chunk_type) \
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        let mut insert_fts = conn.prepare_cached(
+            "INSERT INTO fts_chunks(rowid, section_title, content) VALUES (?1, ?2, ?3)",
+        )?;
+        let mut count = 0u32;
+        for chunk in &chunks {
+            insert_chunk.execute(rusqlite::params![
+                post_number,
+                chunk.section_title,
+                chunk.content,
+                chunk.chunk_type.as_str(),
+            ])?;
+            let id = conn.last_insert_rowid();
+            insert_fts.execute(rusqlite::params![id, chunk.section_title, chunk.content])?;
+            count += 1;
+        }
+        Ok(count)
+    })();
+    match result {
+        Ok(count) => {
+            conn.execute_batch("RELEASE rechunk")?;
+            Ok(count)
+        }
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK TO rechunk");
+            let _ = conn.execute_batch("RELEASE rechunk");
+            Err(e)
+        }
     }
-    Ok(count)
 }
 
 #[cfg(test)]
@@ -452,10 +518,12 @@ mod tests {
         // Deterministic timestamp for test assertions
         save_sync_state_at(
             db.conn(),
-            Some("2025-01-01T00:00:00+09:00"),
-            100,
-            50,
-            Some(3),
+            &SyncStateUpdate {
+                latest_updated_at: Some("2025-01-01T00:00:00+09:00"),
+                total_count: 100,
+                local_count: 50,
+                last_page: Some(3),
+            },
             1735689600, // 2025-01-01 00:00:00 UTC
         )
         .unwrap();
@@ -474,13 +542,31 @@ mod tests {
     #[test]
     fn sync_state_clears_checkpoint() {
         let db = Db::open_memory().unwrap();
-        save_sync_state(db.conn(), None, 0, 0, Some(5)).unwrap();
+        save_sync_state(
+            db.conn(),
+            &SyncStateUpdate {
+                latest_updated_at: None,
+                total_count: 0,
+                local_count: 0,
+                last_page: Some(5),
+            },
+        )
+        .unwrap();
         assert_eq!(
             get_sync_state(db.conn()).unwrap().unwrap().last_page,
             Some(5)
         );
 
-        save_sync_state(db.conn(), None, 10, 10, None).unwrap();
+        save_sync_state(
+            db.conn(),
+            &SyncStateUpdate {
+                latest_updated_at: None,
+                total_count: 10,
+                local_count: 10,
+                last_page: None,
+            },
+        )
+        .unwrap();
         assert!(
             get_sync_state(db.conn())
                 .unwrap()
@@ -562,20 +648,29 @@ mod tests {
         rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
 
         let chunks = embed::get_unembedded_chunks(db.conn(), 100).unwrap();
-        let emb: Vec<(i64, Vec<f32>)> = chunks
+        let emb: Vec<(i64, rurico::embed::ChunkedEmbedding)> = chunks
             .iter()
-            .map(|(id, _)| (*id, vec![0.1; rurico::embed::EMBEDDING_DIMS as usize]))
+            .map(|(id, _)| {
+                (
+                    *id,
+                    rurico::embed::ChunkedEmbedding {
+                        chunks: vec![vec![0.1; rurico::embed::EMBEDDING_DIMS as usize]],
+                    },
+                )
+            })
             .collect();
-        embed::add_embeddings(db.conn(), &emb).unwrap();
+        embed::add_chunked_embeddings(db.conn(), &emb).unwrap();
         assert!(embed::has_embeddings(db.conn()));
 
         rechunk_post(db.conn(), 1, "# New\nContent").unwrap();
 
         let orphans: u32 = db
             .conn()
-            .query_row("SELECT COUNT(*) FROM vec_chunks", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |row| {
+                row.get(0)
+            })
             .unwrap();
-        assert_eq!(orphans, 0, "rechunk should clean orphaned vec_chunks");
+        assert_eq!(orphans, 0, "rechunk should clean orphaned embeddings");
     }
 
     #[test]
@@ -859,7 +954,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "4", "[T-004] schema_version should be '4'");
+        assert_eq!(
+            version, "5",
+            "[T-004] schema_version should be '5' after full migration"
+        );
 
         // section_title の語で検索可能
         let hits: u32 = db
@@ -884,4 +982,101 @@ mod tests {
             .unwrap();
         assert!(vocab > 0, "[T-004] fts_chunks_vocab should be populated");
     }
+
+    // TC-005: WAL recovery — is_recoverable_open_error recognizes DatabaseCorrupt
+    #[test]
+    fn is_recoverable_for_database_corrupt() {
+        use rusqlite::ffi::ErrorCode;
+        let err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error { code: ErrorCode::DatabaseCorrupt, extended_code: 11 },
+            None,
+        );
+        assert!(is_recoverable_open_error(&err));
+    }
+
+    // TC-005: WAL recovery — is_recoverable_open_error recognizes CannotOpen
+    #[test]
+    fn is_recoverable_for_cannot_open() {
+        use rusqlite::ffi::ErrorCode;
+        let err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error { code: ErrorCode::CannotOpen, extended_code: 14 },
+            None,
+        );
+        assert!(is_recoverable_open_error(&err));
+    }
+
+    // TC-005: WAL recovery — non-SqliteFailure error is not recoverable
+    #[test]
+    fn is_not_recoverable_for_non_sqlite_failure() {
+        let err = rusqlite::Error::QueryReturnedNoRows;
+        assert!(!is_recoverable_open_error(&err));
+    }
+
+    // TC-005: WAL recovery — open_with_wal_recovery succeeds on a valid DB file
+    #[test]
+    fn open_with_wal_recovery_opens_valid_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("wal_test.db");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
+        }
+        let conn = open_with_wal_recovery(&db_path).unwrap();
+        assert!(conn.is_autocommit());
+    }
+
+    // TC-002: init_schema rejects a non-numeric (corrupt) schema version string
+    #[test]
+    fn init_schema_rejects_corrupt_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(DDL).unwrap();
+            conn.execute(
+                "INSERT INTO index_meta (key, value) VALUES ('schema_version', 'not-a-number')",
+                [],
+            )
+            .unwrap();
+        }
+        match Db::open(&path) {
+            Ok(_) => panic!("[TC-002] expected Db::open to fail"),
+            Err(StorageError::Open(msg)) => assert!(
+                msg.contains("corrupt schema version"),
+                "[TC-002] unexpected error message: {msg}"
+            ),
+            Err(e) => panic!("[TC-002] expected StorageError::Open, got {e:?}"),
+        }
+    }
+
+    // TC-008: init_schema rejects a schema version number higher than SCHEMA_VERSION
+    #[test]
+    fn init_schema_rejects_future_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("future.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(DDL).unwrap();
+            conn.execute(
+                "INSERT INTO index_meta (key, value) VALUES ('schema_version', '99')",
+                [],
+            )
+            .unwrap();
+        }
+        match Db::open(&path) {
+            Ok(_) => panic!("[TC-008] expected Db::open to fail"),
+            Err(StorageError::Open(msg)) => {
+                assert!(
+                    msg.contains("newer than supported"),
+                    "[TC-008] unexpected error message: {msg}"
+                );
+                assert!(
+                    msg.contains("99"),
+                    "[TC-008] message should include the invalid version: {msg}"
+                );
+            }
+            Err(e) => panic!("[TC-008] expected StorageError::Open, got {e:?}"),
+        }
+    }
+
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -27,7 +27,7 @@ pub fn fts_search(conn: &Connection, query: &str, limit: u32) -> Result<Vec<FtsH
 
     let match_query = clean_for_trigram(matched.as_str());
 
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT c.id, c.post_number, c.section_title, c.content, f.rank \
          FROM fts_chunks f \
          JOIN chunks c ON c.id = f.rowid \
@@ -51,34 +51,89 @@ pub fn fts_search(conn: &Connection, query: &str, limit: u32) -> Result<Vec<FtsH
     Ok(rows)
 }
 
+const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
+
 pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
     limit: u32,
 ) -> Result<Vec<VecHit>, StorageError> {
     let bytes: &[u8] = rurico::storage::f32_as_bytes(query_embedding);
+    let oversample = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
 
-    let mut stmt = conn.prepare(
-        "SELECT v.chunk_id, v.distance, c.post_number, c.section_title, c.content \
-         FROM vec_chunks v \
-         JOIN chunks c ON c.id = v.chunk_id \
-         WHERE v.embedding MATCH ?1 AND k = ?2 \
-         ORDER BY v.distance",
-    )?;
-
-    let rows: Vec<VecHit> = stmt
-        .query_map(rusqlite::params![bytes, limit], |row| {
-            Ok(VecHit {
-                chunk_id: row.get(0)?,
-                distance: row.get(1)?,
-                post_number: row.get(2)?,
-                section_title: row.get(3)?,
-                content: row.get(4)?,
-            })
+    // Step 1: KNN query — fetch only chunk_id + distance to avoid the sqlite-vec
+    // restriction that prohibits JOIN conditions on vec0 auxiliary columns (+chunk_id).
+    let knn_rows: Vec<(i64, f32)> = {
+        let mut stmt = conn.prepare_cached(
+            "SELECT chunk_id, distance FROM vec_chunks \
+             WHERE embedding MATCH ?1 AND k = ?2 \
+             ORDER BY distance",
+        )?;
+        stmt.query_map(rusqlite::params![bytes, oversample], |row| {
+            Ok((row.get(0)?, row.get(1)?))
         })?
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?
+    };
 
-    Ok(rows)
+    if knn_rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // MaxSim: keep the sub-embedding with the smallest distance per chunk_id
+    let mut best: HashMap<i64, f32> = HashMap::new();
+    for (chunk_id, distance) in &knn_rows {
+        use std::collections::hash_map::Entry;
+        match best.entry(*chunk_id) {
+            Entry::Vacant(v) => {
+                v.insert(*distance);
+            }
+            Entry::Occupied(mut o) => {
+                if distance < o.get() {
+                    *o.get_mut() = *distance;
+                }
+            }
+        }
+    }
+
+    // Step 2: batch-fetch chunk metadata for the deduplicated chunk_ids
+    let chunk_ids: Vec<i64> = best.keys().copied().collect();
+    let sql = format!(
+        "SELECT id, post_number, section_title, content FROM chunks WHERE id IN ({})",
+        super::in_placeholders(chunk_ids.len())
+    );
+    let mut stmt2 = conn.prepare(&sql)?;
+    let params = super::as_sql_params(&chunk_ids);
+    let meta: HashMap<i64, (u32, Option<String>, String)> = stmt2
+        .query_map(params.as_slice(), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, u32>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|(id, pn, st, c)| (id, (pn, st, c)))
+        .collect();
+
+    let mut hits: Vec<VecHit> = best
+        .into_iter()
+        .filter_map(|(chunk_id, distance)| {
+            meta.get(&chunk_id).map(|(post_number, section_title, content)| VecHit {
+                chunk_id,
+                distance,
+                post_number: *post_number,
+                section_title: section_title.clone(),
+                content: content.clone(),
+            })
+        })
+        .collect();
+
+    hits.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+    hits.truncate(limit as usize);
+
+    Ok(hits)
 }
 
 const RECENCY_HALF_LIFE: f64 = 30.0;
@@ -100,16 +155,17 @@ pub fn hybrid_search(
         Some(emb) if super::has_embeddings(conn) => match vec_search(conn, emb, candidate_limit) {
             Ok(hits) => hits,
             Err(e) => {
-                warn!(%e, "vec_search failed, falling back to FTS only");
+                eprintln!("  warning: vector search failed, falling back to text search only");
+                warn!(%e, %query, candidate_limit, "vec_search failed, falling back to FTS only");
                 Vec::new()
             }
         },
         _ => Vec::new(),
     };
 
-    let fts_ranked: Vec<(u32, f64)> = fts_hits.iter().map(|h| (h.post_number, 0.0)).collect();
-    let vec_ranked: Vec<(u32, f64)> = vec_hits.iter().map(|h| (h.post_number, 0.0)).collect();
-    let merged = rurico::storage::rrf_merge(&fts_ranked, &vec_ranked);
+    let fts_rrf_input: Vec<(u32, f64)> = fts_hits.iter().map(|h| (h.post_number, 0.0)).collect();
+    let vec_rrf_input: Vec<(u32, f64)> = vec_hits.iter().map(|h| (h.post_number, 0.0)).collect();
+    let merged = rurico::storage::rrf_merge(&fts_rrf_input, &vec_rrf_input);
 
     // Fetch metadata for all candidates (not just limit) to apply decay before truncation
     let candidate_numbers: Vec<u32> = merged.iter().map(|(pn, _)| *pn).collect();
@@ -120,37 +176,37 @@ pub fn hybrid_search(
 
     let scored = apply_recency_boost(merged, &post_meta, now);
 
-    let mut results = Vec::new();
-    for (post_number, score) in scored.into_iter().take(limit as usize) {
-        let meta = post_meta
-            .get(&post_number)
-            .cloned()
-            .unwrap_or_else(|| PostMeta {
-                name: format!("#{post_number}"),
-                url: String::new(),
-                updated_at: String::new(),
-            });
-
-        let (section_title, snippet) = fts_map
-            .get(&post_number)
-            .map(|h| (h.section_title.clone(), h.content.clone()))
-            .or_else(|| {
-                vec_map
-                    .get(&post_number)
-                    .map(|h| (h.section_title.clone(), h.content.clone()))
-            })
-            .unwrap_or_default();
-
-        results.push(SearchResult {
-            post_number,
-            post_name: meta.name,
-            post_url: meta.url,
-            section_title,
-            snippet: truncate_snippet(&snippet, 200),
-            score,
-        });
-    }
-
+    let results = scored
+        .into_iter()
+        .take(limit as usize)
+        .map(|(post_number, score)| {
+            let meta = post_meta
+                .get(&post_number)
+                .cloned()
+                .unwrap_or_else(|| PostMeta {
+                    name: format!("#{post_number}"),
+                    url: String::new(),
+                    updated_at: String::new(),
+                });
+            let (section_title, snippet) = fts_map
+                .get(&post_number)
+                .map(|h| (h.section_title.clone(), h.content.clone()))
+                .or_else(|| {
+                    vec_map
+                        .get(&post_number)
+                        .map(|h| (h.section_title.clone(), h.content.clone()))
+                })
+                .unwrap_or_default();
+            SearchResult {
+                post_number,
+                post_name: meta.name,
+                post_url: meta.url,
+                section_title,
+                snippet: truncate_snippet(&snippet, 200),
+                score,
+            }
+        })
+        .collect();
     Ok(results)
 }
 
@@ -203,10 +259,7 @@ fn batch_fetch_post_meta(
         super::in_placeholders(post_numbers.len())
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = post_numbers
-        .iter()
-        .map(|n| n as &dyn rusqlite::types::ToSql)
-        .collect();
+    let params = super::as_sql_params(post_numbers);
     let rows = stmt
         .query_map(params.as_slice(), |row| {
             Ok((
@@ -765,24 +818,175 @@ mod tests {
 
     #[test]
     fn hybrid_search_with_embeddings() {
-        use rurico::embed::EMBEDDING_DIMS;
+        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
 
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
         let unembedded = storage::get_unembedded_chunks(db.conn(), 100).unwrap();
         assert!(!unembedded.is_empty());
-        let embeddings: Vec<(i64, Vec<f32>)> = unembedded
+        let embeddings: Vec<(i64, ChunkedEmbedding)> = unembedded
             .iter()
-            .map(|(id, _)| (*id, vec![0.1; EMBEDDING_DIMS as usize]))
+            .map(|(id, _)| {
+                (
+                    *id,
+                    ChunkedEmbedding {
+                        chunks: vec![vec![0.1; EMBEDDING_DIMS]],
+                    },
+                )
+            })
             .collect();
-        storage::add_embeddings(db.conn(), &embeddings).unwrap();
+        storage::add_chunked_embeddings(db.conn(), &embeddings).unwrap();
 
-        let query_emb = vec![0.1; EMBEDDING_DIMS as usize];
+        let query_emb = vec![0.1; EMBEDDING_DIMS];
         let results =
             hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
         assert!(!results.is_empty());
         assert!(!results[0].post_name.is_empty());
         assert!(!results[0].post_url.is_empty());
+    }
+
+    /// Distinct embeddings produce different vec_search distances and ranking.
+    #[test]
+    fn vec_search_ranks_closer_embedding_first() {
+        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
+
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        // Distinct embeddings per chunk: vary dim 0 weight to control distance
+        let chunks = storage::get_unembedded_chunks(db.conn(), 100).unwrap();
+        assert!(chunks.len() >= 2, "need at least 2 chunks");
+
+        let embeddings: Vec<(i64, ChunkedEmbedding)> = chunks
+            .iter()
+            .enumerate()
+            .map(|(i, (id, _))| {
+                let mut emb = vec![0.01_f32; EMBEDDING_DIMS];
+                // chunk 0: strong dim-0 signal (close to query)
+                // chunk 1+: weaker dim-0 signal (farther from query)
+                emb[0] = if i == 0 { 1.0 } else { 0.01 };
+                emb[1] = if i == 0 { 0.01 } else { 1.0 };
+                (*id, ChunkedEmbedding { chunks: vec![emb] })
+            })
+            .collect();
+        storage::add_chunked_embeddings(db.conn(), &embeddings).unwrap();
+
+        // Query: strong dim-0 signal
+        let mut query_emb = vec![0.01_f32; EMBEDDING_DIMS];
+        query_emb[0] = 1.0;
+
+        let results =
+            hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        assert!(results.len() >= 2, "expected at least 2 results");
+
+        // First result should come from the chunk with the closest embedding
+        // (chunk 0 with strong dim-0 matches query's strong dim-0)
+        assert!(
+            results[0].score >= results[1].score,
+            "closer embedding should score higher: s0={} s1={}",
+            results[0].score,
+            results[1].score,
+        );
+    }
+
+    /// MaxSim dedup: multiple sub-embeddings per chunk, best distance wins.
+    #[test]
+    fn maxsim_dedup_selects_best_sub_embedding() {
+        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
+
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let chunks = storage::get_unembedded_chunks(db.conn(), 100).unwrap();
+        assert!(chunks.len() >= 2, "need at least 2 chunks");
+
+        // Each chunk gets 2 sub-embeddings with different dim-0 weights
+        let embeddings: Vec<(i64, ChunkedEmbedding)> = chunks
+            .iter()
+            .enumerate()
+            .map(|(i, (id, _))| {
+                // sub-emb A: closer to query for chunk 0, farther for others
+                let mut sub_a = vec![0.01_f32; EMBEDDING_DIMS];
+                sub_a[0] = if i == 0 { 0.9 } else { 0.01 };
+                sub_a[1] = if i == 0 { 0.01 } else { 0.9 };
+
+                // sub-emb B: always far from query
+                let mut sub_b = vec![0.01_f32; EMBEDDING_DIMS];
+                sub_b[2] = 1.0;
+
+                (*id, ChunkedEmbedding {
+                    chunks: vec![sub_a, sub_b],
+                })
+            })
+            .collect();
+        storage::add_chunked_embeddings(db.conn(), &embeddings).unwrap();
+
+        // Query: strong dim-0
+        let mut query_emb = vec![0.01_f32; EMBEDDING_DIMS];
+        query_emb[0] = 1.0;
+
+        let results =
+            hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        assert!(!results.is_empty(), "should have results with multi-sub embeddings");
+
+        // Dedup: each chunk_id produces at most one result (2 sub-embs per chunk → not 2× results)
+        assert!(
+            results.len() <= chunks.len(),
+            "dedup should keep at most one result per chunk: got {} results for {} chunks",
+            results.len(),
+            chunks.len()
+        );
+        // No duplicate (post_number, section_title) pairs in results
+        let mut seen = std::collections::HashSet::new();
+        for r in &results {
+            let key = (r.post_number, r.section_title.clone());
+            assert!(
+                seen.insert(key.clone()),
+                "duplicate chunk in results: post {} section {:?}",
+                key.0,
+                key.1
+            );
+        }
+    }
+
+    // TC-004: MaxSim selects the sub-embedding with the lower distance (closer to query)
+    #[test]
+    fn vec_search_maxsim_picks_closer_sub_embedding() {
+        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
+
+        let db = Db::open_memory().unwrap();
+        let body = "# Rust\nOwnership and borrowing";
+        let post = test_post(1, "Rust", body);
+        storage::upsert_post(db.conn(), &post).unwrap();
+        storage::rechunk_post(db.conn(), 1, body).unwrap();
+
+        let chunks = storage::get_unembedded_chunks(db.conn(), 10).unwrap();
+        assert_eq!(chunks.len(), 1);
+        let chunk_id = chunks[0].0;
+
+        // sub_idx 0: orthogonal to query (far)
+        let mut sub_far = vec![0.0f32; EMBEDDING_DIMS];
+        sub_far[1] = 1.0;
+        // sub_idx 1: aligned with query (close, distance ≈ 0)
+        let mut sub_close = vec![0.0f32; EMBEDDING_DIMS];
+        sub_close[0] = 1.0;
+
+        storage::add_chunked_embeddings(
+            db.conn(),
+            &[(chunk_id, ChunkedEmbedding { chunks: vec![sub_far, sub_close] })],
+        )
+        .unwrap();
+
+        let mut query = vec![0.0f32; EMBEDDING_DIMS];
+        query[0] = 1.0;
+
+        let hits = vec_search(db.conn(), &query, 1).unwrap();
+        assert_eq!(hits.len(), 1, "[TC-004] should return exactly one hit");
+        assert!(
+            hits[0].distance < 0.1,
+            "[TC-004] MaxSim must select sub_idx=1 (closer sub-embedding), got distance={}",
+            hits[0].distance
+        );
     }
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -120,13 +120,14 @@ pub fn vec_search(
     let mut hits: Vec<VecHit> = best
         .into_iter()
         .filter_map(|(chunk_id, distance)| {
-            meta.get(&chunk_id).map(|(post_number, section_title, content)| VecHit {
-                chunk_id,
-                distance,
-                post_number: *post_number,
-                section_title: section_title.clone(),
-                content: content.clone(),
-            })
+            meta.get(&chunk_id)
+                .map(|(post_number, section_title, content)| VecHit {
+                    chunk_id,
+                    distance,
+                    post_number: *post_number,
+                    section_title: section_title.clone(),
+                    content: content.clone(),
+                })
         })
         .collect();
 
@@ -915,9 +916,12 @@ mod tests {
                 let mut sub_b = vec![0.01_f32; EMBEDDING_DIMS];
                 sub_b[2] = 1.0;
 
-                (*id, ChunkedEmbedding {
-                    chunks: vec![sub_a, sub_b],
-                })
+                (
+                    *id,
+                    ChunkedEmbedding {
+                        chunks: vec![sub_a, sub_b],
+                    },
+                )
             })
             .collect();
         storage::add_chunked_embeddings(db.conn(), &embeddings).unwrap();
@@ -928,7 +932,10 @@ mod tests {
 
         let results =
             hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
-        assert!(!results.is_empty(), "should have results with multi-sub embeddings");
+        assert!(
+            !results.is_empty(),
+            "should have results with multi-sub embeddings"
+        );
 
         // Dedup: each chunk_id produces at most one result (2 sub-embs per chunk → not 2× results)
         assert!(
@@ -974,7 +981,12 @@ mod tests {
 
         storage::add_chunked_embeddings(
             db.conn(),
-            &[(chunk_id, ChunkedEmbedding { chunks: vec![sub_far, sub_close] })],
+            &[(
+                chunk_id,
+                ChunkedEmbedding {
+                    chunks: vec![sub_far, sub_close],
+                },
+            )],
         )
         .unwrap();
 

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -18,7 +18,7 @@ pub struct EsaPostRow {
 
 impl EsaPostRow {
     pub fn tags_json(&self) -> String {
-        serde_json::to_string(&self.tags).unwrap_or_else(|_| "[]".into())
+        serde_json::to_string(&self.tags).expect("Vec<String> serialization is infallible")
     }
 }
 
@@ -29,6 +29,14 @@ pub struct SyncState {
     pub local_count: u32,
     pub last_page: Option<u32>,
     pub updated_at: String,
+}
+
+#[derive(Debug)]
+pub struct SyncStateUpdate<'a> {
+    pub latest_updated_at: Option<&'a str>,
+    pub total_count: u32,
+    pub local_count: u32,
+    pub last_page: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -49,6 +57,41 @@ pub struct TeamStatus {
     /// DB path for human-readable output (not included in JSON)
     #[serde(skip)]
     pub db_path: Option<String>,
+}
+
+impl TeamStatus {
+    pub fn synced(team: impl Into<String>, posts: u32, sync_state: Option<SyncState>) -> Self {
+        Self {
+            team: team.into(),
+            status: SyncStatus::Synced,
+            posts,
+            sync_state,
+            error: None,
+            db_path: None,
+        }
+    }
+
+    pub fn not_synced(team: impl Into<String>, db_path: Option<String>) -> Self {
+        Self {
+            team: team.into(),
+            status: SyncStatus::NotSynced,
+            posts: 0,
+            sync_state: None,
+            error: None,
+            db_path,
+        }
+    }
+
+    pub fn error(team: impl Into<String>, message: impl ToString) -> Self {
+        Self {
+            team: team.into(),
+            status: SyncStatus::Error,
+            posts: 0,
+            sync_state: None,
+            error: Some(message.to_string()),
+            db_path: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -48,7 +48,15 @@ pub async fn harvest(
     let state = storage::get_sync_state(db.conn())?;
 
     if full {
-        storage::save_sync_state(db.conn(), None, 0, 0, None)?;
+        storage::save_sync_state(
+            db.conn(),
+            &storage::SyncStateUpdate {
+                latest_updated_at: None,
+                total_count: 0,
+                local_count: 0,
+                last_page: None,
+            },
+        )?;
     }
 
     let (start_page, base_query) = resolve_start(full, &state);
@@ -119,10 +127,12 @@ pub async fn harvest(
 
         storage::save_sync_state(
             &tx,
-            latest.as_deref(),
-            api_total,
-            prior_count + total_stored,
-            resp.next_page,
+            &storage::SyncStateUpdate {
+                latest_updated_at: latest.as_deref(),
+                total_count: api_total,
+                local_count: prior_count + total_stored,
+                last_page: resp.next_page,
+            },
         )?;
         tx.commit().map_err(StorageError::Db)?;
 
@@ -143,7 +153,15 @@ pub async fn harvest(
     let local_count = storage::count_posts(db.conn())?;
     let gap_detected = local_count < api_total;
 
-    storage::save_sync_state(db.conn(), latest.as_deref(), api_total, local_count, None)?;
+    storage::save_sync_state(
+        db.conn(),
+        &storage::SyncStateUpdate {
+            latest_updated_at: latest.as_deref(),
+            total_count: api_total,
+            local_count,
+            last_page: None,
+        },
+    )?;
 
     if gap_detected {
         eprintln!(

--- a/tests/audit_structural.rs
+++ b/tests/audit_structural.rs
@@ -159,10 +159,7 @@ fn t_003_run_embed_no_eprintln() {
 #[test]
 fn t_003_run_embed_has_4_tracing_info() {
     let path = src_dir().join("commands").join("data.rs");
-    assert!(
-        path.exists(),
-        "[T-003] src/commands/data.rs does not exist"
-    );
+    assert!(path.exists(), "[T-003] src/commands/data.rs does not exist");
     let source = fs::read_to_string(&path).unwrap();
     let count = count_in_function(&source, "run_embed", "tracing::info!");
     // Also check for bare `info!` (if `use tracing::info;` is at the top)

--- a/tests/audit_structural.rs
+++ b/tests/audit_structural.rs
@@ -1,0 +1,271 @@
+//! Structural audit tests for the sae codebase.
+//!
+//! These tests validate source-level properties (line counts, grep matches,
+//! module structure) that correspond to the audit spec T-001, T-003, T-004,
+//! T-007, T-008.
+//!
+//! They read source files at test time and assert on their textual content.
+//! This approach lets `cargo test` catch structural regressions without
+//! requiring external CI scripts.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Locate the project src/ directory relative to the cargo manifest.
+fn src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+/// Count non-test, non-blank lines in a Rust source file.
+/// Excludes lines inside `#[cfg(test)]` modules (from the marker to EOF or
+/// matching closing brace).
+fn count_non_test_lines(path: &Path) -> usize {
+    let content = fs::read_to_string(path).expect("failed to read source file");
+    let mut in_test_module = false;
+    let mut count = 0;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.contains("#[cfg(test)]") {
+            in_test_module = true;
+            continue;
+        }
+
+        // Treat everything from #[cfg(test)] to EOF as test code
+        if in_test_module {
+            continue;
+        }
+
+        if !trimmed.is_empty() {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+/// Count occurrences of `needle` in the given text, restricted to lines
+/// between `fn {fn_name}` and the next `fn ` at the same or lesser indent.
+fn count_in_function(source: &str, fn_name: &str, needle: &str) -> usize {
+    let fn_start = format!("fn {fn_name}");
+    let mut in_fn = false;
+    let mut brace_depth: i32 = 0;
+    let mut entered_body = false;
+    let mut count = 0;
+
+    for line in source.lines() {
+        if !in_fn {
+            if line.contains(&fn_start) {
+                in_fn = true;
+                brace_depth = 0;
+                for ch in line.chars() {
+                    match ch {
+                        '{' => brace_depth += 1,
+                        '}' => brace_depth -= 1,
+                        _ => {}
+                    }
+                }
+                if brace_depth > 0 {
+                    entered_body = true;
+                }
+                if line.contains(needle) {
+                    count += 1;
+                }
+            }
+            continue;
+        }
+
+        // Inside the function (signature or body)
+        for ch in line.chars() {
+            match ch {
+                '{' => brace_depth += 1,
+                '}' => brace_depth -= 1,
+                _ => {}
+            }
+        }
+        if brace_depth > 0 {
+            entered_body = true;
+        }
+
+        if line.contains(needle) {
+            count += 1;
+        }
+
+        if entered_body && brace_depth <= 0 {
+            break;
+        }
+    }
+
+    count
+}
+
+// ---------------------------------------------------------------------------
+// T-001: Line count thresholds after extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn t_001_main_rs_under_400_non_test_lines() {
+    let path = src_dir().join("main.rs");
+    let lines = count_non_test_lines(&path);
+    assert!(
+        lines < 400,
+        "[T-001] main.rs has {lines} non-test lines, expected < 400"
+    );
+}
+
+#[test]
+fn t_001_each_command_file_under_200_non_test_lines() {
+    let commands_dir = src_dir().join("commands");
+    assert!(
+        commands_dir.is_dir(),
+        "[T-001] src/commands/ directory does not exist"
+    );
+
+    let expected_files = ["search.rs", "post.rs", "archive.rs", "data.rs", "status.rs"];
+    for filename in &expected_files {
+        let path = commands_dir.join(filename);
+        assert!(
+            path.exists(),
+            "[T-001] src/commands/{filename} does not exist"
+        );
+        let lines = count_non_test_lines(&path);
+        assert!(
+            lines < 200,
+            "[T-001] commands/{filename} has {lines} non-test lines, expected < 200"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T-003: eprintln! replaced with tracing::info! in run_embed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn t_003_run_embed_no_eprintln() {
+    let path = src_dir().join("commands").join("data.rs");
+    assert!(
+        path.exists(),
+        "[T-003] src/commands/data.rs does not exist (run_embed should live there)"
+    );
+    let source = fs::read_to_string(&path).unwrap();
+    let count = count_in_function(&source, "run_embed", "eprintln!");
+    assert_eq!(
+        count, 0,
+        "[T-003] run_embed should contain 0 eprintln! calls, found {count}"
+    );
+}
+
+#[test]
+fn t_003_run_embed_has_4_tracing_info() {
+    let path = src_dir().join("commands").join("data.rs");
+    assert!(
+        path.exists(),
+        "[T-003] src/commands/data.rs does not exist"
+    );
+    let source = fs::read_to_string(&path).unwrap();
+    let count = count_in_function(&source, "run_embed", "tracing::info!");
+    // Also check for bare `info!` (if `use tracing::info;` is at the top)
+    let count_bare = count_in_function(&source, "run_embed", "info!");
+    // Subtract tracing::info! matches from info! matches to avoid double count
+    let total = if count > 0 { count } else { count_bare };
+    assert_eq!(
+        total, 4,
+        "[T-003] run_embed should contain 4 tracing::info!/info! calls, found {total}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T-004: embed_query warn! includes %query structured field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn t_004_embed_query_warn_includes_query_field() {
+    let path = src_dir().join("commands").join("search.rs");
+    assert!(
+        path.exists(),
+        "[T-004] src/commands/search.rs does not exist"
+    );
+    let source = fs::read_to_string(&path).unwrap();
+
+    // Find warn! calls near embed_query that contain %query
+    let mut found = false;
+    for line in source.lines() {
+        if line.contains("embed_query") || line.contains("warn!") {
+            if line.contains("%query") {
+                found = true;
+                break;
+            }
+        }
+    }
+    // Broader search: look for %query in the embed_query error-handling block
+    if !found {
+        // Look for %query anywhere in the run_search function
+        let count = count_in_function(&source, "run_search", "%query");
+        assert!(
+            count >= 1,
+            "[T-004] run_search should contain at least 1 occurrence of '%query' \
+             in a warn! call for embed_query failure, found {count}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T-007: Each commands/*.rs has #[cfg(test)] module with at least 1 test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn t_007_each_command_file_has_test_module() {
+    let commands_dir = src_dir().join("commands");
+    assert!(
+        commands_dir.is_dir(),
+        "[T-007] src/commands/ directory does not exist"
+    );
+
+    let expected_files = ["search.rs", "post.rs", "archive.rs", "data.rs", "status.rs"];
+    for filename in &expected_files {
+        let path = commands_dir.join(filename);
+        assert!(
+            path.exists(),
+            "[T-007] src/commands/{filename} does not exist"
+        );
+        let source = fs::read_to_string(&path).unwrap();
+        assert!(
+            source.contains("#[cfg(test)]"),
+            "[T-007] commands/{filename} should contain #[cfg(test)] module"
+        );
+        assert!(
+            source.contains("#[test]"),
+            "[T-007] commands/{filename} should contain at least one #[test] function"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T-008: vec_search warn! includes %query and candidate_limit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn t_008_vec_search_warn_includes_query_field() {
+    let path = src_dir().join("storage").join("search.rs");
+    let source = fs::read_to_string(&path).unwrap();
+
+    // Look for %query in the hybrid_search function (where vec_search error is handled)
+    let count = count_in_function(&source, "hybrid_search", "%query");
+    assert!(
+        count >= 1,
+        "[T-008] hybrid_search should contain '%query' in vec_search warn!, found {count}"
+    );
+}
+
+#[test]
+fn t_008_vec_search_warn_includes_candidate_limit() {
+    let path = src_dir().join("storage").join("search.rs");
+    let source = fs::read_to_string(&path).unwrap();
+
+    let count = count_in_function(&source, "hybrid_search", "candidate_limit");
+    assert!(
+        count >= 1,
+        "[T-008] hybrid_search should contain 'candidate_limit' in vec_search warn!, found {count}"
+    );
+}

--- a/tests/audit_sync_state.rs
+++ b/tests/audit_sync_state.rs
@@ -54,10 +54,7 @@ fn t_005_save_sync_state_none_optionals() {
         state.latest_updated_at, None,
         "[T-005] latest_updated_at should be None"
     );
-    assert_eq!(
-        state.last_page, None,
-        "[T-005] last_page should be None"
-    );
+    assert_eq!(state.last_page, None, "[T-005] last_page should be None");
 }
 
 /// [T-005] SyncStateUpdate borrows from caller's Option<String> via .as_deref()

--- a/tests/audit_sync_state.rs
+++ b/tests/audit_sync_state.rs
@@ -1,0 +1,88 @@
+//! T-005: Compile-time signature check for save_sync_state / save_sync_state_at.
+//!
+//! After FR-006, these functions should accept `&SyncStateUpdate` instead of
+//! 4 individual parameters. This test file will fail to compile if the
+//! signature does not match the spec.
+
+use sae::storage::{Db, SyncStateUpdate, get_sync_state, save_sync_state};
+
+/// [T-005] save_sync_state accepts (conn, &SyncStateUpdate)
+#[test]
+fn t_005_save_sync_state_accepts_sync_state_update() {
+    let db = Db::open_memory().unwrap();
+
+    let update = SyncStateUpdate {
+        latest_updated_at: Some("2025-01-01T00:00:00+09:00"),
+        total_count: 100,
+        local_count: 50,
+        last_page: Some(3),
+    };
+
+    save_sync_state(db.conn(), &update).unwrap();
+
+    let state = get_sync_state(db.conn()).unwrap().unwrap();
+    assert_eq!(
+        state.latest_updated_at.as_deref(),
+        Some("2025-01-01T00:00:00+09:00"),
+        "[T-005] latest_updated_at should roundtrip"
+    );
+    assert_eq!(state.total_count, 100, "[T-005] total_count should be 100");
+    assert_eq!(state.local_count, 50, "[T-005] local_count should be 50");
+    assert_eq!(
+        state.last_page,
+        Some(3),
+        "[T-005] last_page should be Some(3)"
+    );
+}
+
+/// [T-005] save_sync_state with None optionals
+#[test]
+fn t_005_save_sync_state_none_optionals() {
+    let db = Db::open_memory().unwrap();
+
+    let update = SyncStateUpdate {
+        latest_updated_at: None,
+        total_count: 0,
+        local_count: 0,
+        last_page: None,
+    };
+
+    save_sync_state(db.conn(), &update).unwrap();
+
+    let state = get_sync_state(db.conn()).unwrap().unwrap();
+    assert_eq!(
+        state.latest_updated_at, None,
+        "[T-005] latest_updated_at should be None"
+    );
+    assert_eq!(
+        state.last_page, None,
+        "[T-005] last_page should be None"
+    );
+}
+
+/// [T-005] SyncStateUpdate borrows from caller's Option<String> via .as_deref()
+#[test]
+fn t_005_sync_state_update_borrows_from_option_string() {
+    let db = Db::open_memory().unwrap();
+
+    // Simulate caller holding Option<String> and borrowing via .as_deref()
+    let owned: Option<String> = Some("2025-06-01T12:00:00+09:00".to_string());
+    let update = SyncStateUpdate {
+        latest_updated_at: owned.as_deref(),
+        total_count: 200,
+        local_count: 150,
+        last_page: Some(5),
+    };
+
+    save_sync_state(db.conn(), &update).unwrap();
+
+    let state = get_sync_state(db.conn()).unwrap().unwrap();
+    assert_eq!(
+        state.latest_updated_at.as_deref(),
+        Some("2025-06-01T12:00:00+09:00"),
+        "[T-005] borrowed value should persist correctly"
+    );
+    assert_eq!(state.total_count, 200);
+    assert_eq!(state.local_count, 150);
+    assert_eq!(state.last_page, Some(5));
+}


### PR DESCRIPTION
Resolves #31

## 概要

- マイグレーション中に発見した3件のストレージ層バグを修正: `vec_search` の sqlite-vec auxiliary column JOIN エラー（2ステップ KNN + batch fetch に分割）、`rechunk_post` エラーパスの SAVEPOINT RELEASE リーク、`sync_state` 行が存在しない場合の `Synced` ステータス誤報
- embed API を `ChunkedEmbedding` / `download_model(ModelId)` / `cached_artifacts` / `Artifacts` に移行; スキーマを v5 に更新し、マルチチャンク埋め込み対応の `embedded_chunk_ids` テーブルを追加
- `archive`、`data`、`post`、`search`、`status` コマンドハンドラを `main.rs` から `src/commands/` モジュールに分離; `tests/` にインテグレーションテストを追加

## テスト計画

- [ ] `cargo test` が通る — TC-002/TC-004/TC-008/TC-009（検索正確性）、マルチチャンク sub-embedding ストレージ、重複 embed ガード、SAVEPOINT リークパスをカバー
- [ ] `cargo build --release` が rurico rev 568eda5 に対して成功する
- [ ] `sync_state` 行のないローカル DB で `sae status` を実行 — `Synced` と報告されないことを確認
- [ ] `sae sync` を完了まで実行 — 埋め込みが保存され `sae search <query>` が結果を返すことを確認
- [ ] スキーマ移行の検証: 既存の v4 DB を開き、`sae` が v5 にデータロスなく再作成することを確認