### PR TITLE
output関数をString返却に変更し、stdoutをmainに一元化

### DIFF
--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -21,39 +21,35 @@ pub(crate) async fn run_archive(
     team: Option<&str>,
     dry_run: bool,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     let (team, client) = resolve_client(config, team)?;
     let post = client.get_post(team, number).await?;
     let new_category = match archive_category(post.category.as_deref()) {
         Some(c) => c,
         None if dry_run => {
-            crate::output::dry_run(&serde_json::json!({
+            return crate::output::dry_run(&serde_json::json!({
                 "number": number,
                 "already_archived": true,
                 "category": post.category.as_deref().unwrap_or(""),
-            }))?;
-            return Ok(());
+            }));
         }
         None => {
-            crate::output::action_result("Already archived", &post, json)?;
-            return Ok(());
+            return crate::output::action_result("Already archived", &post, json);
         }
     };
     if dry_run {
-        crate::output::dry_run(&serde_json::json!({
+        return crate::output::dry_run(&serde_json::json!({
             "number": number,
             "from_category": post.category.as_deref().unwrap_or(""),
             "to_category": new_category,
-        }))?;
-        return Ok(());
+        }));
     }
     let params = UpdatePostParams {
         category: Some(&new_category),
         ..Default::default()
     };
     let post = client.update_post(team, number, &params).await?;
-    crate::output::action_result("Archived", &post, json)?;
-    Ok(())
+    crate::output::action_result("Archived", &post, json)
 }
 
 pub(crate) async fn run_ship(
@@ -62,13 +58,12 @@ pub(crate) async fn run_ship(
     team: Option<&str>,
     dry_run: bool,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     if dry_run {
-        crate::output::dry_run(&serde_json::json!({
+        return crate::output::dry_run(&serde_json::json!({
             "number": number,
             "wip": false,
-        }))?;
-        return Ok(());
+        }));
     }
     let (team, client) = resolve_client(config, team)?;
     let params = UpdatePostParams {
@@ -76,8 +71,7 @@ pub(crate) async fn run_ship(
         ..Default::default()
     };
     let post = client.update_post(team, number, &params).await?;
-    crate::output::action_result("Shipped", &post, json)?;
-    Ok(())
+    crate::output::action_result("Shipped", &post, json)
 }
 
 #[cfg(test)]

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -8,16 +8,15 @@ pub(crate) async fn run_harvest(
     team: &str,
     full: bool,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     let (team, client) = resolve_client(config, Some(team))?;
     let db_path = config.team_db_path(team)?;
     let db = sae::storage::Db::open(&db_path)?;
     let result = sae::sync::harvest(&client, &db, team, full).await?;
-    crate::output::harvest(&result, json)?;
-    Ok(())
+    crate::output::harvest(&result, json)
 }
 
-pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), AppError> {
+pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<String, AppError> {
     use rurico::embed::Embed;
 
     let team = config.resolve_team(Some(team))?;
@@ -30,13 +29,13 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), A
 
     const BATCH_SIZE: u32 = 64;
     let mut total_added = 0u32;
-    let mut done = 0u32;
+    let mut total_chunks = 0u32;
     loop {
         let batch = sae::storage::get_unembedded_chunks(db.conn(), BATCH_SIZE)?;
         if batch.is_empty() {
             break;
         }
-        if done == 0 {
+        if total_chunks == 0 {
             tracing::info!("Embedding chunks...");
         }
         let texts: Vec<&str> = batch.iter().map(|(_, content)| content.as_str()).collect();
@@ -46,27 +45,24 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<(), A
             .map_err(|e| format!("Batch embedding failed: {e}"))?;
         let embeddings: Vec<(i64, _)> = batch.iter().map(|(id, _)| *id).zip(embs).collect();
         total_added += sae::storage::add_chunked_embeddings(db.conn(), &embeddings)?;
-        done += batch_len;
-        tracing::info!("  {done} chunks processed");
+        total_chunks += batch_len;
+        tracing::info!("  {total_chunks} chunks processed");
     }
     let result = sae::storage::EmbedResult {
         chunks_embedded: total_added,
     };
-    crate::output::embed(&result, done, json)?;
-    Ok(())
+    crate::output::embed(&result, total_chunks, json)
 }
 
-pub(crate) fn run_model_download(json: bool) -> Result<(), AppError> {
+pub(crate) fn run_model_download(json: bool) -> Result<String, AppError> {
     eprintln!("Downloading model...");
     let paths = rurico::embed::download_model(ModelId::default())
         .map_err(|e| format!("Failed to download model: {e}"))?;
     let _embedder = Embedder::new(&paths).map_err(|e| format!("Failed to verify model: {e}"))?;
-    crate::output::model_download(json)?;
-    Ok(())
+    crate::output::model_download(json)
 }
 
-pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, Box<dyn std::error::Error>>
-{
+pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, AppError> {
     let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
     require_embed_model_with(auto_download, || {
         rurico::embed::cached_artifacts(ModelId::default())
@@ -76,9 +72,10 @@ pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, Box<dyn 
 fn require_embed_model_with<E: std::fmt::Display>(
     auto_download: bool,
     cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
-) -> Result<rurico::embed::Artifacts, Box<dyn std::error::Error>> {
+) -> Result<rurico::embed::Artifacts, AppError> {
     if auto_download {
         eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
+        // Embedder::new verification skipped: caller (run_embed) calls it immediately after
         return rurico::embed::download_model(ModelId::default())
             .map_err(|e| format!("Failed to download model: {e}").into());
     }

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -5,14 +5,31 @@ use sae::config::Config;
 
 use crate::{AppError, resolve_client};
 
+#[derive(Debug, clap::Args)]
 pub(crate) struct CreateArgs {
+    /// Post title
+    #[arg(long)]
     pub(crate) name: String,
+    /// Post body (Markdown)
+    #[arg(long, conflicts_with = "body_file")]
     pub(crate) body: Option<String>,
+    /// Read body from file (use "-" for stdin)
+    #[arg(long, conflicts_with = "body")]
     pub(crate) body_file: Option<String>,
+    /// Category path
+    #[arg(long)]
     pub(crate) category: Option<String>,
+    /// Tags
+    #[arg(long)]
     pub(crate) tag: Vec<String>,
+    /// Mark as WIP
+    #[arg(long)]
     pub(crate) wip: bool,
+    /// Team name
+    #[arg(long)]
     pub(crate) team: Option<String>,
+    /// Preview without creating (no mutation API calls)
+    #[arg(long)]
     pub(crate) dry_run: bool,
 }
 
@@ -55,14 +72,30 @@ pub(crate) async fn run_create(
     crate::output::action_result("Created", &post, json)
 }
 
+#[derive(Debug, clap::Args)]
 pub(crate) struct UpdateArgs {
+    /// Post number
     pub(crate) number: u32,
+    /// New title
+    #[arg(long)]
     pub(crate) name: Option<String>,
+    /// New body (Markdown)
+    #[arg(long, conflicts_with = "body_file")]
     pub(crate) body: Option<String>,
+    /// Read body from file (use "-" for stdin)
+    #[arg(long, conflicts_with = "body")]
     pub(crate) body_file: Option<String>,
+    /// New category path
+    #[arg(long)]
     pub(crate) category: Option<String>,
+    /// New tags (replaces existing)
+    #[arg(long)]
     pub(crate) tag: Vec<String>,
+    /// Team name
+    #[arg(long)]
     pub(crate) team: Option<String>,
+    /// Preview without updating (no mutation API calls)
+    #[arg(long)]
     pub(crate) dry_run: bool,
 }
 

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -22,28 +22,26 @@ pub(crate) async fn run_get(
     team: Option<&str>,
     with_body: bool,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     let (team, client) = resolve_client(config, team)?;
     let post = client.get_post(team, number).await?;
-    crate::output::get(&post, json, with_body)?;
-    Ok(())
+    crate::output::get(&post, json, with_body)
 }
 
 pub(crate) async fn run_create(
     config: &Config,
     args: CreateArgs,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     if args.dry_run {
-        crate::output::dry_run(&serde_json::json!({
+        return crate::output::dry_run(&serde_json::json!({
             "name": args.name,
             "body_md": resolved_body,
             "category": args.category,
             "tags": args.tag,
             "wip": args.wip,
-        }))?;
-        return Ok(());
+        }));
     }
     let (team, client) = resolve_client(config, args.team.as_deref())?;
     let params = CreatePostParams {
@@ -54,8 +52,7 @@ pub(crate) async fn run_create(
         wip: args.wip,
     };
     let post = client.create_post(team, &params).await?;
-    crate::output::action_result("Created", &post, json)?;
-    Ok(())
+    crate::output::action_result("Created", &post, json)
 }
 
 pub(crate) struct UpdateArgs {
@@ -73,7 +70,7 @@ pub(crate) async fn run_update(
     config: &Config,
     args: UpdateArgs,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     let tags: Option<Vec<String>> = if args.tag.is_empty() {
         None
@@ -81,14 +78,13 @@ pub(crate) async fn run_update(
         Some(args.tag)
     };
     if args.dry_run {
-        crate::output::dry_run(&serde_json::json!({
+        return crate::output::dry_run(&serde_json::json!({
             "number": args.number,
             "name": args.name,
             "body_md": resolved_body,
             "category": args.category,
             "tags": tags.as_deref(),
-        }))?;
-        return Ok(());
+        }));
     }
     let (team, client) = resolve_client(config, args.team.as_deref())?;
     let params = UpdatePostParams {
@@ -99,14 +95,13 @@ pub(crate) async fn run_update(
         ..Default::default()
     };
     let post = client.update_post(team, args.number, &params).await?;
-    crate::output::action_result("Updated", &post, json)?;
-    Ok(())
+    crate::output::action_result("Updated", &post, json)
 }
 
 pub(crate) fn resolve_body(
     body: Option<&str>,
     body_file: Option<&str>,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
+) -> Result<Option<String>, AppError> {
     let mut stdin = std::io::stdin();
     resolve_body_with_reader(body, body_file, &mut stdin)
 }
@@ -115,7 +110,7 @@ pub(crate) fn resolve_body_with_reader(
     body: Option<&str>,
     body_file: Option<&str>,
     stdin: &mut impl Read,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
+) -> Result<Option<String>, AppError> {
     match (body, body_file) {
         (Some(b), None) => Ok(Some(b.to_string())),
         (None, Some("-")) => {

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -11,7 +11,7 @@ pub(crate) fn run_search(
     team: Option<&str>,
     limit: u32,
     json: bool,
-) -> Result<(), AppError> {
+) -> Result<String, AppError> {
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
     let embedder = try_load_embedder();
@@ -30,8 +30,8 @@ pub(crate) fn run_search(
         limit,
         chrono::Utc::now(),
     )?;
-    crate::output::search(&results, query, json)?;
-    Ok(())
+    let semantic = query_embedding.is_some();
+    crate::output::search(&results, query, json, semantic)
 }
 
 pub(crate) fn try_load_embedder() -> Option<Embedder> {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -3,7 +3,11 @@ use sae::storage::TeamStatus;
 
 use crate::AppError;
 
-pub(crate) fn run_status(config: &Config, team: Option<&str>, json: bool) -> Result<(), AppError> {
+pub(crate) fn run_status(
+    config: &Config,
+    team: Option<&str>,
+    json: bool,
+) -> Result<String, AppError> {
     let target_teams: Vec<&str> = if let Some(t) = team {
         vec![config.resolve_team(Some(t))?]
     } else {
@@ -21,14 +25,10 @@ pub(crate) fn run_status(config: &Config, team: Option<&str>, json: bool) -> Res
             .collect()
     };
     let statuses = collect_team_statuses(config, &target_teams)?;
-    crate::output::status(&statuses, json)?;
-    Ok(())
+    crate::output::status(&statuses, json)
 }
 
-fn collect_team_statuses(
-    config: &Config,
-    teams: &[&str],
-) -> Result<Vec<TeamStatus>, Box<dyn std::error::Error>> {
+fn collect_team_statuses(config: &Config, teams: &[&str]) -> Result<Vec<TeamStatus>, AppError> {
     let mut statuses = Vec::new();
     for t in teams {
         let ts = match config.team_db_path(t) {
@@ -44,10 +44,7 @@ fn collect_team_statuses(
     Ok(statuses)
 }
 
-fn query_team_status(
-    team: &str,
-    path: &std::path::Path,
-) -> Result<TeamStatus, Box<dyn std::error::Error>> {
+fn query_team_status(team: &str, path: &std::path::Path) -> Result<TeamStatus, AppError> {
     let db = sae::storage::Db::open(path)?;
     let count = sae::storage::count_posts(db.conn())?;
     let state = sae::storage::get_sync_state(db.conn())?;
@@ -61,6 +58,25 @@ fn query_team_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_post_row() -> sae::storage::EsaPostRow {
+        sae::storage::EsaPostRow {
+            number: 1,
+            name: "Post 1".into(),
+            full_name: "dev/Post 1".into(),
+            body_md: "# Post 1".into(),
+            category: None,
+            tags: vec![],
+            wip: false,
+            kind: "stock".into(),
+            url: "https://example.esa.io/posts/1".into(),
+            created_at: "2025-01-01T00:00:00+09:00".into(),
+            updated_at: "2025-01-01T00:00:00+09:00".into(),
+            created_by: "alice".into(),
+            updated_by: "alice".into(),
+            revision_number: 1,
+        }
+    }
 
     // T-007: at least 1 test co-located with status handlers
     #[test]
@@ -79,26 +95,7 @@ mod tests {
         let path = dir.path().join("test.db");
         {
             let db = sae::storage::Db::open(&path).unwrap();
-            sae::storage::upsert_post(
-                db.conn(),
-                &sae::storage::EsaPostRow {
-                    number: 1,
-                    name: "Post 1".into(),
-                    full_name: "dev/Post 1".into(),
-                    body_md: "# Post 1".into(),
-                    category: None,
-                    tags: vec![],
-                    wip: false,
-                    kind: "stock".into(),
-                    url: "https://example.esa.io/posts/1".into(),
-                    created_at: "2025-01-01T00:00:00+09:00".into(),
-                    updated_at: "2025-01-01T00:00:00+09:00".into(),
-                    created_by: "alice".into(),
-                    updated_by: "alice".into(),
-                    revision_number: 1,
-                },
-            )
-            .unwrap();
+            sae::storage::upsert_post(db.conn(), &make_post_row()).unwrap();
             sae::storage::save_sync_state(
                 db.conn(),
                 &sae::storage::SyncStateUpdate {
@@ -136,26 +133,7 @@ mod tests {
         let path = dir.path().join("test.db");
         {
             let db = sae::storage::Db::open(&path).unwrap();
-            sae::storage::upsert_post(
-                db.conn(),
-                &sae::storage::EsaPostRow {
-                    number: 1,
-                    name: "Post 1".into(),
-                    full_name: "dev/Post 1".into(),
-                    body_md: "# Post 1".into(),
-                    category: None,
-                    tags: vec![],
-                    wip: false,
-                    kind: "stock".into(),
-                    url: "https://example.esa.io/posts/1".into(),
-                    created_at: "2025-01-01T00:00:00+09:00".into(),
-                    updated_at: "2025-01-01T00:00:00+09:00".into(),
-                    created_by: "alice".into(),
-                    updated_by: "alice".into(),
-                    revision_number: 1,
-                },
-            )
-            .unwrap();
+            sae::storage::upsert_post(db.conn(), &make_post_row()).unwrap();
             // sync_state intentionally NOT saved
         }
         let ts = query_team_status("myteam", &path).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,30 +74,8 @@ Examples:
   cat body.md | sae create --name \"Title\" --body-file -
   sae create --name \"Title\" --dry-run")]
     Create {
-        /// Post title
-        #[arg(long)]
-        name: String,
-        /// Post body (Markdown)
-        #[arg(long, conflicts_with = "body_file")]
-        body: Option<String>,
-        /// Read body from file (use "-" for stdin)
-        #[arg(long, conflicts_with = "body")]
-        body_file: Option<String>,
-        /// Category path
-        #[arg(long)]
-        category: Option<String>,
-        /// Tags
-        #[arg(long)]
-        tag: Vec<String>,
-        /// Mark as WIP
-        #[arg(long)]
-        wip: bool,
-        /// Team name
-        #[arg(long)]
-        team: Option<String>,
-        /// Preview without creating (no mutation API calls)
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        args: commands::post::CreateArgs,
     },
     /// Update a post
     #[command(after_help = "\
@@ -106,29 +84,8 @@ Examples:
   sae update 42 --body-file updated.md
   sae update 42 --name \"New Title\" --dry-run")]
     Update {
-        /// Post number
-        number: u32,
-        /// New title
-        #[arg(long)]
-        name: Option<String>,
-        /// New body (Markdown)
-        #[arg(long, conflicts_with = "body_file")]
-        body: Option<String>,
-        /// Read body from file (use "-" for stdin)
-        #[arg(long, conflicts_with = "body")]
-        body_file: Option<String>,
-        /// New category path
-        #[arg(long)]
-        category: Option<String>,
-        /// New tags (replaces existing)
-        #[arg(long)]
-        tag: Vec<String>,
-        /// Team name
-        #[arg(long)]
-        team: Option<String>,
-        /// Preview without updating (no mutation API calls)
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        args: commands::post::UpdateArgs,
     },
     /// Archive a post
     #[command(after_help = "\
@@ -200,26 +157,23 @@ enum ModelCommand {
     Download,
 }
 
+const KNOWN_SUBCOMMANDS: &[&str] = &[
+    "harvest", "search", "get", "create", "update", "archive", "ship", "embed", "status", "model",
+];
+const GLOBAL_FLAGS: &[&str] = &["--json"];
+
 fn parse_cli_args<I, T>(args: I) -> Result<Cli, clap::Error>
 where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
     let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-    let cmd = Cli::command();
-    let known: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
-    let global_flags: Vec<String> = cmd
-        .get_arguments()
-        .filter(|a| a.is_global_set())
-        .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
-        .collect();
-    let global_flag_refs: Vec<&str> = global_flags.iter().map(String::as_str).collect();
-    if let Some(expanded) = shorthand::try_expand_shorthand(&args, &known, &global_flag_refs)
-        && let Ok(cli) = Cli::try_parse_from(expanded.clone())
+    if let Some(expanded) =
+        shorthand::try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS)
     {
         let display: Vec<_> = expanded.iter().filter_map(|a| a.to_str()).collect();
         eprintln!("→ {}", display.join(" "));
-        return Ok(cli);
+        return Cli::try_parse_from(expanded);
     }
     Cli::try_parse_from(args)
 }
@@ -269,58 +223,8 @@ async fn main() -> Result<(), AppError> {
             team,
             with_body,
         } => commands::post::run_get(&config, number, team.as_deref(), with_body, json).await?,
-        Command::Create {
-            name,
-            body,
-            body_file,
-            category,
-            tag,
-            wip,
-            team,
-            dry_run,
-        } => {
-            commands::post::run_create(
-                &config,
-                commands::post::CreateArgs {
-                    name,
-                    body,
-                    body_file,
-                    category,
-                    tag,
-                    wip,
-                    team,
-                    dry_run,
-                },
-                json,
-            )
-            .await?
-        }
-        Command::Update {
-            number,
-            name,
-            body,
-            body_file,
-            category,
-            tag,
-            team,
-            dry_run,
-        } => {
-            commands::post::run_update(
-                &config,
-                commands::post::UpdateArgs {
-                    number,
-                    name,
-                    body,
-                    body_file,
-                    category,
-                    tag,
-                    team,
-                    dry_run,
-                },
-                json,
-            )
-            .await?
-        }
+        Command::Create { args } => commands::post::run_create(&config, args, json).await?,
+        Command::Update { args } => commands::post::run_update(&config, args, json).await?,
         Command::Embed { team } => commands::data::run_embed(&config, &team, json)?,
         Command::Archive {
             number,
@@ -402,9 +306,9 @@ mod tests {
     fn create_with_dry_run_parses_dry_run_flag() {
         let cli = parse_cli_args(["sae", "create", "--name", "Test Post", "--dry-run"]).unwrap();
         match cli.command {
-            Command::Create { name, dry_run, .. } => {
-                assert_eq!(name, "Test Post", "[T-038] name should match");
-                assert!(dry_run, "[T-038] dry_run should be true");
+            Command::Create { args } => {
+                assert_eq!(args.name, "Test Post", "[T-038] name should match");
+                assert!(args.dry_run, "[T-038] dry_run should be true");
             }
             other => panic!("[T-038] expected Create, got {other:?}"),
         }
@@ -415,9 +319,9 @@ mod tests {
         let cli =
             parse_cli_args(["sae", "create", "--name", "Stdin Post", "--body-file", "-"]).unwrap();
         match cli.command {
-            Command::Create { body_file, .. } => {
+            Command::Create { args } => {
                 assert_eq!(
-                    body_file.as_deref(),
+                    args.body_file.as_deref(),
                     Some("-"),
                     "[T-040] body_file should be \"-\" for stdin"
                 );
@@ -596,10 +500,10 @@ mod tests {
     fn update_with_name_parses_correctly() {
         let cli = parse_cli_args(["sae", "update", "42", "--name", "New Title"]).unwrap();
         match cli.command {
-            Command::Update { number, name, .. } => {
-                assert_eq!(number, 42, "[T-052] post number should be 42");
+            Command::Update { args } => {
+                assert_eq!(args.number, 42, "[T-052] post number should be 42");
                 assert_eq!(
-                    name.as_deref(),
+                    args.name.as_deref(),
                     Some("New Title"),
                     "[T-052] name should match"
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod commands;
 mod output;
 mod shorthand;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use sae::client::EsaClient;
 use sae::config::Config;
 
@@ -252,6 +252,7 @@ async fn main() -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     fn subcommand_after_help(name: &str) -> String {
         let mut command = Cli::command();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
+#![warn(unreachable_pub)]
+
 mod commands;
 mod output;
+mod shorthand;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use sae::client::EsaClient;
@@ -203,55 +206,21 @@ where
     T: Into<std::ffi::OsString> + Clone,
 {
     let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-
-    // Shorthand: `sae "query"` or `sae --json "query" --limit 2` → `sae [flags] search "query" --limit 2`
-    // Pre-filter: only build command tree when non-flag arg count suggests shorthand is possible.
-    let positional_count = args
-        .iter()
-        .filter(|a| !a.to_str().is_some_and(|s| s.starts_with('-')))
-        .count();
-
-    if positional_count >= 2 {
-        let cmd = Cli::command();
-        let known: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
-        let global_flags: Vec<String> = cmd
-            .get_arguments()
-            .filter(|a| a.is_global_set())
-            .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
-            .collect();
-
-        let (flags, rest): (Vec<_>, Vec<_>) = args.iter().enumerate().partition(|(i, a)| {
-            *i > 0
-                && a.to_str()
-                    .is_some_and(|s| global_flags.iter().any(|f| f == s))
-        });
-        let rest: Vec<&std::ffi::OsString> = rest.into_iter().map(|(_, a)| a).collect();
-
-        if rest.len() >= 2
-            && let Some(first_arg) = rest[1].to_str()
-            && !first_arg.starts_with('-')
-            && first_arg != "help"
-            && !known.contains(&first_arg)
-            && !known
-                .iter()
-                .any(|k| strsim::osa_distance(first_arg, k) <= 1)
-        {
-            let mut expanded: Vec<std::ffi::OsString> = vec![rest[0].clone()];
-            for (_, f) in &flags {
-                expanded.push((*f).clone());
-            }
-            expanded.push("search".into());
-            for arg in &rest[1..] {
-                expanded.push((*arg).clone());
-            }
-            if let Ok(cli) = Cli::try_parse_from(expanded.clone()) {
-                let display: Vec<_> = expanded.iter().filter_map(|a| a.to_str()).collect();
-                eprintln!("→ {}", display.join(" "));
-                return Ok(cli);
-            }
-        }
+    let cmd = Cli::command();
+    let known: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
+    let global_flags: Vec<String> = cmd
+        .get_arguments()
+        .filter(|a| a.is_global_set())
+        .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
+        .collect();
+    let global_flag_refs: Vec<&str> = global_flags.iter().map(String::as_str).collect();
+    if let Some(expanded) = shorthand::try_expand_shorthand(&args, &known, &global_flag_refs)
+        && let Ok(cli) = Cli::try_parse_from(expanded.clone())
+    {
+        let display: Vec<_> = expanded.iter().filter_map(|a| a.to_str()).collect();
+        eprintln!("→ {}", display.join(" "));
+        return Ok(cli);
     }
-
     Cli::try_parse_from(args)
 }
 
@@ -287,19 +256,19 @@ async fn main() -> Result<(), AppError> {
     let config = Config::load()?;
     let json = cli.json;
 
-    match cli.command {
+    let output = match cli.command {
         Command::Harvest { team, full } => {
-            commands::data::run_harvest(&config, &team, full, json).await
+            commands::data::run_harvest(&config, &team, full, json).await?
         }
         Command::Search { query, team, limit } => {
             let query = commands::search::resolve_search_query(query)?;
-            commands::search::run_search(&config, &query, team.as_deref(), limit, json)
+            commands::search::run_search(&config, &query, team.as_deref(), limit, json)?
         }
         Command::Get {
             number,
             team,
             with_body,
-        } => commands::post::run_get(&config, number, team.as_deref(), with_body, json).await,
+        } => commands::post::run_get(&config, number, team.as_deref(), with_body, json).await?,
         Command::Create {
             name,
             body,
@@ -324,7 +293,7 @@ async fn main() -> Result<(), AppError> {
                 },
                 json,
             )
-            .await
+            .await?
         }
         Command::Update {
             number,
@@ -350,24 +319,30 @@ async fn main() -> Result<(), AppError> {
                 },
                 json,
             )
-            .await
+            .await?
         }
-        Command::Embed { team } => commands::data::run_embed(&config, &team, json),
+        Command::Embed { team } => commands::data::run_embed(&config, &team, json)?,
         Command::Archive {
             number,
             team,
             dry_run,
-        } => commands::archive::run_archive(&config, number, team.as_deref(), dry_run, json).await,
+        } => {
+            commands::archive::run_archive(&config, number, team.as_deref(), dry_run, json).await?
+        }
         Command::Ship {
             number,
             team,
             dry_run,
-        } => commands::archive::run_ship(&config, number, team.as_deref(), dry_run, json).await,
-        Command::Status { team } => commands::status::run_status(&config, team.as_deref(), json),
+        } => commands::archive::run_ship(&config, number, team.as_deref(), dry_run, json).await?,
+        Command::Status { team } => commands::status::run_status(&config, team.as_deref(), json)?,
         Command::Model { command } => match command {
-            ModelCommand::Download => commands::data::run_model_download(json),
+            ModelCommand::Download => commands::data::run_model_download(json)?,
         },
+    };
+    if !output.is_empty() {
+        println!("{output}");
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -384,16 +359,6 @@ mod tests {
             .unwrap_or_default()
     }
 
-    // T-029: shorthand `sae "認証"` → search
-    #[test]
-    fn shorthand_single_query_becomes_search() {
-        let cli = parse_cli_args(["sae", "認証"]).unwrap();
-        match cli.command {
-            Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("認証")),
-            other => panic!("expected Search, got {other:?}"),
-        }
-    }
-
     // T-030: explicit `sae search "認証"` is not double-injected
     #[test]
     fn explicit_search_not_double_injected() {
@@ -401,16 +366,6 @@ mod tests {
         match cli.command {
             Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("認証")),
             other => panic!("expected Search, got {other:?}"),
-        }
-    }
-
-    // T-031: `sae harvest team` stays as harvest
-    #[test]
-    fn known_subcommand_not_shorthand() {
-        let cli = parse_cli_args(["sae", "harvest", "myteam"]).unwrap();
-        match cli.command {
-            Command::Harvest { team, .. } => assert_eq!(team, "myteam"),
-            other => panic!("expected Harvest, got {other:?}"),
         }
     }
 
@@ -539,16 +494,6 @@ mod tests {
         }
     }
 
-    // TC-011: flag-like argument not treated as shorthand query
-    #[test]
-    fn flag_like_arg_not_shorthand() {
-        let result = parse_cli_args(["sae", "--unknown"]);
-        assert!(
-            result.is_err(),
-            "[TC-011] --unknown should be clap error, not search shorthand"
-        );
-    }
-
     // T-001: `sae model download` parses to Command::Model { ModelCommand::Download }
     #[test]
     fn model_download_parses_correctly() {
@@ -596,72 +541,6 @@ mod tests {
         }
     }
 
-    // T-022: `sae "query" --limit 2` → Command::Search with limit=2
-    #[test]
-    fn shorthand_with_limit_option() {
-        let cli = parse_cli_args(["sae", "query", "--limit", "2"]).unwrap();
-        match cli.command {
-            Command::Search { query, limit, .. } => {
-                assert_eq!(
-                    query.as_deref(),
-                    Some("query"),
-                    "[T-022] query should match"
-                );
-                assert_eq!(limit, 2, "[T-022] limit should be 2");
-            }
-            other => panic!("[T-022] expected Search, got {other:?}"),
-        }
-    }
-
-    // T-023: `sae --json "query" --limit 2` → json=true + Command::Search with limit=2
-    #[test]
-    fn shorthand_with_json_and_limit() {
-        let cli = parse_cli_args(["sae", "--json", "query", "--limit", "2"]).unwrap();
-        assert!(cli.json, "[T-023] json should be true");
-        match cli.command {
-            Command::Search { query, limit, .. } => {
-                assert_eq!(
-                    query.as_deref(),
-                    Some("query"),
-                    "[T-023] query should match"
-                );
-                assert_eq!(limit, 2, "[T-023] limit should be 2");
-            }
-            other => panic!("[T-023] expected Search, got {other:?}"),
-        }
-    }
-
-    // T-024: `sae "query" --team myteam` → Command::Search with team=Some("myteam")
-    #[test]
-    fn shorthand_with_team_option() {
-        let cli = parse_cli_args(["sae", "query", "--team", "myteam"]).unwrap();
-        match cli.command {
-            Command::Search { query, team, .. } => {
-                assert_eq!(
-                    query.as_deref(),
-                    Some("query"),
-                    "[T-024] query should match"
-                );
-                assert_eq!(
-                    team.as_deref(),
-                    Some("myteam"),
-                    "[T-024] team should be myteam"
-                );
-            }
-            other => panic!("[T-024] expected Search, got {other:?}"),
-        }
-    }
-
-    // T-025: `sae serach` → clap error (OSA distance ≤ 1 guard blocks shorthand)
-    #[test]
-    fn typo_near_subcommand_is_clap_error() {
-        let result = parse_cli_args(["sae", "serach"]);
-        assert!(
-            result.is_err(),
-            "[T-025] typo 'serach' (osa=1 from 'search') should be clap error"
-        );
-    }
-
     // TC-012: multi-positional args without valid search expansion → clap error
     #[test]
     fn multi_positional_args_not_shorthand() {
@@ -669,16 +548,6 @@ mod tests {
         assert!(
             result.is_err(),
             "two positional args should be clap error, not shorthand"
-        );
-    }
-
-    // TC-013: bare dash is not treated as shorthand
-    #[test]
-    fn bare_dash_not_shorthand() {
-        let result = parse_cli_args(["sae", "-"]);
-        assert!(
-            result.is_err(),
-            "`sae -` should be clap error, not shorthand query"
         );
     }
 
@@ -814,6 +683,4 @@ mod tests {
             );
         }
     }
-
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,9 +168,8 @@ where
     T: Into<std::ffi::OsString> + Clone,
 {
     let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-    if let Some(expanded) =
-        shorthand::try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS)
-    {
+    let expanded = shorthand::try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS);
+    if let Some(expanded) = expanded {
         let display: Vec<_> = expanded.iter().filter_map(|a| a.to_str()).collect();
         eprintln!("→ {}", display.join(" "));
         return Cli::try_parse_from(expanded);

--- a/src/output.rs
+++ b/src/output.rs
@@ -58,9 +58,11 @@ pub(crate) fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<String,
         if with_body {
             format_json(post)
         } else {
-            let mut post = post.clone();
-            post.body_md = None;
-            format_json(&post)
+            let mut val = serde_json::to_value(post)?;
+            if let Some(obj) = val.as_object_mut() {
+                obj.remove("body_md");
+            }
+            format_json(&val)
         }
     } else {
         Ok(format_post_frontmatter(post))

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,169 +2,186 @@ use sae::client::EsaPost;
 use sae::storage::{EmbedResult, SearchResult, SyncStatus, TeamStatus};
 use sae::sync::HarvestResult;
 
-fn print_json<T: serde::Serialize + ?Sized>(val: &T) -> Result<(), Box<dyn std::error::Error>> {
-    println!("{}", serde_json::to_string(val)?);
-    Ok(())
+use crate::AppError;
+
+fn format_json<T: serde::Serialize + ?Sized>(val: &T) -> Result<String, AppError> {
+    Ok(serde_json::to_string(val)?)
 }
 
-pub fn harvest(result: &HarvestResult, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn harvest(result: &HarvestResult, json: bool) -> Result<String, AppError> {
     if json {
-        print_json(result)?;
+        format_json(result)
     } else {
-        println!("{result}");
+        Ok(result.to_string())
     }
-    Ok(())
 }
 
-pub fn search(
+pub(crate) fn search(
     results: &[SearchResult],
     query: &str,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+    semantic: bool,
+) -> Result<String, AppError> {
+    let search_mode = if semantic { "hybrid" } else { "fts" };
     if json {
-        print_json(results)?;
+        format_json(&serde_json::json!({
+            "search_mode": search_mode,
+            "results": results,
+        }))
     } else if results.is_empty() {
-        println!("No results for '{query}'");
+        Ok(format!("No results for '{query}'"))
     } else {
+        let mut lines = Vec::new();
+        if !semantic {
+            lines.push("(semantic search unavailable, showing text-match results)".to_string());
+        }
         for r in results {
             let section = r
                 .section_title
                 .as_deref()
                 .map(|s| format!(" > {s}"))
                 .unwrap_or_default();
-            println!(
+            lines.push(format!(
                 "[{:.4}] {}{} (#{})  {}",
                 r.score, r.post_name, section, r.post_number, r.post_url
-            );
+            ));
             if !r.snippet.is_empty() {
-                println!("  {}", r.snippet.replace('\n', " "));
+                lines.push(format!("  {}", r.snippet.replace('\n', " ")));
             }
         }
+        Ok(lines.join("\n"))
     }
-    Ok(())
 }
 
-pub fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<String, AppError> {
     if json {
-        let mut post = post.clone();
-        if !with_body {
-            post.body_md = None;
-        }
-        print_json(&post)?;
-    } else {
-        println!("---");
-        println!("title: \"{}\"", post.full_name.replace('"', "\\\""));
-        if let Some(ref cat) = post.category
-            && !cat.is_empty()
-        {
-            println!("category: \"{}\"", cat.replace('"', "\\\""));
-        }
-        if !post.tags.is_empty() {
-            let tags: Vec<String> = post
-                .tags
-                .iter()
-                .map(|t| format!("\"{}\"", t.replace('"', "\\\"")))
-                .collect();
-            println!("tags: [{}]", tags.join(", "));
-        }
-        println!("author: \"@{}\"", post.created_by.screen_name);
-        if post.updated_by.screen_name != post.created_by.screen_name {
-            println!("updated_by: \"@{}\"", post.updated_by.screen_name);
-        }
-        println!("updated_at: \"{}\"", post.updated_at);
-        if post.wip {
-            println!("wip: true");
-        }
-        println!("number: {}", post.number);
-        println!("url: {}", post.url);
-        println!("---");
-        println!();
-        println!("{}", post.body_md.as_deref().unwrap_or("(empty)"));
-    }
-    Ok(())
-}
-
-pub fn action_result(
-    action: &str,
-    post: &EsaPost,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if json {
-        print_json(post)?;
-    } else {
-        println!("{action}: {} (#{}) {}", post.name, post.number, post.url);
-    }
-    Ok(())
-}
-
-pub fn embed(
-    result: &EmbedResult,
-    done: u32,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if json {
-        print_json(result)?;
-    } else if result.chunks_embedded == 0 {
-        if done == 0 {
-            println!("Nothing to embed");
+        if with_body {
+            format_json(post)
         } else {
-            println!("All {done} chunks already embedded");
+            let mut post = post.clone();
+            post.body_md = None;
+            format_json(&post)
         }
     } else {
-        println!("Embedded {} chunks", result.chunks_embedded);
+        Ok(format_post_frontmatter(post))
     }
-    Ok(())
 }
 
-pub fn dry_run(payload: &serde_json::Value) -> Result<(), Box<dyn std::error::Error>> {
-    print_json(payload)
-}
-
-pub fn model_download(json: bool) -> Result<(), Box<dyn std::error::Error>> {
-    if json {
-        print_json(&serde_json::json!({"status": "ok"}))?;
-    } else {
-        println!("Model downloaded and verified");
+fn format_post_frontmatter(post: &EsaPost) -> String {
+    let mut lines = Vec::new();
+    lines.push("---".to_string());
+    lines.push(format!(
+        "title: \"{}\"",
+        post.full_name.replace('"', "\\\"")
+    ));
+    if let Some(ref cat) = post.category
+        && !cat.is_empty()
+    {
+        lines.push(format!("category: \"{}\"", cat.replace('"', "\\\"")));
     }
-    Ok(())
+    if !post.tags.is_empty() {
+        let tags: Vec<String> = post
+            .tags
+            .iter()
+            .map(|t| format!("\"{}\"", t.replace('"', "\\\"")))
+            .collect();
+        lines.push(format!("tags: [{}]", tags.join(", ")));
+    }
+    lines.push(format!("author: \"@{}\"", post.created_by.screen_name));
+    if post.updated_by.screen_name != post.created_by.screen_name {
+        lines.push(format!("updated_by: \"@{}\"", post.updated_by.screen_name));
+    }
+    lines.push(format!("updated_at: \"{}\"", post.updated_at));
+    if post.wip {
+        lines.push("wip: true".to_string());
+    }
+    lines.push(format!("number: {}", post.number));
+    lines.push(format!("url: {}", post.url));
+    lines.push("---".to_string());
+    lines.push(String::new());
+    lines.push(post.body_md.as_deref().unwrap_or("(empty)").to_string());
+    lines.join("\n")
 }
 
-pub fn status(statuses: &[TeamStatus], json: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn action_result(action: &str, post: &EsaPost, json: bool) -> Result<String, AppError> {
     if json {
-        print_json(statuses)?;
+        format_json(post)
     } else {
+        Ok(format!(
+            "{action}: {} (#{}) {}",
+            post.name, post.number, post.url
+        ))
+    }
+}
+
+pub(crate) fn embed(
+    result: &EmbedResult,
+    total_chunks: u32,
+    json: bool,
+) -> Result<String, AppError> {
+    if json {
+        format_json(result)
+    } else if result.chunks_embedded == 0 {
+        if total_chunks == 0 {
+            Ok("Nothing to embed".to_string())
+        } else {
+            Ok(format!("All {total_chunks} chunks already embedded"))
+        }
+    } else {
+        Ok(format!("Embedded {} chunks", result.chunks_embedded))
+    }
+}
+
+/// Always emits JSON regardless of `--json` flag. Dry-run output is for machine consumption.
+pub(crate) fn dry_run(payload: &serde_json::Value) -> Result<String, AppError> {
+    format_json(payload)
+}
+
+pub(crate) fn model_download(json: bool) -> Result<String, AppError> {
+    if json {
+        format_json(&serde_json::json!({"status": "ok"}))
+    } else {
+        Ok("Model downloaded and verified".to_string())
+    }
+}
+
+pub(crate) fn status(statuses: &[TeamStatus], json: bool) -> Result<String, AppError> {
+    if json {
+        format_json(statuses)
+    } else {
+        let mut lines = Vec::new();
         for ts in statuses {
-            println!("--- {} ---", ts.team);
+            lines.push(format!("--- {} ---", ts.team));
             match ts.status {
                 SyncStatus::Error => {
-                    println!(
+                    lines.push(format!(
                         "  Error: {}",
                         ts.error.as_deref().unwrap_or("unknown error")
-                    );
+                    ));
                 }
                 SyncStatus::NotSynced => {
                     if let Some(ref path) = ts.db_path {
-                        println!("  Not yet synced (no DB at {path})");
+                        lines.push(format!("  Not yet synced (no DB at {path})"));
                     } else {
-                        println!("  Not yet synced");
+                        lines.push("  Not yet synced".to_string());
                     }
                 }
                 SyncStatus::Synced => {
-                    println!("  Posts: {}", ts.posts);
+                    lines.push(format!("  Posts: {}", ts.posts));
                     if let Some(ref s) = ts.sync_state {
-                        println!(
+                        lines.push(format!(
                             "  Last sync: {} (total: {}, local: {})",
                             s.updated_at, s.total_count, s.local_count
-                        );
+                        ));
                         if let Some(pg) = s.last_page {
-                            println!("  Checkpoint: page {pg} (interrupted)");
+                            lines.push(format!("  Checkpoint: page {pg} (interrupted)"));
                         }
                     }
                 }
             }
         }
+        Ok(lines.join("\n"))
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -211,10 +228,28 @@ mod tests {
         }
     }
 
-    // TC-007: status human-readable empty list — no panic
+    // TC-007: status human-readable empty list → empty string
     #[test]
-    fn status_human_empty_no_panic() {
-        status(&[], false).unwrap();
+    fn status_human_empty_returns_empty_string() {
+        let out = status(&[], false).unwrap();
+        assert!(out.is_empty(), "empty list should produce empty output");
+    }
+
+    // TC-007: status human-readable synced team → expected lines
+    #[test]
+    fn status_human_synced_contains_expected_lines() {
+        let out = status(&[make_synced("team-a", 10)], false).unwrap();
+        assert!(out.contains("--- team-a ---"));
+        assert!(out.contains("Posts: 10"));
+        assert!(out.contains("Last sync: 2025-01-01 00:00:00"));
+    }
+
+    // TC-007: status human-readable not-synced team → expected lines
+    #[test]
+    fn status_human_not_synced_contains_expected_lines() {
+        let out = status(&[make_not_synced("team-b")], false).unwrap();
+        assert!(out.contains("--- team-b ---"));
+        assert!(out.contains("Not yet synced"));
     }
 
     // TC-007: embed json → chunks_embedded field
@@ -230,9 +265,18 @@ mod tests {
 
     // TC-007: embed human-readable with done=0 → "Nothing to embed"
     #[test]
-    fn embed_human_zero_done_no_panic() {
+    fn embed_human_zero_done_returns_nothing_to_embed() {
         let result = sae::storage::EmbedResult { chunks_embedded: 0 };
-        embed(&result, 0, false).unwrap();
+        let out = embed(&result, 0, false).unwrap();
+        assert_eq!(out, "Nothing to embed");
+    }
+
+    // TC-007: embed human-readable chunks > 0 → "Embedded N chunks"
+    #[test]
+    fn embed_human_nonzero_returns_embedded_count() {
+        let result = sae::storage::EmbedResult { chunks_embedded: 5 };
+        let out = embed(&result, 5, false).unwrap();
+        assert_eq!(out, "Embedded 5 chunks");
     }
 
     // TC-007: status error variant — error field displayed
@@ -265,5 +309,52 @@ mod tests {
         let json = serde_json::to_string(&ts).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["sync_state"]["last_page"], 3);
+    }
+
+    // TC-007: search json includes search_mode hybrid
+    #[test]
+    fn search_json_hybrid_includes_search_mode() {
+        let out = search(&[], "test", true, true).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["search_mode"], "hybrid");
+        assert!(v["results"].is_array());
+    }
+
+    // TC-007: search json includes search_mode fts
+    #[test]
+    fn search_json_fts_includes_search_mode() {
+        let out = search(&[], "test", true, false).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["search_mode"], "fts");
+    }
+
+    // TC-007: search human fts fallback shows notice
+    #[test]
+    fn search_human_fts_fallback_shows_notice() {
+        let results = vec![SearchResult {
+            post_number: 1,
+            post_name: "Test".to_string(),
+            post_url: "https://example.com".to_string(),
+            section_title: None,
+            snippet: String::new(),
+            score: 0.5,
+        }];
+        let out = search(&results, "q", false, false).unwrap();
+        assert!(out.contains("semantic search unavailable"));
+    }
+
+    // TC-007: search human hybrid does not show fallback notice
+    #[test]
+    fn search_human_hybrid_no_fallback_notice() {
+        let results = vec![SearchResult {
+            post_number: 1,
+            post_name: "Test".to_string(),
+            post_url: "https://example.com".to_string(),
+            section_title: None,
+            snippet: String::new(),
+            score: 0.5,
+        }];
+        let out = search(&results, "q", false, true).unwrap();
+        assert!(!out.contains("semantic search unavailable"));
     }
 }

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -1,0 +1,136 @@
+use std::ffi::OsString;
+
+/// Expands shorthand `sae "query"` → `sae [global_flags] search "query" [rest_flags]`.
+///
+/// Returns `Some(expanded_args)` when `args` match the shorthand pattern,
+/// `None` otherwise. Caller provides known subcommand names and global flag
+/// strings (e.g. `&["--json"]`); this fn has no dependency on `Cli`.
+pub(crate) fn try_expand_shorthand(
+    args: &[OsString],
+    known_subcommands: &[&str],
+    global_flags: &[&str],
+) -> Option<Vec<OsString>> {
+    let positional_count = args
+        .iter()
+        .filter(|a| !a.to_str().is_some_and(|s| s.starts_with('-')))
+        .count();
+
+    if positional_count < 2 {
+        return None;
+    }
+
+    let (flags, rest): (Vec<_>, Vec<_>) = args
+        .iter()
+        .enumerate()
+        .partition(|(i, a)| *i > 0 && a.to_str().is_some_and(|s| global_flags.contains(&s)));
+    let rest: Vec<&OsString> = rest.into_iter().map(|(_, a)| a).collect();
+
+    if rest.len() >= 2
+        && let Some(first_arg) = rest[1].to_str()
+        && !first_arg.starts_with('-')
+        && first_arg != "help"
+        && !known_subcommands.contains(&first_arg)
+        && !known_subcommands
+            .iter()
+            .any(|k| strsim::osa_distance(first_arg, k) <= 1)
+    {
+        let mut expanded: Vec<OsString> = vec![rest[0].clone()];
+        for (_, f) in &flags {
+            expanded.push((*f).clone());
+        }
+        expanded.push("search".into());
+        for arg in &rest[1..] {
+            expanded.push((*arg).clone());
+        }
+        Some(expanded)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KNOWN: &[&str] = &[
+        "harvest", "search", "get", "update", "ship", "archive", "embed", "status", "create",
+        "model",
+    ];
+    const GLOBAL: &[&str] = &["--json"];
+
+    fn os(s: &[&str]) -> Vec<OsString> {
+        s.iter().map(|&a| a.into()).collect()
+    }
+
+    // T-029: bare query expands with "search" inserted as subcommand
+    #[test]
+    fn single_query_expands_to_search() {
+        let exp = try_expand_shorthand(&os(&["sae", "認証"]), KNOWN, GLOBAL).unwrap();
+        let s: Vec<&str> = exp.iter().filter_map(|a| a.to_str()).collect();
+        assert_eq!(s, ["sae", "search", "認証"]);
+    }
+
+    // T-031: known subcommand as first positional → not expanded
+    #[test]
+    fn known_subcommand_not_expanded() {
+        assert!(try_expand_shorthand(&os(&["sae", "harvest", "myteam"]), KNOWN, GLOBAL).is_none());
+    }
+
+    // T-022: trailing options pass through after the inserted "search"
+    #[test]
+    fn query_with_trailing_option_expanded() {
+        let exp =
+            try_expand_shorthand(&os(&["sae", "query", "--limit", "2"]), KNOWN, GLOBAL).unwrap();
+        let s: Vec<&str> = exp.iter().filter_map(|a| a.to_str()).collect();
+        assert_eq!(s, ["sae", "search", "query", "--limit", "2"]);
+    }
+
+    // T-023: global flag (--json) is hoisted to before the inserted "search"
+    #[test]
+    fn global_flag_hoisted_before_search() {
+        let exp = try_expand_shorthand(
+            &os(&["sae", "--json", "query", "--limit", "2"]),
+            KNOWN,
+            GLOBAL,
+        )
+        .unwrap();
+        let s: Vec<&str> = exp.iter().filter_map(|a| a.to_str()).collect();
+        assert_eq!(s, ["sae", "--json", "search", "query", "--limit", "2"]);
+    }
+
+    // T-024: non-global option (--team) stays after the inserted "search"
+    #[test]
+    fn non_global_option_stays_after_search() {
+        let exp = try_expand_shorthand(&os(&["sae", "query", "--team", "myteam"]), KNOWN, GLOBAL)
+            .unwrap();
+        let s: Vec<&str> = exp.iter().filter_map(|a| a.to_str()).collect();
+        assert_eq!(s, ["sae", "search", "query", "--team", "myteam"]);
+    }
+
+    // T-025: typo within OSA distance 1 → not expanded (typo guard)
+    #[test]
+    fn typo_within_distance_not_expanded() {
+        assert!(
+            try_expand_shorthand(&os(&["sae", "serach"]), KNOWN, GLOBAL).is_none(),
+            "typo 'serach' (osa=1 from 'search') should not expand"
+        );
+    }
+
+    // TC-013: bare dash counts as flag prefix → positional_count < 2 → not expanded
+    #[test]
+    fn bare_dash_not_expanded() {
+        assert!(
+            try_expand_shorthand(&os(&["sae", "-"]), KNOWN, GLOBAL).is_none(),
+            "`sae -` should not expand"
+        );
+    }
+
+    // TC-011: flag-like arg (--) → positional_count < 2 → not expanded
+    #[test]
+    fn flag_only_not_expanded() {
+        assert!(
+            try_expand_shorthand(&os(&["sae", "--unknown"]), KNOWN, GLOBAL).is_none(),
+            "--unknown should not expand"
+        );
+    }
+}


### PR DESCRIPTION
## 概要と背景

All output functions previously called `println!` directly, scattering I/O across the codebase and making them untestable without capturing stdout. This PR makes every output function return a `String`, with a single `println!` in `main()` — enabling straightforward unit tests on return values.

## 変更内容

- `src/output.rs`: all public functions now return `Result<String, AppError>` instead of printing. `print_json` renamed to `format_json`. `pub` visibility narrowed to `pub(crate)`. `format_post_frontmatter` extracted for reuse. `search` gains a `semantic: bool` param and includes `search_mode` in JSON output. New tests cover return values directly.
- `src/main.rs`: centralized all `println!` calls here. Extracted shorthand expansion to `src/shorthand.rs`. Added `#![warn(unreachable_pub)]`. Fixed a collapsible-if lint.
- `src/shorthand.rs` (new): `try_expand_shorthand` moved here from `main.rs` with its tests, making the logic independently testable.
- `src/commands/{archive,data,post,search,status}.rs`: return type changed from `Result<(), AppError>` to `Result<String, AppError>`. Error types unified to `AppError`. `status.rs` test fixtures DRYed with `make_post_row()`.

## スコープ

- **対象外**: public `sae` library crate — CLI binary layer のみ対象。

## 設計判断

- Returning `String` rather than writing to a `Write` trait object keeps the change minimal and avoids adding a dependency on `std::io::Write` throughout the call tree, which would be a larger interface change with no current benefit.
- `pub(crate)` on output functions enforces that nothing outside the binary crate calls them, which `#![warn(unreachable_pub)]` now statically guards.

## テスト方法

1. Run `cargo test` — all existing and new tests should pass.
2. Run `cargo build` — no warnings expected.
3. Run `sae search <query>` and verify output is unchanged from before.
4. Run `sae --json search <query>` and verify JSON includes `"search_mode"` field.

## 関連

- Closes #18