### PR TITLE
検索前に未埋め込みチャンクを自動埋め込みする

### DIFF
--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -28,7 +28,7 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
         Embedder::new(&paths).map_err(|e| SaeError::Other(format!("Failed to load model: {e}")))?;
     tracing::info!("Model ready");
 
-    const BATCH_SIZE: u32 = 64;
+    const BATCH_SIZE: u32 = 256;
     let mut total_added = 0u32;
     let mut total_chunks = 0u32;
     loop {
@@ -44,6 +44,13 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
         let embs = embedder
             .embed_documents_batch(&texts)
             .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))?;
+        if embs.len() != batch.len() {
+            return Err(SaeError::Other(format!(
+                "Embedding count mismatch: expected {}, got {}",
+                batch.len(),
+                embs.len()
+            )));
+        }
         let embeddings: Vec<(i64, _)> = batch.iter().map(|(id, _)| *id).zip(embs).collect();
         total_added += sae::storage::add_chunked_embeddings(db.conn(), &embeddings)?;
         total_chunks += batch_len;
@@ -77,7 +84,7 @@ fn require_embed_model_with<E: std::fmt::Display>(
 ) -> Result<rurico::embed::Artifacts, SaeError> {
     if auto_download {
         eprintln!("Downloading model (SAE_AUTO_DOWNLOAD_MODEL=1)...");
-        // Embedder::new verification skipped: caller (run_embed) calls it immediately after
+        // Verification deferred to caller — download-only path
         return rurico::embed::download_model(ModelId::default())
             .map_err(|e| SaeError::Other(format!("Failed to download model: {e}")));
     }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -15,11 +15,11 @@ pub(crate) fn run_search(
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
     let embedder = try_load_embedder();
-    if let Some(ref emb) = embedder {
-        if let Err(e) = auto_embed_pending(&db, team, emb) {
-            eprintln!("Warning: auto-embed failed ({e}), continuing with existing embeddings");
-            tracing::warn!(error = %e, "auto_embed_pending failed, continuing search");
-        }
+    if let Some(ref emb) = embedder
+        && let Err(e) = auto_embed_pending(&db, team, emb)
+    {
+        eprintln!("Warning: auto-embed failed ({e}), continuing with existing embeddings");
+        tracing::warn!(error = %e, "auto_embed_pending failed, continuing search");
     }
     let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(query) {
         Ok(v) => Some(v),
@@ -80,7 +80,11 @@ where
             embs.len()
         )));
     }
-    let embeddings: Vec<(i64, _)> = batch.iter().zip(embs).map(|((id, _), emb)| (*id, emb)).collect();
+    let embeddings: Vec<(i64, _)> = batch
+        .iter()
+        .zip(embs)
+        .map(|((id, _), emb)| (*id, emb))
+        .collect();
     sae::storage::add_chunked_embeddings(db.conn(), &embeddings)?;
     Ok(batch.len() as u32 == budget)
 }
@@ -196,7 +200,10 @@ mod tests {
             Ok(vec![])
         });
         assert!(result.is_ok());
-        assert!(!called.get(), "embed_fn must not be called when no chunks pending");
+        assert!(
+            !called.get(),
+            "embed_fn must not be called when no chunks pending"
+        );
     }
 
     // TC-038: auto_embed_pending_with embeds chunks within budget
@@ -246,7 +253,10 @@ mod tests {
                 .collect())
         });
         assert!(result.is_ok());
