### PR TITLE
AppError を型付き SaeError と構造化 exit code に置換

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=568eda5#568eda54c77b93a56f61179844447974ebbae9c9"
+source = "git+https://github.com/thkt/rurico?rev=2e3a3b6#2e3a3b6d4861d1fe7005f00d8363eaf3fae4b04f"
 dependencies = [
  "bytemuck",
  "hf-hub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=2e3a3b6#2e3a3b6d4861d1fe7005f00d8363eaf3fae4b04f"
+source = "git+https://github.com/thkt/rurico?rev=07e20b1#07e20b1074e55ccbff92e68e421e4e3ec21edc76"
 dependencies = [
  "bytemuck",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "2e3a3b6" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "07e20b1" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 strsim = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "568eda5" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "2e3a3b6" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 strsim = "0.11"
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,12 @@ sae --json status
 
 - DB: `~/.local/share/sae/{team}.db`（SQLite）
 - 設定: `~/.config/sae/config.json`
+
+## Exit code
+
+| Code | 意味               | 例                                       |
+| ---- | ------------------ | ---------------------------------------- |
+| 0    | 正常終了           |                                          |
+| 1    | Operational エラー | API エラー、ネットワーク障害             |
+| 2    | Input エラー       | 不明なチーム、トークン未設定、未 harvest |
+| 4    | Internal エラー    | DB 破損、JSON シリアライズ失敗           |

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -1,7 +1,7 @@
 use sae::client::UpdatePostParams;
 use sae::config::Config;
 
-use crate::{AppError, resolve_client};
+use crate::{SaeError, resolve_client};
 
 pub(crate) fn archive_category(current: Option<&str>) -> Option<String> {
     let current = current.unwrap_or("");
@@ -21,7 +21,7 @@ pub(crate) async fn run_archive(
     team: Option<&str>,
     dry_run: bool,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let (team, client) = resolve_client(config, team)?;
     let post = client.get_post(team, number).await?;
     let new_category = match archive_category(post.category.as_deref()) {
@@ -58,7 +58,7 @@ pub(crate) async fn run_ship(
     team: Option<&str>,
     dry_run: bool,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     if dry_run {
         return crate::output::dry_run(&serde_json::json!({
             "number": number,

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -1,14 +1,14 @@
 use rurico::embed::{Embedder, ModelId};
 use sae::config::Config;
 
-use crate::{AppError, require_db, resolve_client};
+use crate::{SaeError, require_db, resolve_client};
 
 pub(crate) async fn run_harvest(
     config: &Config,
     team: &str,
     full: bool,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let (team, client) = resolve_client(config, Some(team))?;
     let db_path = config.team_db_path(team)?;
     let db = sae::storage::Db::open(&db_path)?;
@@ -16,7 +16,7 @@ pub(crate) async fn run_harvest(
     crate::output::harvest(&result, json)
 }
 
-pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<String, AppError> {
+pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<String, SaeError> {
     use rurico::embed::Embed;
 
     let team = config.resolve_team(Some(team))?;
@@ -24,7 +24,8 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
 
     let paths = require_embed_model()?;
     tracing::info!("Loading model...");
-    let embedder = Embedder::new(&paths).map_err(|e| format!("Failed to load model: {e}"))?;
+    let embedder = Embedder::new(&paths)
+        .map_err(|e| SaeError::Other(format!("Failed to load model: {e}")))?;
     tracing::info!("Model ready");
 
     const BATCH_SIZE: u32 = 64;
@@ -42,7 +43,7 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
         let batch_len = batch.len() as u32;
         let embs = embedder
             .embed_documents_batch(&texts)
-            .map_err(|e| format!("Batch embedding failed: {e}"))?;
+            .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))?;
         let embeddings: Vec<(i64, _)> = batch.iter().map(|(id, _)| *id).zip(embs).collect();
         total_added += sae::storage::add_chunked_embeddings(db.conn(), &embeddings)?;
         total_chunks += batch_len;
@@ -54,15 +55,16 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
     crate::output::embed(&result, total_chunks, json)
 }
 
-pub(crate) fn run_model_download(json: bool) -> Result<String, AppError> {
+pub(crate) fn run_model_download(json: bool) -> Result<String, SaeError> {
     eprintln!("Downloading model...");
     let paths = rurico::embed::download_model(ModelId::default())
-        .map_err(|e| format!("Failed to download model: {e}"))?;
-    let _embedder = Embedder::new(&paths).map_err(|e| format!("Failed to verify model: {e}"))?;
+        .map_err(|e| SaeError::Other(format!("Failed to download model: {e}")))?;
+    let _embedder = Embedder::new(&paths)
+        .map_err(|e| SaeError::Other(format!("Failed to verify model: {e}")))?;
     crate::output::model_download(json)
 }
 
-pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, AppError> {
+pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, SaeError> {
     let auto_download = std::env::var("SAE_AUTO_DOWNLOAD_MODEL").as_deref() == Ok("1");
     require_embed_model_with(auto_download, || {
         rurico::embed::cached_artifacts(ModelId::default())
@@ -72,17 +74,19 @@ pub(crate) fn require_embed_model() -> Result<rurico::embed::Artifacts, AppError
 fn require_embed_model_with<E: std::fmt::Display>(
     auto_download: bool,
     cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
-) -> Result<rurico::embed::Artifacts, AppError> {
+) -> Result<rurico::embed::Artifacts, SaeError> {
     if auto_download {
         eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
         // Embedder::new verification skipped: caller (run_embed) calls it immediately after
         return rurico::embed::download_model(ModelId::default())
-            .map_err(|e| format!("Failed to download model: {e}").into());
+            .map_err(|e| SaeError::Other(format!("Failed to download model: {e}")));
     }
     match cache_check() {
         Ok(Some(p)) => Ok(p),
-        Ok(None) => Err("Model not found. Run 'sae model download' first.".into()),
-        Err(e) => Err(format!("Failed to check model cache: {e}").into()),
+        Ok(None) => Err(SaeError::Input(
+            "Model not found. Run 'sae model download' first.".to_string(),
+        )),
+        Err(e) => Err(SaeError::Other(format!("Failed to check model cache: {e}"))),
     }
 }
 

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -24,8 +24,8 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
 
     let paths = require_embed_model()?;
     tracing::info!("Loading model...");
-    let embedder = Embedder::new(&paths)
-        .map_err(|e| SaeError::Other(format!("Failed to load model: {e}")))?;
+    let embedder =
+        Embedder::new(&paths).map_err(|e| SaeError::Other(format!("Failed to load model: {e}")))?;
     tracing::info!("Model ready");
 
     const BATCH_SIZE: u32 = 64;

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use sae::client::{CreatePostParams, UpdatePostParams};
 use sae::config::Config;
 
-use crate::{AppError, resolve_client};
+use crate::{SaeError, resolve_client};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct CreateArgs {
@@ -39,7 +39,7 @@ pub(crate) async fn run_get(
     team: Option<&str>,
     with_body: bool,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let (team, client) = resolve_client(config, team)?;
     let post = client.get_post(team, number).await?;
     crate::output::get(&post, json, with_body)
@@ -49,7 +49,7 @@ pub(crate) async fn run_create(
     config: &Config,
     args: CreateArgs,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     if args.dry_run {
         return crate::output::dry_run(&serde_json::json!({
@@ -103,7 +103,7 @@ pub(crate) async fn run_update(
     config: &Config,
     args: UpdateArgs,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     let tags: Option<Vec<String>> = if args.tag.is_empty() {
         None
@@ -134,7 +134,7 @@ pub(crate) async fn run_update(
 pub(crate) fn resolve_body(
     body: Option<&str>,
     body_file: Option<&str>,
-) -> Result<Option<String>, AppError> {
+) -> Result<Option<String>, SaeError> {
     let mut stdin = std::io::stdin();
     resolve_body_with_reader(body, body_file, &mut stdin)
 }
@@ -143,7 +143,7 @@ pub(crate) fn resolve_body_with_reader(
     body: Option<&str>,
     body_file: Option<&str>,
     stdin: &mut impl Read,
-) -> Result<Option<String>, AppError> {
+) -> Result<Option<String>, SaeError> {
     match (body, body_file) {
         (Some(b), None) => Ok(Some(b.to_string())),
         (None, Some("-")) => {

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -3,7 +3,7 @@ use std::io::{IsTerminal, Read};
 use rurico::embed::{Embed, Embedder, ModelId};
 use sae::config::Config;
 
-use crate::{AppError, require_db};
+use crate::{SaeError, require_db};
 
 pub(crate) fn run_search(
     config: &Config,
@@ -11,7 +11,7 @@ pub(crate) fn run_search(
     team: Option<&str>,
     limit: u32,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
     let embedder = try_load_embedder();
@@ -65,7 +65,7 @@ fn try_load_embedder_with<E: std::fmt::Display>(
     }
 }
 
-pub(crate) fn resolve_search_query(query: Option<String>) -> Result<String, AppError> {
+pub(crate) fn resolve_search_query(query: Option<String>) -> Result<String, SaeError> {
     let stdin = std::io::stdin();
     resolve_value_with_reader(
         query,
@@ -82,14 +82,13 @@ pub(crate) fn resolve_value_with_reader(
     stdin_is_terminal: bool,
     label: &str,
     placeholder: &str,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     match value {
         Some(value) if value != "-" => Ok(value),
         Some(_) => read_stdin_value(&mut stdin, label, placeholder),
-        None if stdin_is_terminal => Err(format!(
+        None if stdin_is_terminal => Err(SaeError::Input(format!(
             "Missing {label}. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
-        )
-        .into()),
+        ))),
         None => read_stdin_value(&mut stdin, label, placeholder),
     }
 }
@@ -98,16 +97,15 @@ fn read_stdin_value(
     mut stdin: impl Read,
     label: &str,
     placeholder: &str,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let mut buf = String::new();
     stdin.read_to_string(&mut buf)?;
 
     let value = buf.trim();
     if value.is_empty() {
-        return Err(format!(
+        return Err(SaeError::Input(format!(
             "No {label} provided. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
-        )
-        .into());
+        )));
     }
 
     Ok(value.to_string())
@@ -137,7 +135,7 @@ mod tests {
         value: Option<&str>,
         stdin: &str,
         is_terminal: bool,
-    ) -> Result<String, AppError> {
+    ) -> Result<String, SaeError> {
         resolve_value_with_reader(
             value.map(str::to_string),
             Cursor::new(stdin),

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,13 +1,13 @@
 use sae::config::Config;
 use sae::storage::TeamStatus;
 
-use crate::AppError;
+use crate::SaeError;
 
 pub(crate) fn run_status(
     config: &Config,
     team: Option<&str>,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let target_teams: Vec<&str> = if let Some(t) = team {
         vec![config.resolve_team(Some(t))?]
     } else {
@@ -28,7 +28,7 @@ pub(crate) fn run_status(
     crate::output::status(&statuses, json)
 }
 
-fn collect_team_statuses(config: &Config, teams: &[&str]) -> Result<Vec<TeamStatus>, AppError> {
+fn collect_team_statuses(config: &Config, teams: &[&str]) -> Result<Vec<TeamStatus>, SaeError> {
     let mut statuses = Vec::new();
     for t in teams {
         let ts = match config.team_db_path(t) {
@@ -44,7 +44,7 @@ fn collect_team_statuses(config: &Config, teams: &[&str]) -> Result<Vec<TeamStat
     Ok(statuses)
 }
 
-fn query_team_status(team: &str, path: &std::path::Path) -> Result<TeamStatus, AppError> {
+fn query_team_status(team: &str, path: &std::path::Path) -> Result<TeamStatus, SaeError> {
     let db = sae::storage::Db::open(path)?;
     let count = sae::storage::count_posts(db.conn())?;
     let state = sae::storage::get_sync_state(db.conn())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod commands;
 mod output;
 mod shorthand;
 
+use std::process::ExitCode;
+
 use clap::{Parser, Subcommand};
 use sae::client::EsaClient;
 use sae::config::Config;
@@ -177,38 +179,65 @@ where
     Cli::try_parse_from(args)
 }
 
-pub(crate) type AppError = Box<dyn std::error::Error>;
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SaeError {
+    #[error(transparent)]
+    Config(#[from] sae::config::ConfigError),
+    #[error(transparent)]
+    Client(#[from] sae::client::ClientError),
+    #[error(transparent)]
+    Storage(#[from] sae::storage::StorageError),
+    #[error(transparent)]
+    Sync(#[from] sae::sync::SyncError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// User action required (e.g., run harvest or model download first)
+    #[error("{0}")]
+    Input(String),
+    /// Operational failure (e.g., model load, embedding, download)
+    #[error("{0}")]
+    Other(String),
+}
 
 pub(crate) fn resolve_client<'a>(
     config: &'a Config,
     team: Option<&'a str>,
-) -> Result<(&'a str, EsaClient), AppError> {
+) -> Result<(&'a str, EsaClient), SaeError> {
     let team = config.resolve_team(team)?;
     let client = EsaClient::from_env()?;
     Ok((team, client))
 }
 
-pub(crate) fn require_db(config: &Config, team: &str) -> Result<sae::storage::Db, AppError> {
+pub(crate) fn require_db(config: &Config, team: &str) -> Result<sae::storage::Db, SaeError> {
     let db_path = config.team_db_path(team)?;
     if !db_path.exists() {
-        return Err(format!("No data for team '{team}'. Run `sae harvest {team}` first.").into());
+        return Err(SaeError::Input(format!(
+            "No data for team '{team}'. Run `sae harvest {team}` first."
+        )));
     }
     Ok(sae::storage::Db::open(&db_path)?)
 }
 
-#[tokio::main]
-async fn main() -> Result<(), AppError> {
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env().add_directive("sae=info".parse()?),
-        )
-        .init();
+fn exit_code_for(e: &SaeError) -> ExitCode {
+    use sae::client::ClientError;
+    use sae::sync::SyncError;
+    match e {
+        SaeError::Input(_) | SaeError::Config(_) => ExitCode::from(2),
+        SaeError::Client(ClientError::TokenNotSet) => ExitCode::from(2),
+        SaeError::Sync(SyncError::Client(ClientError::TokenNotSet)) => ExitCode::from(2),
+        SaeError::Storage(_) | SaeError::Sync(SyncError::Storage(_)) | SaeError::Json(_) => {
+            ExitCode::from(4)
+        }
+        SaeError::Client(_) | SaeError::Sync(_) | SaeError::Io(_) | SaeError::Other(_) => {
+            ExitCode::FAILURE
+        }
+    }
+}
 
-    let cli = parse_cli_args(std::env::args_os()).unwrap_or_else(|e| e.exit());
-    let config = Config::load()?;
+async fn run(cli: Cli, config: Config) -> Result<String, SaeError> {
     let json = cli.json;
-
     let output = match cli.command {
         Command::Harvest { team, full } => {
             commands::data::run_harvest(&config, &team, full, json).await?
@@ -242,10 +271,39 @@ async fn main() -> Result<(), AppError> {
             ModelCommand::Download => commands::data::run_model_download(json)?,
         },
     };
-    if !output.is_empty() {
-        println!("{output}");
+    Ok(output)
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("sae=info".parse().expect("hardcoded directive is valid")),
+        )
+        .init();
+
+    let cli = parse_cli_args(std::env::args_os()).unwrap_or_else(|e| e.exit());
+    let config = match Config::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return exit_code_for(&e.into());
+        }
+    };
+    match run(cli, config).await {
+        Ok(output) => {
+            if !output.is_empty() {
+                println!("{output}");
+            }
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            exit_code_for(&e)
+        }
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,13 +2,13 @@ use sae::client::EsaPost;
 use sae::storage::{EmbedResult, SearchResult, SyncStatus, TeamStatus};
 use sae::sync::HarvestResult;
 
-use crate::AppError;
+use crate::SaeError;
 
-fn format_json<T: serde::Serialize + ?Sized>(val: &T) -> Result<String, AppError> {
+fn format_json<T: serde::Serialize + ?Sized>(val: &T) -> Result<String, SaeError> {
     Ok(serde_json::to_string(val)?)
 }
 
-pub(crate) fn harvest(result: &HarvestResult, json: bool) -> Result<String, AppError> {
+pub(crate) fn harvest(result: &HarvestResult, json: bool) -> Result<String, SaeError> {
     if json {
         format_json(result)
     } else {
@@ -21,7 +21,7 @@ pub(crate) fn search(
     query: &str,
     json: bool,
     semantic: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     let search_mode = if semantic { "hybrid" } else { "fts" };
     if json {
         format_json(&serde_json::json!({
@@ -53,7 +53,7 @@ pub(crate) fn search(
     }
 }
 
-pub(crate) fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<String, AppError> {
+pub(crate) fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<String, SaeError> {
     if json {
         if with_body {
             format_json(post)
@@ -105,7 +105,7 @@ fn format_post_frontmatter(post: &EsaPost) -> String {
     lines.join("\n")
 }
 
-pub(crate) fn action_result(action: &str, post: &EsaPost, json: bool) -> Result<String, AppError> {
+pub(crate) fn action_result(action: &str, post: &EsaPost, json: bool) -> Result<String, SaeError> {
     if json {
         format_json(post)
     } else {
@@ -120,7 +120,7 @@ pub(crate) fn embed(
     result: &EmbedResult,
     total_chunks: u32,
     json: bool,
-) -> Result<String, AppError> {
+) -> Result<String, SaeError> {
     if json {
         format_json(result)
     } else if result.chunks_embedded == 0 {
@@ -135,11 +135,11 @@ pub(crate) fn embed(
 }
 
 /// Always emits JSON regardless of `--json` flag. Dry-run output is for machine consumption.
-pub(crate) fn dry_run(payload: &serde_json::Value) -> Result<String, AppError> {
+pub(crate) fn dry_run(payload: &serde_json::Value) -> Result<String, SaeError> {
     format_json(payload)
 }
 
-pub(crate) fn model_download(json: bool) -> Result<String, AppError> {
+pub(crate) fn model_download(json: bool) -> Result<String, SaeError> {
     if json {
         format_json(&serde_json::json!({"status": "ok"}))
     } else {
@@ -147,7 +147,7 @@ pub(crate) fn model_download(json: bool) -> Result<String, AppError> {
     }
 }
 
-pub(crate) fn status(statuses: &[TeamStatus], json: bool) -> Result<String, AppError> {
+pub(crate) fn status(statuses: &[TeamStatus], json: bool) -> Result<String, SaeError> {
     if json {
         format_json(statuses)
     } else {
@@ -189,7 +189,7 @@ pub(crate) fn status(statuses: &[TeamStatus], json: bool) -> Result<String, AppE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sae::storage::{SyncState, SyncStatus, TeamStatus};
+    use sae::storage::SyncState;
 
     fn make_synced(team: &str, posts: u32) -> TeamStatus {
         TeamStatus {


### PR DESCRIPTION
## 背景

`AppError` was a `Box<dyn Error>` type alias, giving no information about error
origin at the call site or at process exit. All failures exited with code 1
regardless of whether the cause was a bad config, a missing harvest, or an
internal DB error.

## 変更内容

- Add `SaeError` enum (via `thiserror`) with variants that cover all error
  domains: `Config`, `Client`, `Storage`, `Sync`, `Json`, `Io`, `Input`,
  `Other`.
- Add `exit_code_for()` with exhaustive `match` arms so the compiler enforces
  coverage when new variants are added.
- Exit codes: 0 = success, 1 = operational (API/network), 2 = input
  (bad config, missing token, no harvest data), 4 = internal (DB, JSON).
- Split `main()` into `run()` (returns `Result<String, SaeError>`) and a
  thin `main()` that maps errors to `ExitCode`.
- Document the exit code table in README.
- Bump `rurico` dependency rev to `2e3a3b6`.

## テスト計画

- [ ] `sae status` with a valid config exits 0.
- [ ] `sae status` with `SAE_ESA_TOKEN` unset exits 2.
- [ ] `sae search` before `sae harvest` exits 2 (Input: no data for team).
- [ ] `cargo build` passes with no warnings.
- [ ] `cargo test` passes.