### PR TITLE
feat(search): hybrid_searchにtags/category/created_byフィルタを追加

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -5,7 +5,6 @@ use sae::config::Config;
 
 use crate::{SaeError, require_db};
 
-/// Emit a user-visible warning to stderr and a structured log entry.
 macro_rules! warn_user {
     ($user_msg:literal; $($log:tt)+) => {{
         eprintln!("Warning: {}", format_args!($user_msg));
@@ -60,6 +59,9 @@ pub(crate) fn run_search(
         query_embedding.as_deref(),
         limit,
         chrono::Utc::now(),
+        None,
+        None,
+        None,
     )?;
     let semantic = query_embedding.is_some();
     let output = crate::output::search(&results, query, json, semantic, embed_info, team)?;
@@ -343,16 +345,16 @@ mod tests {
         );
     }
 
-    // TC-010: try_load_embedder_with returns None when model is not cached
+    // TC-010: try_load_embedder_with returns Absent when model is not cached
     #[test]
-    fn try_load_embedder_with_returns_none_when_no_model() {
+    fn try_load_embedder_with_returns_absent_when_no_model() {
         let result = try_load_embedder_with(|| Ok::<_, &str>(None));
         assert!(matches!(result, ModelLoad::Absent));
     }
 
-    // TC-010: try_load_embedder_with returns None on cache check error
+    // TC-010: try_load_embedder_with returns Failed on cache check error
     #[test]
-    fn try_load_embedder_with_returns_none_on_cache_error() {
+    fn try_load_embedder_with_returns_failed_on_cache_error() {
         let result =
             try_load_embedder_with(|| Err::<Option<rurico::embed::Artifacts>, _>("cache error"));
         assert!(matches!(result, ModelLoad::Failed(_)));

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -59,9 +59,7 @@ pub(crate) fn run_search(
         query_embedding.as_deref(),
         limit,
         chrono::Utc::now(),
-        None,
-        None,
-        None,
+        &sae::storage::SearchFilter::default(),
     )?;
     let semantic = query_embedding.is_some();
     let output = crate::output::search(&results, query, json, semantic, embed_info, team)?;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -38,6 +38,7 @@ impl Spinner {
                 }
             }))
         } else {
+            eprintln!("{msg}");
             None
         };
 
@@ -61,6 +62,8 @@ impl Spinner {
         drop(self);
         if is_tty {
             eprintln!("\x1b[32m✓\x1b[0m {msg}");
+        } else {
+            eprintln!("{msg}");
         }
     }
 

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -44,7 +44,7 @@ fn existing_embedded_ids(
     chunk_ids: &[i64],
 ) -> Result<HashSet<i64>, StorageError> {
     let sql = format!(
-        "SELECT DISTINCT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
+        "SELECT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
         super::in_placeholders(chunk_ids.len())
     );
     let mut stmt = conn.prepare(&sql)?;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub mod types;
 pub use embed::{
     add_chunked_embeddings, count_unembedded_chunks, get_unembedded_chunks, has_embeddings,
 };
-pub use search::{SearchResult, hybrid_search};
+pub use search::{SearchFilter, SearchResult, hybrid_search};
 pub use types::*;
 
 use std::path::Path;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -23,6 +23,12 @@ pub(crate) fn in_placeholders(len: usize) -> String {
         .join(", ")
 }
 
+// Use when multiple IN clauses share a parameter list: unnamed `?` avoids
+// index collisions that numbered `?N` would cause when params are appended incrementally.
+pub(crate) fn anon_placeholders(n: usize) -> String {
+    vec!["?"; n].join(", ")
+}
+
 pub(crate) fn as_sql_params<T: rusqlite::types::ToSql>(
     values: &[T],
 ) -> Vec<&dyn rusqlite::types::ToSql> {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -15,7 +15,14 @@ pub struct SearchResult {
     pub score: f64,
 }
 
-pub fn fts_search(conn: &Connection, query: &str, limit: u32) -> Result<Vec<FtsHit>, StorageError> {
+pub fn fts_search(
+    conn: &Connection,
+    query: &str,
+    limit: u32,
+    tags: Option<&[&str]>,
+    category: Option<&str>,
+    created_by: Option<&str>,
+) -> Result<Vec<FtsHit>, StorageError> {
     let normalized = normalize_punctuation(query);
     let matched = match rurico::storage::prepare_match_query(conn, &normalized) {
         Ok(m) => m,
@@ -24,20 +31,26 @@ pub fn fts_search(conn: &Connection, query: &str, limit: u32) -> Result<Vec<FtsH
             return Ok(Vec::new());
         }
     };
-
     let match_query = clean_for_trigram(matched.as_str());
 
-    let mut stmt = conn.prepare_cached(
+    let mut sql = String::from(
         "SELECT c.id, c.post_number, c.section_title, c.content, f.rank \
          FROM fts_chunks f \
          JOIN chunks c ON c.id = f.rowid \
-         WHERE fts_chunks MATCH ?1 \
-         ORDER BY f.rank \
-         LIMIT ?2",
-    )?;
+         JOIN posts p ON p.number = c.post_number \
+         WHERE fts_chunks MATCH ?",
+    );
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(match_query)];
 
+    append_tags_filter(&mut sql, &mut params, tags);
+    append_eq_filter(&mut sql, &mut params, "p.category", category);
+    append_eq_filter(&mut sql, &mut params, "p.created_by", created_by);
+    sql.push_str(" ORDER BY f.rank LIMIT ?");
+    params.push(Box::new(limit));
+
+    let mut stmt = conn.prepare(&sql)?;
     let rows: Vec<FtsHit> = stmt
-        .query_map(rusqlite::params![&match_query, limit], |row| {
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok(FtsHit {
                 chunk_id: row.get(0)?,
                 post_number: row.get(1)?,
@@ -57,6 +70,9 @@ pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
     limit: u32,
+    tags: Option<&[&str]>,
+    category: Option<&str>,
+    created_by: Option<&str>,
 ) -> Result<Vec<VecHit>, StorageError> {
     let bytes: &[u8] = rurico::storage::f32_as_bytes(query_embedding);
     let oversample = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
@@ -82,29 +98,35 @@ pub fn vec_search(
     // MaxSim: keep the sub-embedding with the smallest distance per chunk_id
     let mut best: HashMap<i64, f32> = HashMap::new();
     for (chunk_id, distance) in &knn_rows {
-        use std::collections::hash_map::Entry;
-        match best.entry(*chunk_id) {
-            Entry::Vacant(v) => {
-                v.insert(*distance);
-            }
-            Entry::Occupied(mut o) => {
-                if distance < o.get() {
-                    *o.get_mut() = *distance;
+        best.entry(*chunk_id)
+            .and_modify(|d| {
+                if *distance < *d {
+                    *d = *distance;
                 }
-            }
-        }
+            })
+            .or_insert(*distance);
     }
 
     // Step 2: batch-fetch chunk metadata for the deduplicated chunk_ids
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let sql = format!(
-        "SELECT id, post_number, section_title, content FROM chunks WHERE id IN ({})",
-        super::in_placeholders(chunk_ids.len())
+    let mut sql = format!(
+        "SELECT c.id, c.post_number, c.section_title, c.content \
+         FROM chunks c \
+         JOIN posts p ON p.number = c.post_number \
+         WHERE c.id IN ({})",
+        super::anon_placeholders(chunk_ids.len())
     );
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = chunk_ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect();
+    append_tags_filter(&mut sql, &mut params, tags);
+    append_eq_filter(&mut sql, &mut params, "p.category", category);
+    append_eq_filter(&mut sql, &mut params, "p.created_by", created_by);
+
     let mut stmt2 = conn.prepare(&sql)?;
-    let params = super::as_sql_params(&chunk_ids);
     let meta: HashMap<i64, (u32, Option<String>, String)> = stmt2
-        .query_map(params.as_slice(), |row| {
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, u32>(1)?,
@@ -147,20 +169,25 @@ pub fn hybrid_search(
     query_embedding: Option<&[f32]>,
     limit: u32,
     now: chrono::DateTime<chrono::Utc>,
+    tags: Option<&[&str]>,
+    category: Option<&str>,
+    created_by: Option<&str>,
 ) -> Result<Vec<SearchResult>, StorageError> {
     let candidate_limit = limit * 3;
 
-    let fts_hits = fts_search(conn, query, candidate_limit)?;
+    let fts_hits = fts_search(conn, query, candidate_limit, tags, category, created_by)?;
 
     let vec_hits = match query_embedding {
-        Some(emb) if super::has_embeddings(conn) => match vec_search(conn, emb, candidate_limit) {
-            Ok(hits) => hits,
-            Err(e) => {
-                eprintln!("  warning: vector search failed, falling back to text search only");
-                warn!(%e, %query, candidate_limit, "vec_search failed, falling back to FTS only");
-                Vec::new()
+        Some(emb) if super::has_embeddings(conn) => {
+            match vec_search(conn, emb, candidate_limit, tags, category, created_by) {
+                Ok(hits) => hits,
+                Err(e) => {
+                    eprintln!("  warning: vector search failed, falling back to text search only");
+                    warn!(%e, %query, candidate_limit, "vec_search failed, falling back to FTS only");
+                    Vec::new()
+                }
             }
-        },
+        }
         _ => Vec::new(),
     };
 
@@ -209,6 +236,36 @@ pub fn hybrid_search(
         })
         .collect();
     Ok(results)
+}
+
+fn append_tags_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    tags: Option<&[&str]>,
+) {
+    if let Some(tags) = tags
+        && !tags.is_empty()
+    {
+        sql.push_str(&format!(
+            " AND EXISTS (SELECT 1 FROM json_each(p.tags) jt WHERE jt.value IN ({}))",
+            super::anon_placeholders(tags.len())
+        ));
+        for &tag in tags {
+            params.push(Box::new(tag.to_string()));
+        }
+    }
+}
+
+fn append_eq_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    column: &str,
+    value: Option<&str>,
+) {
+    if let Some(v) = value {
+        sql.push_str(&format!(" AND {column} = ?"));
+        params.push(Box::new(v.to_string()));
+    }
 }
 
 fn apply_recency_boost(
@@ -452,7 +509,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "ガイド", 10).unwrap();
+        let hits = fts_search(db.conn(), "ガイド", 10, None, None, None).unwrap();
         assert!(!hits.is_empty());
         let post_nums: Vec<u32> = hits.iter().map(|h| h.post_number).collect();
         assert!(post_nums.contains(&3));
@@ -463,7 +520,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "認証", 10).unwrap();
+        let hits = fts_search(db.conn(), "認証", 10, None, None, None).unwrap();
         assert!(!hits.is_empty());
         let post_nums: Vec<u32> = hits.iter().map(|h| h.post_number).collect();
         assert!(post_nums.contains(&1) || post_nums.contains(&2));
@@ -474,7 +531,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "設", 10).unwrap();
+        let hits = fts_search(db.conn(), "設", 10, None, None, None).unwrap();
         assert!(!hits.is_empty());
     }
 
@@ -493,8 +550,17 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let results =
-            hybrid_search(db.conn(), "認証の仕組み", None, 10, chrono::Utc::now()).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "認証の仕組み",
+            None,
+            10,
+            chrono::Utc::now(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].post_number, 1);
         assert!(!results[0].post_name.is_empty());
@@ -506,7 +572,17 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let results = hybrid_search(db.conn(), "", None, 10, chrono::Utc::now()).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "",
+            None,
+            10,
+            chrono::Utc::now(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(results.is_empty());
     }
 
@@ -571,7 +647,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        fts_search(db.conn(), "認証、フロー", 10).unwrap();
+        fts_search(db.conn(), "認証、フロー", 10, None, None, None).unwrap();
     }
 
     #[test]
@@ -596,19 +672,19 @@ mod tests {
         }
 
         // C++ should match post 10 (+ is preserved, no rurico quoting issue)
-        let hits = fts_search(db.conn(), "C++", 10).unwrap();
+        let hits = fts_search(db.conn(), "C++", 10, None, None, None).unwrap();
         assert!(!hits.is_empty(), "C++ should match");
         assert!(hits.iter().any(|h| h.post_number == 10));
 
         // rate-limit → "rate limit" (- stripped). Both ≥3 chars, no vocab
         // expansion needed, so no single-element parenthesization issue.
-        let hits = fts_search(db.conn(), "rate-limit", 10).unwrap();
+        let hits = fts_search(db.conn(), "rate-limit", 10, None, None, None).unwrap();
         assert!(!hits.is_empty(), "rate-limit (split) should match");
         assert!(hits.iter().any(|h| h.post_number == 11));
 
         // std::io → "std io" (: stripped). "io" (2 chars) expands via vocab.
         // clean_for_trigram unwraps single-element parens for trigram compat.
-        let hits = fts_search(db.conn(), "std::io", 10).unwrap();
+        let hits = fts_search(db.conn(), "std::io", 10, None, None, None).unwrap();
         assert!(!hits.is_empty(), "std::io (split) should match");
         assert!(hits.iter().any(|h| h.post_number == 10));
     }
@@ -652,7 +728,8 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let results = hybrid_search(db.conn(), "認証の仕組み", None, 10, now).unwrap();
+        let results =
+            hybrid_search(db.conn(), "認証の仕組み", None, 10, now, None, None, None).unwrap();
         assert!(results.len() >= 2, "both posts should match");
 
         let score_a = results.iter().find(|r| r.post_number == 1).unwrap().score;
@@ -678,7 +755,8 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let results = hybrid_search(db.conn(), "認証の仕組み", None, 10, now).unwrap();
+        let results =
+            hybrid_search(db.conn(), "認証の仕組み", None, 10, now, None, None, None).unwrap();
 
         assert!(!results.is_empty(), "post should still be returned");
         assert!(
@@ -696,7 +774,7 @@ mod tests {
         storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
-        let hits = fts_search(db.conn(), "フローの説明", 10).unwrap();
+        let hits = fts_search(db.conn(), "フローの説明", 10, None, None, None).unwrap();
         assert!(
             !hits.is_empty(),
             "[T-002] content-only term must still be found (regression)"
@@ -714,7 +792,7 @@ mod tests {
         let count = storage::rechunk_post(db.conn(), 1, body).unwrap();
         assert_eq!(count, 1, "[T-003] preamble should produce 1 chunk");
 
-        let hits = fts_search(db.conn(), "見出しなし", 10).unwrap();
+        let hits = fts_search(db.conn(), "見出しなし", 10, None, None, None).unwrap();
         assert!(
             !hits.is_empty(),
             "[T-003] preamble chunk should be searchable by content"
@@ -734,7 +812,7 @@ mod tests {
         storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
-        let hits = fts_search(db.conn(), "認証ガイド", 10).unwrap();
+        let hits = fts_search(db.conn(), "認証ガイド", 10, None, None, None).unwrap();
         assert!(
             !hits.is_empty(),
             "[T-001] section_title-only term should be found via FTS"
@@ -758,19 +836,19 @@ mod tests {
         storage::rechunk_post(db.conn(), 1, &enriched).unwrap();
 
         // Post name
-        let hits = fts_search(db.conn(), "Daily振り返り", 10).unwrap();
+        let hits = fts_search(db.conn(), "Daily振り返り", 10, None, None, None).unwrap();
         assert!(!hits.is_empty(), "post name should be searchable");
 
         // Author
-        let hits = fts_search(db.conn(), "thkt", 10).unwrap();
+        let hits = fts_search(db.conn(), "thkt", 10, None, None, None).unwrap();
         assert!(!hits.is_empty(), "author should be searchable");
 
         // Category
-        let hits = fts_search(db.conn(), "日報", 10).unwrap();
+        let hits = fts_search(db.conn(), "日報", 10, None, None, None).unwrap();
         assert!(!hits.is_empty(), "category/tag should be searchable");
 
         // Combined query (matching esa web search behavior)
-        let hits = fts_search(db.conn(), "Daily 振り返り thkt", 10).unwrap();
+        let hits = fts_search(db.conn(), "Daily 振り返り thkt", 10, None, None, None).unwrap();
         assert!(
             !hits.is_empty(),
             "combined name + author query should match"
@@ -840,8 +918,17 @@ mod tests {
         storage::add_chunked_embeddings(db.conn(), &embeddings).unwrap();
 
         let query_emb = vec![0.1; EMBEDDING_DIMS];
-        let results =
-            hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "認証",
+            Some(&query_emb),
+            10,
+            chrono::Utc::now(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(!results.is_empty());
         assert!(!results[0].post_name.is_empty());
         assert!(!results[0].post_url.is_empty());
@@ -877,8 +964,17 @@ mod tests {
         let mut query_emb = vec![0.01_f32; EMBEDDING_DIMS];
         query_emb[0] = 1.0;
 
-        let results =
-            hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "認証",
+            Some(&query_emb),
+            10,
+            chrono::Utc::now(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(results.len() >= 2, "expected at least 2 results");
 
         // First result should come from the chunk with the closest embedding
@@ -930,8 +1026,17 @@ mod tests {
         let mut query_emb = vec![0.01_f32; EMBEDDING_DIMS];
         query_emb[0] = 1.0;
 
-        let results =
-            hybrid_search(db.conn(), "認証", Some(&query_emb), 10, chrono::Utc::now()).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "認証",
+            Some(&query_emb),
+            10,
+            chrono::Utc::now(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(
             !results.is_empty(),
             "should have results with multi-sub embeddings"
@@ -993,12 +1098,142 @@ mod tests {
         let mut query = vec![0.0f32; EMBEDDING_DIMS];
         query[0] = 1.0;
 
-        let hits = vec_search(db.conn(), &query, 1).unwrap();
+        let hits = vec_search(db.conn(), &query, 1, None, None, None).unwrap();
         assert_eq!(hits.len(), 1, "[TC-004] should return exactly one hit");
         assert!(
             hits[0].distance < 0.1,
             "[TC-004] MaxSim must select sub_idx=1 (closer sub-embedding), got distance={}",
             hits[0].distance
+        );
+    }
+
+    #[test]
+    fn fts_filter_category_narrows_results() {
+        let db = Db::open_memory().unwrap();
+
+        let mut post1 = storage::test_post_row(1);
+        post1.body_md = "# 認証フロー\n認証の仕組みを説明します".into();
+        post1.category = Some("backend".into());
+        storage::upsert_post(db.conn(), &post1).unwrap();
+        storage::rechunk_post(db.conn(), 1, &post1.body_md).unwrap();
+
+        let mut post2 = storage::test_post_row(2);
+        post2.body_md = "# 認証フロー\n認証の実装".into();
+        post2.category = Some("frontend".into());
+        storage::upsert_post(db.conn(), &post2).unwrap();
+        storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
+
+        let hits = fts_search(db.conn(), "認証", 10, None, Some("backend"), None).unwrap();
+        assert!(!hits.is_empty(), "category filter should return results");
+        assert!(
+            hits.iter().all(|h| h.post_number == 1),
+            "category=backend should only match post 1"
+        );
+    }
+
+    #[test]
+    fn fts_filter_created_by_narrows_results() {
+        let db = Db::open_memory().unwrap();
+
+        let mut post1 = storage::test_post_row(1);
+        post1.body_md = "# 認証フロー\n認証の仕組みを説明します".into();
+        post1.created_by = "alice".into();
+        storage::upsert_post(db.conn(), &post1).unwrap();
+        storage::rechunk_post(db.conn(), 1, &post1.body_md).unwrap();
+
+        let mut post2 = storage::test_post_row(2);
+        post2.body_md = "# 認証フロー\n認証の実装".into();
+        post2.created_by = "bob".into();
+        storage::upsert_post(db.conn(), &post2).unwrap();
+        storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
+
+        let hits = fts_search(db.conn(), "認証", 10, None, None, Some("alice")).unwrap();
+        assert!(!hits.is_empty(), "created_by filter should return results");
+        assert!(
+            hits.iter().all(|h| h.post_number == 1),
+            "created_by=alice should only match post 1"
+        );
+    }
+
+    #[test]
+    fn fts_filter_tags_narrows_results() {
+        let db = Db::open_memory().unwrap();
+
+        let mut post1 = storage::test_post_row(1);
+        post1.body_md = "# 認証フロー\n認証の仕組みを説明します".into();
+        post1.tags = vec!["security".into(), "auth".into()];
+        storage::upsert_post(db.conn(), &post1).unwrap();
+        storage::rechunk_post(db.conn(), 1, &post1.body_md).unwrap();
+
+        let mut post2 = storage::test_post_row(2);
+        post2.body_md = "# 認証フロー\n認証の実装".into();
+        post2.tags = vec!["frontend".into()];
+        storage::upsert_post(db.conn(), &post2).unwrap();
+        storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
+
+        let hits = fts_search(db.conn(), "認証", 10, Some(&["security"]), None, None).unwrap();
+        assert!(!hits.is_empty(), "tags filter should return results");
+        assert!(
+            hits.iter().all(|h| h.post_number == 1),
+            "tags=[security] should only match post 1"
+        );
+    }
+
+    #[test]
+    fn fts_filter_all_none_returns_all_matching() {
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let hits = fts_search(db.conn(), "認証", 10, None, None, None).unwrap();
+        assert!(
+            !hits.is_empty(),
+            "no filters should return all matching posts"
+        );
+    }
+
+    #[test]
+    fn fts_filter_empty_tags_returns_all_matching() {
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let hits = fts_search(db.conn(), "認証", 10, Some(&[]), None, None).unwrap();
+        assert!(
+            !hits.is_empty(),
+            "empty tags slice should not filter anything"
+        );
+    }
+
+    #[test]
+    fn hybrid_search_filter_category_narrows_results() {
+        let db = Db::open_memory().unwrap();
+
+        let mut post1 = storage::test_post_row(1);
+        post1.body_md = "# 認証フロー\n認証の仕組みを説明します".into();
+        post1.category = Some("backend".into());
+        storage::upsert_post(db.conn(), &post1).unwrap();
+        storage::rechunk_post(db.conn(), 1, &post1.body_md).unwrap();
+
+        let mut post2 = storage::test_post_row(2);
+        post2.body_md = "# 認証フロー\n認証の実装".into();
+        post2.category = Some("frontend".into());
+        storage::upsert_post(db.conn(), &post2).unwrap();
+        storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
+
+        let results = hybrid_search(
+            db.conn(),
+            "認証の仕組み",
+            None,
+            10,
+            chrono::Utc::now(),
+            None,
+            Some("backend"),
+            None,
+        )
+        .unwrap();
+        assert!(!results.is_empty(), "category filter should return results");
+        assert!(
+            results.iter().all(|r| r.post_number == 1),
+            "category=backend should only match post 1"
         );
     }
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -15,13 +15,18 @@ pub struct SearchResult {
     pub score: f64,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilter<'a> {
+    pub tags: Option<&'a [&'a str]>,
+    pub category: Option<&'a str>,
+    pub created_by: Option<&'a str>,
+}
+
 pub fn fts_search(
     conn: &Connection,
     query: &str,
     limit: u32,
-    tags: Option<&[&str]>,
-    category: Option<&str>,
-    created_by: Option<&str>,
+    filter: &SearchFilter<'_>,
 ) -> Result<Vec<FtsHit>, StorageError> {
     let normalized = normalize_punctuation(query);
     let matched = match rurico::storage::prepare_match_query(conn, &normalized) {
@@ -42,9 +47,9 @@ pub fn fts_search(
     );
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(match_query)];
 
-    append_tags_filter(&mut sql, &mut params, tags);
-    append_eq_filter(&mut sql, &mut params, "p.category", category);
-    append_eq_filter(&mut sql, &mut params, "p.created_by", created_by);
+    append_tags_filter(&mut sql, &mut params, filter.tags);
+    append_eq_filter(&mut sql, &mut params, "p.category", filter.category);
+    append_eq_filter(&mut sql, &mut params, "p.created_by", filter.created_by);
     sql.push_str(" ORDER BY f.rank LIMIT ?");
     params.push(Box::new(limit));
 
@@ -70,9 +75,7 @@ pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
     limit: u32,
-    tags: Option<&[&str]>,
-    category: Option<&str>,
-    created_by: Option<&str>,
+    filter: &SearchFilter<'_>,
 ) -> Result<Vec<VecHit>, StorageError> {
     let bytes: &[u8] = rurico::storage::f32_as_bytes(query_embedding);
     let oversample = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
@@ -120,9 +123,9 @@ pub fn vec_search(
         .iter()
         .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
         .collect();
-    append_tags_filter(&mut sql, &mut params, tags);
-    append_eq_filter(&mut sql, &mut params, "p.category", category);
-    append_eq_filter(&mut sql, &mut params, "p.created_by", created_by);
+    append_tags_filter(&mut sql, &mut params, filter.tags);
+    append_eq_filter(&mut sql, &mut params, "p.category", filter.category);
+    append_eq_filter(&mut sql, &mut params, "p.created_by", filter.created_by);
 
     let mut stmt2 = conn.prepare(&sql)?;
     let meta: HashMap<i64, (u32, Option<String>, String)> = stmt2
@@ -169,17 +172,15 @@ pub fn hybrid_search(
     query_embedding: Option<&[f32]>,
     limit: u32,
     now: chrono::DateTime<chrono::Utc>,
-    tags: Option<&[&str]>,
-    category: Option<&str>,
-    created_by: Option<&str>,
+    filter: &SearchFilter<'_>,
 ) -> Result<Vec<SearchResult>, StorageError> {
     let candidate_limit = limit * 3;
 
-    let fts_hits = fts_search(conn, query, candidate_limit, tags, category, created_by)?;
+    let fts_hits = fts_search(conn, query, candidate_limit, filter)?;
 
     let vec_hits = match query_embedding {
         Some(emb) if super::has_embeddings(conn) => {
-            match vec_search(conn, emb, candidate_limit, tags, category, created_by) {
+            match vec_search(conn, emb, candidate_limit, filter) {
                 Ok(hits) => hits,
                 Err(e) => {
                     eprintln!("  warning: vector search failed, falling back to text search only");
@@ -509,7 +510,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "ガイド", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "ガイド", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty());
         let post_nums: Vec<u32> = hits.iter().map(|h| h.post_number).collect();
         assert!(post_nums.contains(&3));
@@ -520,7 +521,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "認証", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "認証", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty());
         let post_nums: Vec<u32> = hits.iter().map(|h| h.post_number).collect();
         assert!(post_nums.contains(&1) || post_nums.contains(&2));
@@ -531,7 +532,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "設", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "設", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty());
     }
 
@@ -556,9 +557,7 @@ mod tests {
             None,
             10,
             chrono::Utc::now(),
-            None,
-            None,
-            None,
+            &SearchFilter::default(),
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -578,9 +577,7 @@ mod tests {
             None,
             10,
             chrono::Utc::now(),
-            None,
-            None,
-            None,
+            &SearchFilter::default(),
         )
         .unwrap();
         assert!(results.is_empty());
@@ -647,7 +644,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        fts_search(db.conn(), "認証、フロー", 10, None, None, None).unwrap();
+        fts_search(db.conn(), "認証、フロー", 10, &SearchFilter::default()).unwrap();
     }
 
     #[test]
@@ -672,19 +669,19 @@ mod tests {
         }
 
         // C++ should match post 10 (+ is preserved, no rurico quoting issue)
-        let hits = fts_search(db.conn(), "C++", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "C++", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty(), "C++ should match");
         assert!(hits.iter().any(|h| h.post_number == 10));
 
         // rate-limit → "rate limit" (- stripped). Both ≥3 chars, no vocab
         // expansion needed, so no single-element parenthesization issue.
-        let hits = fts_search(db.conn(), "rate-limit", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "rate-limit", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty(), "rate-limit (split) should match");
         assert!(hits.iter().any(|h| h.post_number == 11));
 
         // std::io → "std io" (: stripped). "io" (2 chars) expands via vocab.
         // clean_for_trigram unwraps single-element parens for trigram compat.
-        let hits = fts_search(db.conn(), "std::io", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "std::io", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty(), "std::io (split) should match");
         assert!(hits.iter().any(|h| h.post_number == 10));
     }
@@ -728,8 +725,15 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let results =
-            hybrid_search(db.conn(), "認証の仕組み", None, 10, now, None, None, None).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "認証の仕組み",
+            None,
+            10,
+            now,
+            &SearchFilter::default(),
+        )
+        .unwrap();
         assert!(results.len() >= 2, "both posts should match");
 
         let score_a = results.iter().find(|r| r.post_number == 1).unwrap().score;
@@ -755,8 +759,15 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let results =
-            hybrid_search(db.conn(), "認証の仕組み", None, 10, now, None, None, None).unwrap();
+        let results = hybrid_search(
+            db.conn(),
+            "認証の仕組み",
+            None,
+            10,
+            now,
+            &SearchFilter::default(),
+        )
+        .unwrap();
 
         assert!(!results.is_empty(), "post should still be returned");
         assert!(
@@ -774,7 +785,7 @@ mod tests {
         storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
-        let hits = fts_search(db.conn(), "フローの説明", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "フローの説明", 10, &SearchFilter::default()).unwrap();
         assert!(
             !hits.is_empty(),
             "[T-002] content-only term must still be found (regression)"
@@ -792,7 +803,7 @@ mod tests {
         let count = storage::rechunk_post(db.conn(), 1, body).unwrap();
         assert_eq!(count, 1, "[T-003] preamble should produce 1 chunk");
 
-        let hits = fts_search(db.conn(), "見出しなし", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "見出しなし", 10, &SearchFilter::default()).unwrap();
         assert!(
             !hits.is_empty(),
             "[T-003] preamble chunk should be searchable by content"
@@ -812,7 +823,7 @@ mod tests {
         storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
-        let hits = fts_search(db.conn(), "認証ガイド", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "認証ガイド", 10, &SearchFilter::default()).unwrap();
         assert!(
             !hits.is_empty(),
             "[T-001] section_title-only term should be found via FTS"
@@ -836,19 +847,25 @@ mod tests {
         storage::rechunk_post(db.conn(), 1, &enriched).unwrap();
 
         // Post name
-        let hits = fts_search(db.conn(), "Daily振り返り", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "Daily振り返り", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty(), "post name should be searchable");
 
         // Author
-        let hits = fts_search(db.conn(), "thkt", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "thkt", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty(), "author should be searchable");
 
         // Category
-        let hits = fts_search(db.conn(), "日報", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "日報", 10, &SearchFilter::default()).unwrap();
         assert!(!hits.is_empty(), "category/tag should be searchable");
 
         // Combined query (matching esa web search behavior)
-        let hits = fts_search(db.conn(), "Daily 振り返り thkt", 10, None, None, None).unwrap();
+        let hits = fts_search(
+            db.conn(),
+            "Daily 振り返り thkt",
+            10,
+            &SearchFilter::default(),
+        )
+        .unwrap();
         assert!(
             !hits.is_empty(),
             "combined name + author query should match"
@@ -924,9 +941,7 @@ mod tests {
             Some(&query_emb),
             10,
             chrono::Utc::now(),
-            None,
-            None,
-            None,
+            &SearchFilter::default(),
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -970,9 +985,7 @@ mod tests {
             Some(&query_emb),
             10,
             chrono::Utc::now(),
-            None,
-            None,
-            None,
+            &SearchFilter::default(),
         )
         .unwrap();
         assert!(results.len() >= 2, "expected at least 2 results");
@@ -1032,9 +1045,7 @@ mod tests {
             Some(&query_emb),
             10,
             chrono::Utc::now(),
-            None,
-            None,
-            None,
+            &SearchFilter::default(),
         )
         .unwrap();
         assert!(
@@ -1098,7 +1109,7 @@ mod tests {
         let mut query = vec![0.0f32; EMBEDDING_DIMS];
         query[0] = 1.0;
 
-        let hits = vec_search(db.conn(), &query, 1, None, None, None).unwrap();
+        let hits = vec_search(db.conn(), &query, 1, &SearchFilter::default()).unwrap();
         assert_eq!(hits.len(), 1, "[TC-004] should return exactly one hit");
         assert!(
             hits[0].distance < 0.1,
@@ -1123,7 +1134,16 @@ mod tests {
         storage::upsert_post(db.conn(), &post2).unwrap();
         storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
 
-        let hits = fts_search(db.conn(), "認証", 10, None, Some("backend"), None).unwrap();
+        let hits = fts_search(
+            db.conn(),
+            "認証",
+            10,
+            &SearchFilter {
+                category: Some("backend"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert!(!hits.is_empty(), "category filter should return results");
         assert!(
             hits.iter().all(|h| h.post_number == 1),
@@ -1147,7 +1167,16 @@ mod tests {
         storage::upsert_post(db.conn(), &post2).unwrap();
         storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
 
-        let hits = fts_search(db.conn(), "認証", 10, None, None, Some("alice")).unwrap();
+        let hits = fts_search(
+            db.conn(),
+            "認証",
+            10,
+            &SearchFilter {
+                created_by: Some("alice"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert!(!hits.is_empty(), "created_by filter should return results");
         assert!(
             hits.iter().all(|h| h.post_number == 1),
@@ -1171,7 +1200,16 @@ mod tests {
         storage::upsert_post(db.conn(), &post2).unwrap();
         storage::rechunk_post(db.conn(), 2, &post2.body_md).unwrap();
 
-        let hits = fts_search(db.conn(), "認証", 10, Some(&["security"]), None, None).unwrap();
+        let hits = fts_search(
+            db.conn(),
+            "認証",
+            10,
+            &SearchFilter {
+                tags: Some(&["security"]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert!(!hits.is_empty(), "tags filter should return results");
         assert!(
             hits.iter().all(|h| h.post_number == 1),
@@ -1184,7 +1222,7 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "認証", 10, None, None, None).unwrap();
+        let hits = fts_search(db.conn(), "認証", 10, &SearchFilter::default()).unwrap();
         assert!(
             !hits.is_empty(),
             "no filters should return all matching posts"
@@ -1196,7 +1234,16 @@ mod tests {
         let db = Db::open_memory().unwrap();
         setup_db_with_posts(&db);
 
-        let hits = fts_search(db.conn(), "認証", 10, Some(&[]), None, None).unwrap();
+        let hits = fts_search(
+            db.conn(),
+            "認証",
+            10,
+            &SearchFilter {
+                tags: Some(&[]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert!(
             !hits.is_empty(),
             "empty tags slice should not filter anything"
@@ -1225,9 +1272,10 @@ mod tests {
             None,
             10,
             chrono::Utc::now(),
-            None,
-            Some("backend"),
-            None,
+            &SearchFilter {
+                category: Some("backend"),
+                ..Default::default()
+            },
         )
         .unwrap();
         assert!(!results.is_empty(), "category filter should return results");


### PR DESCRIPTION
## 概要

- `fts_search` / `vec_search` / `hybrid_search` に `tags`, `category`, `created_by` フィルタパラメータを追加
- `append_eq_filter`（汎用、yomuパターンに揃えてamici抽出前提）と `append_tags_filter`（sae固有: `json_each` EXISTS サブクエリ）を導入
- `anon_placeholders` ヘルパーを追加 — 複数のフィルタ句を増分追加する際に `?N` 番号付きプレースホルダーとのインデックス衝突を回避
- `fts_search` を `prepare_cached` → `conn.prepare` に変更（動的SQLはステートメントキャッシュ非対応）
- MaxSim重複排除: `Entry::Vacant/Occupied` match → `and_modify().or_insert()` に簡略化
- `existing_embedded_ids` から `SELECT DISTINCT` を削除（呼び出し元の HashSet が重複排除）
- `progress.rs` の非ttyパスをyomuに揃える（`new()` / `finish()` でメッセージを出力）
- フィルタテスト6件追加（category/created_by/tags絞り込み、全None、空tags）

## 設計メモ

`append_eq_filter` は `column: &str` パラメータを使用し、yomuの `append_type_filter` パターンに合わせている。`append_in_filter` は追加しない（YAGNI: tagsフィルタは異なる構造のEXISTSサブクエリを使用; sae内に他のIN-filter用途なし）。ADR-0037参照。

**既知の制限**: `vec_search` のフィルタはメタデータbatch-fetch（Step 2）で適用され、KNNクエリには適用されない（sqlite-vecのvec0仮想テーブルでJOIN不可）。KNN oversampleウィンドウに一致するpostが十分含まれない場合、`limit` 件未満の結果になる可能性がある。FTSパスは影響なし。

## テスト計画

- [ ] `cargo test` 通過（243テスト）
- [ ] フィルタなし（None, None, None デフォルト）での `sae search "query" --team <team>` 正常動作