### PR TITLE
Embedder::probe() を Embedder::new() の前に追加

### DIFF
--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -1,4 +1,4 @@
-use rurico::embed::{Embedder, ModelId};
+use rurico::embed::{Embedder, ModelId, ProbeStatus};
 use sae::config::Config;
 
 use crate::{SaeError, require_db, resolve_client};
@@ -24,6 +24,19 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
 
     let paths = require_embed_model()?;
     let spinner = crate::progress::Spinner::new("Loading model...");
+    match Embedder::probe(&paths) {
+        Ok(ProbeStatus::Available) => {}
+        Ok(ProbeStatus::BackendUnavailable) => {
+            spinner.cancel();
+            return Err(SaeError::Other(
+                "MLX backend is unavailable".to_string(),
+            ));
+        }
+        Err(e) => {
+            spinner.cancel();
+            return Err(SaeError::Other(format!("Model probe failed: {e}")));
+        }
+    }
     let embedder =
         Embedder::new(&paths).map_err(|e| SaeError::Other(format!("Failed to load model: {e}")))?;
     spinner.finish("Model ready");
@@ -65,6 +78,19 @@ pub(crate) fn run_model_download(json: bool) -> Result<String, SaeError> {
             return Err(SaeError::Other(format!("Failed to download model: {e}")));
         }
     };
+    match Embedder::probe(&paths) {
+        Ok(ProbeStatus::Available) => {}
+        Ok(ProbeStatus::BackendUnavailable) => {
+            spinner.cancel();
+            return Err(SaeError::Other(
+                "Model downloaded but MLX backend is unavailable".to_string(),
+            ));
+        }
+        Err(e) => {
+            spinner.cancel();
+            return Err(SaeError::Other(format!("Model probe failed: {e}")));
+        }
+    }
     match Embedder::new(&paths) {
         Ok(_) => {
             spinner.finish("Model ready");

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -28,9 +28,7 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
         Ok(ProbeStatus::Available) => {}
         Ok(ProbeStatus::BackendUnavailable) => {
             spinner.cancel();
-            return Err(SaeError::Other(
-                "MLX backend is unavailable".to_string(),
-            ));
+            return Err(SaeError::Other("MLX backend is unavailable".to_string()));
         }
         Err(e) => {
             spinner.cancel();


### PR DESCRIPTION
Closes #44

- `run_embed` と `run_model_download` の両フローで `Embedder::new()` 呼び出し前に `Embedder::probe()` を実行し、MLX バックエンドの可用性を早期チェックする。
- `ProbeStatus::BackendUnavailable` の場合はスピナーをキャンセルし、"MLX backend is unavailable" という明示的なエラーを返して汎用エラーと区別できるようにする。
- `model download` フロー完了後のプローブでも同様に BackendUnavailable を検出し、"Model downloaded but MLX backend is unavailable" として報告する。

## テスト計画

- MLX 利用可能環境で `sae embed` / `sae model download` が正常完了することを確認
- MLX 非対応環境（またはモック）で `BackendUnavailable` エラーメッセージが出力され、クラッシュしないことを確認
- `probe` がエラーを返すケースで `"Model probe failed: ..."` メッセージが出力されることを確認