-        assert!(result.unwrap(), "budget=1 with 2 chunks should signal budget exhausted");
+        assert!(
+            result.unwrap(),
+            "budget=1 with 2 chunks should signal budget exhausted"
+        );
         assert_eq!(
             sae::storage::count_unembedded_chunks(db.conn()).unwrap(),
             1,
@@ -264,9 +274,8 @@ mod tests {
 
         assert_eq!(sae::storage::count_unembedded_chunks(db.conn()).unwrap(), 1);
 
-        let result = auto_embed_pending_with(&db, 256, |_| {
-            Err(SaeError::Other("model OOM".into()))
-        });
+        let result =
+            auto_embed_pending_with(&db, 256, |_| Err(SaeError::Other("model OOM".into())));
         assert!(result.is_err(), "embed_fn error should propagate");
         assert!(result.unwrap_err().to_string().contains("model OOM"));
         assert_eq!(
@@ -287,7 +296,10 @@ mod tests {
         let result = auto_embed_pending_with(&db, 256, |_| Ok(vec![]));
         assert!(result.is_err(), "count mismatch should be an error");
         assert!(
-            result.unwrap_err().to_string().contains("Embedding count mismatch"),
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Embedding count mismatch"),
             "error should describe the mismatch"
         );
         assert_eq!(

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,6 +1,6 @@
 use std::io::{IsTerminal, Read};
 
-use rurico::embed::{Embed, Embedder, ModelId};
+use rurico::embed::{ChunkedEmbedding, Embed, Embedder, ModelId};
 use sae::config::Config;
 
 use crate::{SaeError, require_db};
@@ -15,6 +15,12 @@ pub(crate) fn run_search(
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
     let embedder = try_load_embedder();
+    if let Some(ref emb) = embedder {
+        if let Err(e) = auto_embed_pending(&db, team, emb) {
+            eprintln!("Warning: auto-embed failed ({e}), continuing with existing embeddings");
+            tracing::warn!(error = %e, "auto_embed_pending failed, continuing search");
+        }
+    }
     let query_embedding = embedder.as_ref().and_then(|e| match e.embed_query(query) {
         Ok(v) => Some(v),
         Err(e) => {
@@ -32,6 +38,51 @@ pub(crate) fn run_search(
     )?;
     let semantic = query_embedding.is_some();
     crate::output::search(&results, query, json, semantic)
+}
+
+fn auto_embed_pending(
+    db: &sae::storage::Db,
+    team: &str,
+    embedder: &Embedder,
+) -> Result<(), SaeError> {
+    const EMBED_BUDGET: u32 = 256;
+    let budget_exhausted = auto_embed_pending_with(db, EMBED_BUDGET, |texts| {
+        embedder
+            .embed_documents_batch(texts)
+            .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
+    })?;
+    if budget_exhausted {
+        eprintln!("Hint: more chunks pending. Run 'sae embed {team}' to index all.");
+    }
+    Ok(())
+}
+
+/// Returns `Ok(true)` when the budget was fully consumed (more chunks may be pending).
+fn auto_embed_pending_with<F>(
+    db: &sae::storage::Db,
+    budget: u32,
+    embed_fn: F,
+) -> Result<bool, SaeError>
+where
+    F: Fn(&[&str]) -> Result<Vec<ChunkedEmbedding>, SaeError>,
+{
+    let batch = sae::storage::get_unembedded_chunks(db.conn(), budget)?;
+    if batch.is_empty() {
+        return Ok(false);
+    }
+    eprintln!("Embedding {} new chunks...", batch.len());
+    let texts: Vec<&str> = batch.iter().map(|(_, c)| c.as_str()).collect();
+    let embs = embed_fn(&texts)?;
+    if embs.len() != batch.len() {
+        return Err(SaeError::Other(format!(
+            "Embedding count mismatch: expected {}, got {}",
+            batch.len(),
+            embs.len()
+        )));
+    }
+    let embeddings: Vec<(i64, _)> = batch.iter().zip(embs).map(|((id, _), emb)| (*id, emb)).collect();
+    sae::storage::add_chunked_embeddings(db.conn(), &embeddings)?;
+    Ok(batch.len() as u32 == budget)
 }
 
 pub(crate) fn try_load_embedder() -> Option<Embedder> {
@@ -115,6 +166,136 @@ fn read_stdin_value(
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    fn make_test_row(number: u32) -> sae::storage::EsaPostRow {
+        sae::storage::EsaPostRow {
+            number,
+            name: format!("Post {number}"),
+            full_name: format!("Post {number}"),
+            body_md: "# Hello\nWorld".into(),
+            category: None,
+            tags: vec![],
+            wip: false,
+            kind: "stock".into(),
+            url: format!("https://example.esa.io/posts/{number}"),
+            created_at: "2025-01-01T00:00:00+09:00".into(),
+            updated_at: "2025-01-01T00:00:00+09:00".into(),
+            created_by: "user".into(),
+            updated_by: "user".into(),
+            revision_number: 1,
+        }
+    }
+
+    // TC-037: auto_embed_pending_with skips embed_fn when no unembedded chunks
+    #[test]
+    fn auto_embed_skips_when_no_unembedded_chunks() {
+        let db = sae::storage::Db::open_memory().unwrap();
+        let called = std::cell::Cell::new(false);
+        let result = auto_embed_pending_with(&db, 256, |_| {
+            called.set(true);
+            Ok(vec![])
+        });
+        assert!(result.is_ok());
+        assert!(!called.get(), "embed_fn must not be called when no chunks pending");
+    }
+
+    // TC-038: auto_embed_pending_with embeds chunks within budget
+    #[test]
+    fn auto_embed_embeds_pending_chunks() {
+        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
+
+        let db = sae::storage::Db::open_memory().unwrap();
+        let row = make_test_row(1);
+        sae::storage::upsert_post(db.conn(), &row).unwrap();
+        sae::storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
+
+        assert_eq!(sae::storage::count_unembedded_chunks(db.conn()).unwrap(), 1);
+
+        let result = auto_embed_pending_with(&db, 256, |texts| {
+            Ok(texts
+                .iter()
+                .map(|_| ChunkedEmbedding {
+                    chunks: vec![vec![0.5; EMBEDDING_DIMS]],
+                })
+                .collect())
+        });
+        assert!(result.is_ok());
+        assert_eq!(sae::storage::count_unembedded_chunks(db.conn()).unwrap(), 0);
+    }
+
+    // TC-039: auto_embed_pending_with respects budget and leaves excess chunks unembedded
+    #[test]
+    fn auto_embed_respects_budget() {
+        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
+
+        let db = sae::storage::Db::open_memory().unwrap();
+        for i in 1u32..=2 {
+            let row = make_test_row(i);
+            sae::storage::upsert_post(db.conn(), &row).unwrap();
+            sae::storage::rechunk_post(db.conn(), i, "# Hello\nWorld").unwrap();
+        }
+
+        assert_eq!(sae::storage::count_unembedded_chunks(db.conn()).unwrap(), 2);
+
+        let result = auto_embed_pending_with(&db, 1, |texts| {
+            Ok(texts
+                .iter()
+                .map(|_| ChunkedEmbedding {
+                    chunks: vec![vec![0.5; EMBEDDING_DIMS]],
+                })
+                .collect())
+        });
+        assert!(result.is_ok());
+        assert!(result.unwrap(), "budget=1 with 2 chunks should signal budget exhausted");
+        assert_eq!(
+            sae::storage::count_unembedded_chunks(db.conn()).unwrap(),
+            1,
+            "budget=1 should leave 1 chunk unembedded"
+        );
+    }
+
+    // TC-040: auto_embed_pending_with propagates embed_fn error without side effects
+    #[test]
+    fn auto_embed_propagates_embed_error() {
+        let db = sae::storage::Db::open_memory().unwrap();
+        let row = make_test_row(1);
+        sae::storage::upsert_post(db.conn(), &row).unwrap();
+        sae::storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
+
+        assert_eq!(sae::storage::count_unembedded_chunks(db.conn()).unwrap(), 1);
+
+        let result = auto_embed_pending_with(&db, 256, |_| {
+            Err(SaeError::Other("model OOM".into()))
+        });
+        assert!(result.is_err(), "embed_fn error should propagate");
+        assert!(result.unwrap_err().to_string().contains("model OOM"));
+        assert_eq!(
+            sae::storage::count_unembedded_chunks(db.conn()).unwrap(),
+            1,
+            "failed embed must not change unembedded count"
+        );
+    }
+
+    // TC-041: auto_embed_pending_with rejects embedding count mismatch
+    #[test]
+    fn auto_embed_rejects_count_mismatch() {
+        let db = sae::storage::Db::open_memory().unwrap();
+        let row = make_test_row(1);
+        sae::storage::upsert_post(db.conn(), &row).unwrap();
+        sae::storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
+
+        let result = auto_embed_pending_with(&db, 256, |_| Ok(vec![]));
+        assert!(result.is_err(), "count mismatch should be an error");
+        assert!(
+            result.unwrap_err().to_string().contains("Embedding count mismatch"),
+            "error should describe the mismatch"
+        );
+        assert_eq!(
+            sae::storage::count_unembedded_chunks(db.conn()).unwrap(),
+            1,
+            "mismatched embed must not change unembedded count"
+        );
+    }
 
     // TC-010: try_load_embedder_with returns None when model is not cached
     #[test]

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -71,6 +71,17 @@ pub fn get_unembedded_chunks(
     Ok(rows)
 }
 
+pub fn count_unembedded_chunks(conn: &Connection) -> Result<u32, StorageError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM chunks c \
+         LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id \
+         WHERE e.chunk_id IS NULL",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(StorageError::from)
+}
+
 pub fn has_embeddings(conn: &Connection) -> bool {
     conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM embedded_chunk_ids)",
@@ -155,5 +166,28 @@ mod tests {
 
         assert!(get_unembedded_chunks(db.conn(), 100).unwrap().is_empty());
         assert!(has_embeddings(db.conn()));
+    }
+
+    #[test]
+    fn count_unembedded_returns_zero_on_empty_db() {
+        let db = Db::open_memory().unwrap();
+        assert_eq!(count_unembedded_chunks(db.conn()).unwrap(), 0);
+    }
+
+    #[test]
+    fn count_unembedded_returns_correct_count_before_and_after_embed() {
+        let db = Db::open_memory().unwrap();
+        let mut row = crate::storage::test_post_row(1);
+        row.body_md = "# Hello\nWorld".into();
+        crate::storage::upsert_post(db.conn(), &row).unwrap();
+        crate::storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
+
+        assert_eq!(count_unembedded_chunks(db.conn()).unwrap(), 1);
+
+        let chunks = get_unembedded_chunks(db.conn(), 100).unwrap();
+        let emb = vec![(chunks[0].0, make_chunked(0.5))];
+        add_chunked_embeddings(db.conn(), &emb).unwrap();
+
+        assert_eq!(count_unembedded_chunks(db.conn()).unwrap(), 0);
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,7 @@
 pub mod embed;
 pub mod search;
 pub mod types;
-pub use embed::{add_chunked_embeddings, get_unembedded_chunks, has_embeddings};
+pub use embed::{add_chunked_embeddings, count_unembedded_chunks, get_unembedded_chunks, has_embeddings};
 pub use search::{SearchResult, hybrid_search};
 pub use types::*;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,9 @@
 pub mod embed;
 pub mod search;
 pub mod types;
-pub use embed::{add_chunked_embeddings, count_unembedded_chunks, get_unembedded_chunks, has_embeddings};
+pub use embed::{
+    add_chunked_embeddings, count_unembedded_chunks, get_unembedded_chunks, has_embeddings,
+};
 pub use search::{SearchResult, hybrid_search};
 pub use types::*;
 


### PR DESCRIPTION
## 概要

検索実行前に未埋め込みチャンクを自動処理する機能を追加する。バジェットキャップ（最大256チャンク）を設けることで検索レイテンシへの影響を抑えつつ、`sae search` の実行時に埋め込みが欠けている状態を自動的に補完する。

## 変更内容

- `src/commands/search.rs`: `auto_embed_pending` / `auto_embed_pending_with<F>` を追加。検索前に未埋め込みチャンクを最大256件処理する
- `src/storage/embed.rs`: `count_unembedded_chunks` / `get_unembedded_chunks` を追加
- `src/storage/mod.rs`: 新ストレージ関数を再エクスポート
- `src/commands/data.rs`: `BATCH_SIZE` を 64→256 に変更、埋め込み件数不一致ガードを追加

## 設計上の判断

| 決定 | 内容 |
|---|---|
| DI via `auto_embed_pending_with<F>` | 実モデル不要のユニットテストを実現。埋め込み関数を引数として注入 |
| バジェットキャップ 256 チャンク | 検索レイテンシ優先。全件処理は `sae embed` に委ねる |
| 失敗は非致命的 | 自動埋め込みが失敗しても warning のみ出力し、検索を続行する |
| 件数不一致ガード | `run_embed` と `auto_embed_pending_with` の両方に追加 |

## テスト

TC-037〜041 の5テストを追加（`src/commands/search.rs`）、ストレージ関数の2テストを追加（`src/storage/embed.rs`）。

Closes #37