### PR TITLE
検索出力のクリーンアップとモデルスピナー削除

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -5,6 +5,14 @@ use sae::config::Config;
 
 use crate::{SaeError, require_db};
 
+/// Emit a user-visible warning to stderr and a structured log entry.
+macro_rules! warn_user {
+    ($user_msg:literal; $($log:tt)+) => {{
+        eprintln!("Warning: {}", format_args!($user_msg));
+        tracing::warn!($($log)+);
+    }};
+}
+
 pub(crate) fn run_search(
     config: &Config,
     query: &str,
@@ -20,23 +28,26 @@ pub(crate) fn run_search(
             "Hint: run 'sae model download && sae embed <team>' to enable semantic search"
         ),
         ModelLoad::Failed(e) => {
-            eprintln!("Warning: embedding model not available ({e})");
-            tracing::warn!(error = %e, "embedding model not available");
+            warn_user!("embedding model not available ({e})"; error = %e, "embedding model not available");
         }
         ModelLoad::Ready(_) => {}
     }
-    if let ModelLoad::Ready(ref emb) = embedder
-        && let Err(e) = auto_embed_pending(&db, team, emb)
-    {
-        eprintln!("Warning: auto-embed failed ({e}), continuing with existing embeddings");
-        tracing::warn!(error = %e, "auto_embed_pending failed, continuing search");
-    }
+    let embed_info = if let ModelLoad::Ready(ref emb) = embedder {
+        match auto_embed_pending(&db, emb) {
+            Ok(info) => Some(info),
+            Err(e) => {
+                warn_user!("auto-embed failed ({e}), continuing with existing embeddings"; error = %e, "auto_embed_pending failed, continuing search");
+                None
+            }
+        }
+    } else {
+        None
+    };
     let query_embedding = if let ModelLoad::Ready(ref e) = embedder {
         match e.embed_query(query) {
             Ok(v) => Some(v),
             Err(e) => {
-                eprintln!("Warning: embed_query failed ({e}), falling back to FTS");
-                tracing::warn!(error = %e, %query, "embed_query failed, falling back to FTS");
+                warn_user!("embed_query failed ({e}), falling back to FTS"; error = %e, %query, "embed_query failed, falling back to FTS");
                 None
             }
         }
@@ -51,7 +62,7 @@ pub(crate) fn run_search(
         chrono::Utc::now(),
     )?;
     let semantic = query_embedding.is_some();
-    let output = crate::output::search(&results, query, json, semantic)?;
+    let output = crate::output::search(&results, query, json, semantic, embed_info, team)?;
     const PREFETCH_TTL_SECS: u64 = 5 * 60;
     if !sae::storage::sync_harvested_within(db.conn(), PREFETCH_TTL_SECS) {
         spawn_background_harvest(team);
@@ -61,40 +72,35 @@ pub(crate) fn run_search(
 
 fn auto_embed_pending(
     db: &sae::storage::Db,
-    team: &str,
     embedder: &Embedder,
-) -> Result<(), SaeError> {
+) -> Result<(u32, bool), SaeError> {
     const EMBED_BUDGET: u32 = 128;
-    let budget_exhausted = auto_embed_pending_with(db, EMBED_BUDGET, |texts| {
+    auto_embed_pending_with(db, EMBED_BUDGET, |texts| {
         embedder
             .embed_documents_batch(texts)
             .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
-    })?;
-    if budget_exhausted {
-        eprintln!("Hint: more chunks pending. Run 'sae embed {team}' to index all.");
-    }
-    Ok(())
+    })
 }
 
-/// Returns `Ok(true)` when the budget was fully consumed (more chunks may be pending).
+/// Embeds up to `budget` pending chunks in one batch.
+/// Returns `(processed, budget_exhausted)` — `budget_exhausted` signals more chunks remain.
 fn auto_embed_pending_with<F>(
     db: &sae::storage::Db,
     budget: u32,
     embed_fn: F,
-) -> Result<bool, SaeError>
+) -> Result<(u32, bool), SaeError>
 where
     F: Fn(&[&str]) -> Result<Vec<ChunkedEmbedding>, SaeError>,
 {
     let result = super::embed_batch::embed_one_batch(db.conn(), budget, embed_fn)?;
     if result.processed == 0 {
-        return Ok(false);
+        return Ok((0, false));
     }
-    eprintln!("Embedded {} new chunks", result.processed);
-    tracing::info!(
+    tracing::debug!(
         chunks = result.processed,
         "auto_embed_pending: embedded chunks during search"
     );
-    Ok(result.budget_exhausted)
+    Ok((result.processed, result.budget_exhausted))
 }
 
 pub(crate) enum ModelLoad {
@@ -121,15 +127,12 @@ fn try_load_embedder_with<E: std::fmt::Display>(
             return ModelLoad::Failed(e.to_string());
         }
     };
-    let spinner = crate::progress::Spinner::new("Loading model...");
     match Embedder::new(&paths) {
         Ok(e) => {
-            spinner.finish("Model ready");
             tracing::debug!("embedding model loaded");
             ModelLoad::Ready(Box::new(e))
         }
         Err(e) => {
-            spinner.cancel();
             tracing::debug!(error = %e, "embedding model load failed");
             ModelLoad::Failed(e.to_string())
         }
@@ -275,7 +278,7 @@ mod tests {
         });
         assert!(result.is_ok());
         assert!(
-            result.unwrap(),
+            result.unwrap().1,
             "budget=1 with 2 chunks should signal budget exhausted"
         );
         assert_eq!(

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -3,7 +3,7 @@ use std::io::{IsTerminal, Read};
 use rurico::embed::{ChunkedEmbedding, Embed, Embedder, ModelId};
 use sae::config::Config;
 
-use crate::{require_db, SaeError};
+use crate::{SaeError, require_db};
 
 /// Emit a user-visible warning to stderr and a structured log entry.
 macro_rules! warn_user {

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -3,7 +3,7 @@ use std::io::{IsTerminal, Read};
 use rurico::embed::{ChunkedEmbedding, Embed, Embedder, ModelId};
 use sae::config::Config;
 
-use crate::{SaeError, require_db};
+use crate::{require_db, SaeError};
 
 /// Emit a user-visible warning to stderr and a structured log entry.
 macro_rules! warn_user {
@@ -70,10 +70,7 @@ pub(crate) fn run_search(
     Ok(output)
 }
 
-fn auto_embed_pending(
-    db: &sae::storage::Db,
-    embedder: &Embedder,
-) -> Result<(u32, bool), SaeError> {
+fn auto_embed_pending(db: &sae::storage::Db, embedder: &Embedder) -> Result<(u32, bool), SaeError> {
     const EMBED_BUDGET: u32 = 128;
     auto_embed_pending_with(db, EMBED_BUDGET, |texts| {
         embedder

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,9 @@ where
     let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
     let expanded = shorthand::try_expand_shorthand(&args, KNOWN_SUBCOMMANDS, GLOBAL_FLAGS);
     if let Some(expanded) = expanded {
-        let display: Vec<_> = expanded.iter().filter_map(|a| a.to_str()).collect();
+        let display: Vec<_> = std::iter::once("sae")
+            .chain(expanded[1..].iter().filter_map(|a| a.to_str()))
+            .collect();
         eprintln!("→ {}", display.join(" "));
         return Cli::try_parse_from(expanded);
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -21,6 +21,8 @@ pub(crate) fn search(
     query: &str,
     json: bool,
     semantic: bool,
+    embed_info: Option<(u32, bool)>,
+    team: &str,
 ) -> Result<String, SaeError> {
     let search_mode = if semantic { "hybrid" } else { "fts" };
     if json {
@@ -47,6 +49,16 @@ pub(crate) fn search(
             ));
             if !r.snippet.is_empty() {
                 lines.push(format!("  {}", r.snippet.replace('\n', " ")));
+            }
+        }
+        if let Some((processed, budget_exhausted)) = embed_info {
+            if processed > 0 {
+                lines.push(format!("(Embedded {processed} new chunks)"));
+            }
+            if budget_exhausted {
+                lines.push(format!(
+                    "Hint: more chunks pending. Run 'sae embed {team}' to index all."
+                ));
             }
         }
         Ok(lines.join("\n"))
@@ -269,8 +281,8 @@ mod tests {
         let result = sae::storage::EmbedResult {
             chunks_embedded: 42,
         };
-        let json = serde_json::to_string(&result).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let out = embed(&result, 42, true).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["chunks_embedded"], 42);
     }
 
@@ -326,7 +338,7 @@ mod tests {
     // TC-007: search json includes search_mode hybrid
     #[test]
     fn search_json_hybrid_includes_search_mode() {
-        let out = search(&[], "test", true, true).unwrap();
+        let out = search(&[], "test", true, true, None, "").unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["search_mode"], "hybrid");
         assert!(v["results"].is_array());
@@ -335,7 +347,7 @@ mod tests {
     // TC-007: search json includes search_mode fts
     #[test]
     fn search_json_fts_includes_search_mode() {
-        let out = search(&[], "test", true, false).unwrap();
+        let out = search(&[], "test", true, false, None, "").unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["search_mode"], "fts");
     }
@@ -351,7 +363,7 @@ mod tests {
             snippet: String::new(),
             score: 0.5,
         }];
-        let out = search(&results, "q", false, false).unwrap();
+        let out = search(&results, "q", false, false, None, "").unwrap();
         assert!(out.contains("semantic search unavailable"));
     }
 
@@ -366,7 +378,7 @@ mod tests {
             snippet: String::new(),
             score: 0.5,
         }];
-        let out = search(&results, "q", false, true).unwrap();
+        let out = search(&results, "q", false, true, None, "").unwrap();
         assert!(!out.contains("semantic search unavailable"));
     }
 }


### PR DESCRIPTION
## 概要

- LLM利用時のstderrノイズ削減のため、モデル読み込み時の「Model ready」スピナーを削除
- auto-embed進捗情報（チャンク数、バジェット超過ヒント）を出力途中のstderrから`output::search`経由でstdout末尾に移動
- shorthand展開表示をフルバイナリパスから`sae`に修正、`warn_user!`マクロを抽出して3箇所の`eprintln` + `tracing::warn`重複を解消、auto-embedのトレーシングレベルを`info`から`debug`に変更

## テスト計画

- [ ] `cargo test` が`output.rs`テストの更新済み`search`呼び出しで通ること
- [ ] モデルがある状態で`sae search <query>`実行時、stderrに「Model ready」スピナーが出ないこと
- [ ] auto-embed進捗行が検索結果の末尾に表示され、結果と混在しないこと
- [ ] shorthand展開（例: `sae s <query>`）が`→ sae search <query>`と表示されること
- [ ] `sae search <query> --json`で`search_mode`と`results`フィールドが変わらないこと