### PR TITLE
SAE_RERANK によるクロスエンコーダー再ランキングをハイブリッド検索に統合

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 description = "esa semantic search CLI"
 
+[features]
+test-support = ["rurico/test-support"]
+
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
@@ -23,6 +26,7 @@ strsim = "0.11"
 wiremock = "0.6"
 tempfile = "3"
 serial_test = "3"
+rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30", features = ["test-support"] }
 
 [profile.release]
 opt-level = 3

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod archive;
 pub(crate) mod data;
 mod embed_batch;
 pub(crate) mod post;
+mod reranker;
 pub(crate) mod search;
 pub(crate) mod status;

--- a/src/commands/reranker.rs
+++ b/src/commands/reranker.rs
@@ -1,0 +1,156 @@
+use rurico::embed::{Embedder, ModelId};
+use rurico::reranker::{Rerank, Reranker, RerankerModelId};
+
+/// Model load state shared across sae and yomu (amici extraction target).
+///
+/// Identical definition exists in yomu — intentional DRY violation
+/// until amici crate extraction.
+pub(crate) enum ModelLoad<T> {
+    Ready(T),
+    Absent,
+    Failed(String),
+}
+
+impl<T> ModelLoad<T> {
+    pub(crate) fn as_ref(&self) -> Option<&T> {
+        match self {
+            Self::Ready(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Emits a user-facing hint or warning based on load state.
+    /// - `Absent`: prints a hint for how to enable the model.
+    /// - `Failed`: prints a warning and logs via tracing.
+    /// - `Ready`: no-op.
+    pub(crate) fn emit_load_hint(&self, absent_hint: &str, model_label: &str) {
+        match self {
+            Self::Absent => eprintln!("Hint: {absent_hint}"),
+            Self::Failed(e) => {
+                eprintln!("Warning: {model_label} not available ({e})");
+                tracing::warn!(error = %e, "{} not available", model_label);
+            }
+            Self::Ready(_) => {}
+        }
+    }
+}
+
+impl<T> std::fmt::Debug for ModelLoad<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ready(_) => write!(f, "ModelLoad::Ready(..)"),
+            Self::Absent => write!(f, "ModelLoad::Absent"),
+            Self::Failed(msg) => write!(f, "ModelLoad::Failed({msg:?})"),
+        }
+    }
+}
+
+pub(crate) fn try_load_embedder() -> ModelLoad<Box<Embedder>> {
+    try_load_embedder_with(|| rurico::embed::cached_artifacts(ModelId::default()))
+}
+
+pub(crate) fn try_load_embedder_with<E: std::fmt::Display>(
+    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
+) -> ModelLoad<Box<Embedder>> {
+    use rurico::embed::ProbeStatus;
+
+    let paths = match cache_check() {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            tracing::debug!("embedding model not cached");
+            return ModelLoad::Absent;
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "embedding model cache check failed");
+            return ModelLoad::Failed(e.to_string());
+        }
+    };
+    match Embedder::probe(&paths) {
+        Ok(ProbeStatus::Available) => {}
+        Ok(ProbeStatus::BackendUnavailable) => {
+            tracing::debug!("MLX backend unavailable");
+            return ModelLoad::Failed("MLX backend is unavailable".to_string());
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "embedding model probe failed");
+            return ModelLoad::Failed(e.to_string());
+        }
+    }
+    match Embedder::new(&paths) {
+        Ok(e) => {
+            tracing::debug!("embedding model loaded");
+            ModelLoad::Ready(Box::new(e))
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "embedding model load failed");
+            ModelLoad::Failed(e.to_string())
+        }
+    }
+}
+
+pub(crate) fn try_load_reranker() -> ModelLoad<Box<dyn Rerank>> {
+    try_load_reranker_with(|| rurico::reranker::cached_artifacts(RerankerModelId::default()))
+}
+
+pub(crate) fn try_load_reranker_with<E: std::fmt::Display>(
+    cache_check: impl FnOnce() -> Result<Option<rurico::reranker::Artifacts>, E>,
+) -> ModelLoad<Box<dyn Rerank>> {
+    use rurico::reranker::ProbeStatus;
+
+    let artifacts = match cache_check() {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            tracing::debug!("reranker model not cached");
+            return ModelLoad::Absent;
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "reranker model cache check failed");
+            return ModelLoad::Failed(e.to_string());
+        }
+    };
+    match Reranker::probe(&artifacts) {
+        Ok(ProbeStatus::Available) => {}
+        Ok(ProbeStatus::BackendUnavailable) => {
+            tracing::debug!("MLX backend unavailable for reranker");
+            return ModelLoad::Failed("MLX backend is unavailable".to_string());
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "reranker model probe failed");
+            return ModelLoad::Failed(e.to_string());
+        }
+    }
+    match Reranker::new(&artifacts) {
+        Ok(r) => {
+            tracing::debug!("reranker model loaded");
+            ModelLoad::Ready(Box::new(r))
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "reranker model load failed");
+            ModelLoad::Failed(e.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TC-042: try_load_reranker_with returns Absent when model is not cached
+    #[test]
+    fn try_load_reranker_with_returns_absent_when_no_model() {
+        let result = try_load_reranker_with(|| Ok::<_, &str>(None));
+        assert!(matches!(result, ModelLoad::Absent));
+    }
+
+    // TC-043: try_load_reranker_with returns Failed on cache check error
+    #[test]
+    fn try_load_reranker_with_returns_failed_on_cache_error() {
+        let result = try_load_reranker_with(|| {
+            Err::<Option<rurico::reranker::Artifacts>, _>("cache broken")
+        });
+        match result {
+            ModelLoad::Failed(msg) => assert!(msg.contains("cache broken")),
+            other => panic!("expected ModelLoad::Failed, got {other:?}"),
+        }
+    }
+}

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,8 +1,10 @@
 use std::io::{IsTerminal, Read};
 
-use rurico::embed::{ChunkedEmbedding, Embed, Embedder, ModelId};
+use rurico::embed::{ChunkedEmbedding, Embed, Embedder};
+use rurico::reranker::Rerank;
 use sae::config::Config;
 
+use super::reranker::{ModelLoad, try_load_embedder, try_load_reranker};
 use crate::{SaeError, require_db};
 
 macro_rules! warn_user {
@@ -22,15 +24,10 @@ pub(crate) fn run_search(
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
     let embedder = try_load_embedder();
-    match &embedder {
-        ModelLoad::Absent => eprintln!(
-            "Hint: run 'sae model download && sae embed <team>' to enable semantic search"
-        ),
-        ModelLoad::Failed(e) => {
-            warn_user!("embedding model not available ({e})"; error = %e, "embedding model not available");
-        }
-        ModelLoad::Ready(_) => {}
-    }
+    embedder.emit_load_hint(
+        "run 'sae model download && sae embed <team>' to enable semantic search",
+        "embedding model",
+    );
     let embed_info = if let ModelLoad::Ready(ref emb) = embedder {
         match auto_embed_pending(&db, emb) {
             Ok(info) => Some(info),
@@ -53,6 +50,22 @@ pub(crate) fn run_search(
     } else {
         None
     };
+    let rerank_enabled = std::env::var("SAE_RERANK").as_deref() == Ok("1");
+    let reranker: Option<ModelLoad<Box<dyn Rerank>>> = if rerank_enabled {
+        Some(try_load_reranker())
+    } else {
+        None
+    };
+    if let Some(ref r) = reranker {
+        r.emit_load_hint(
+            "reranker model not cached; unset SAE_RERANK=1 to skip reranking",
+            "reranker",
+        );
+    }
+    let reranker_ref: Option<&dyn Rerank> = reranker
+        .as_ref()
+        .and_then(|r| r.as_ref())
+        .map(|b| b.as_ref() as &dyn Rerank);
     let results = sae::storage::hybrid_search(
         db.conn(),
         query,
@@ -60,6 +73,7 @@ pub(crate) fn run_search(
         limit,
         chrono::Utc::now(),
         &sae::storage::SearchFilter::default(),
+        reranker_ref,
     )?;
     let semantic = query_embedding.is_some();
     let output = crate::output::search(&results, query, json, semantic, embed_info, team)?;
@@ -98,55 +112,6 @@ where
         "auto_embed_pending: embedded chunks during search"
     );
     Ok((result.processed, result.budget_exhausted))
-}
-
-pub(crate) enum ModelLoad {
-    Ready(Box<Embedder>),
-    Absent,
-    Failed(String),
-}
-
-pub(crate) fn try_load_embedder() -> ModelLoad {
-    try_load_embedder_with(|| rurico::embed::cached_artifacts(ModelId::default()))
-}
-
-fn try_load_embedder_with<E: std::fmt::Display>(
-    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
-) -> ModelLoad {
-    use rurico::embed::ProbeStatus;
-
-    let paths = match cache_check() {
-        Ok(Some(p)) => p,
-        Ok(None) => {
-            tracing::debug!("embedding model not cached");
-            return ModelLoad::Absent;
-        }
-        Err(e) => {
-            tracing::debug!(error = %e, "embedding model cache check failed");
-            return ModelLoad::Failed(e.to_string());
-        }
-    };
-    match Embedder::probe(&paths) {
-        Ok(ProbeStatus::Available) => {}
-        Ok(ProbeStatus::BackendUnavailable) => {
-            tracing::debug!("MLX backend unavailable");
-            return ModelLoad::Failed("MLX backend is unavailable".to_string());
-        }
-        Err(e) => {
-            tracing::debug!(error = %e, "embedding model probe failed");
-            return ModelLoad::Failed(e.to_string());
-        }
-    }
-    match Embedder::new(&paths) {
-        Ok(e) => {
-            tracing::debug!("embedding model loaded");
-            ModelLoad::Ready(Box::new(e))
-        }
-        Err(e) => {
-            tracing::debug!(error = %e, "embedding model load failed");
-            ModelLoad::Failed(e.to_string())
-        }
-    }
 }
 
 fn spawn_background_harvest(team: &str) {
@@ -346,6 +311,7 @@ mod tests {
     // TC-010: try_load_embedder_with returns Absent when model is not cached
     #[test]
     fn try_load_embedder_with_returns_absent_when_no_model() {
+        use crate::commands::reranker::try_load_embedder_with;
         let result = try_load_embedder_with(|| Ok::<_, &str>(None));
         assert!(matches!(result, ModelLoad::Absent));
     }
@@ -353,6 +319,7 @@ mod tests {
     // TC-010: try_load_embedder_with returns Failed on cache check error
     #[test]
     fn try_load_embedder_with_returns_failed_on_cache_error() {
+        use crate::commands::reranker::try_load_embedder_with;
         let result =
             try_load_embedder_with(|| Err::<Option<rurico::embed::Artifacts>, _>("cache error"));
         assert!(matches!(result, ModelLoad::Failed(_)));

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use rurico::reranker::Rerank;
 use rusqlite::Connection;
 use tracing::warn;
 
@@ -180,8 +181,13 @@ pub fn hybrid_search(
     limit: u32,
     now: chrono::DateTime<chrono::Utc>,
     filter: &SearchFilter<'_>,
+    reranker: Option<&dyn Rerank>,
 ) -> Result<Vec<SearchResult>, StorageError> {
-    let candidate_limit = limit * 3;
+    let candidate_limit = if reranker.is_some() {
+        limit * 4
+    } else {
+        limit * 3
+    };
 
     let fts_hits = fts_search(conn, query, candidate_limit, filter)?;
 
@@ -207,10 +213,49 @@ pub fn hybrid_search(
     let candidate_numbers: Vec<u32> = merged.iter().map(|(pn, _)| *pn).collect();
     let post_meta = batch_fetch_post_meta(conn, &candidate_numbers)?;
 
-    let fts_map: HashMap<u32, &FtsHit> = fts_hits.iter().map(|h| (h.post_number, h)).collect();
-    let vec_map: HashMap<u32, &VecHit> = vec_hits.iter().map(|h| (h.post_number, h)).collect();
+    // P1: keep the first (highest-ranked) chunk per post so the reranker sees
+    // the most relevant content, not whichever chunk happened to be last.
+    let mut fts_map: HashMap<u32, &FtsHit> = HashMap::new();
+    for h in &fts_hits {
+        fts_map.entry(h.post_number).or_insert(h);
+    }
+    let mut vec_map: HashMap<u32, &VecHit> = HashMap::new();
+    for h in &vec_hits {
+        vec_map.entry(h.post_number).or_insert(h);
+    }
 
-    let scored = apply_recency_boost(merged, &post_meta, now);
+    // P2: apply recency boost in every path so it is never discarded.
+    // When the cross-encoder is active it re-scores first, then recency
+    // is added on top; the fallback and no-reranker paths behave as before.
+    let scored = if let Some(ranker) = reranker {
+        let pairs: Vec<(&str, &str)> = merged
+            .iter()
+            .map(|(pn, _)| {
+                let content = fts_map
+                    .get(pn)
+                    .map(|h| h.content.as_str())
+                    .or_else(|| vec_map.get(pn).map(|h| h.content.as_str()))
+                    .unwrap_or("");
+                (query, content)
+            })
+            .collect();
+        match ranker.score_batch(&pairs) {
+            Ok(scores) => {
+                let cross_scored: Vec<(u32, f64)> = merged
+                    .into_iter()
+                    .zip(scores)
+                    .map(|((pn, _), s)| (pn, s as f64))
+                    .collect();
+                apply_recency_boost(cross_scored, &post_meta, now)
+            }
+            Err(e) => {
+                warn!(%e, "cross-encoder reranking failed, keeping heuristic order");
+                apply_recency_boost(merged, &post_meta, now)
+            }
+        }
+    } else {
+        apply_recency_boost(merged, &post_meta, now)
+    };
 
     let results = scored
         .into_iter()
@@ -568,6 +613,7 @@ mod tests {
             10,
             chrono::Utc::now(),
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -588,6 +634,7 @@ mod tests {
             10,
             chrono::Utc::now(),
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
         assert!(results.is_empty());
@@ -742,6 +789,7 @@ mod tests {
             10,
             now,
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
         assert!(results.len() >= 2, "both posts should match");
@@ -776,6 +824,7 @@ mod tests {
             10,
             now,
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
 
@@ -954,6 +1003,7 @@ mod tests {
             10,
             chrono::Utc::now(),
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -998,6 +1048,7 @@ mod tests {
             10,
             chrono::Utc::now(),
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
         assert!(results.len() >= 2, "expected at least 2 results");
@@ -1058,6 +1109,7 @@ mod tests {
             10,
             chrono::Utc::now(),
             &SearchFilter::default(),
+            None,
         )
         .unwrap();
         assert!(
@@ -1288,6 +1340,7 @@ mod tests {
                 category: Some("backend"),
                 ..Default::default()
             },
+            None,
         )
         .unwrap();
         assert!(!results.is_empty(), "category filter should return results");
@@ -1295,5 +1348,34 @@ mod tests {
             results.iter().all(|r| r.post_number == 1),
             "category=backend should only match post 1"
         );
+    }
+
+    // TC-044: hybrid_search with MockReranker applies cross-encoder scores to results
+    #[test]
+    fn hybrid_search_reranker_applies_cross_encoder_scores() {
+        use rurico::reranker::MockReranker;
+
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let reranker = MockReranker::with_score(0.99);
+        let results = hybrid_search(
+            db.conn(),
+            "認証の仕組み",
+            None,
+            10,
+            chrono::Utc::now(),
+            &SearchFilter::default(),
+            Some(&reranker),
+        )
+        .unwrap();
+        assert!(!results.is_empty(), "reranker search should return results");
+        for r in &results {
+            assert!(
+                r.score >= 0.99,
+                "score should be cross-encoder (0.99) × recency boost (≥1.0); got {}",
+                r.score
+            );
+        }
     }
 }


### PR DESCRIPTION
## 概要

- `SAE_RERANK=1` を設定すると rurico の cross-encoder reranker がハイブリッド検索スコアを再計算する。未設定時は従来の挙動を維持する
- `reranker` モジュールを新設し、`ModelLoad<T>` enum でモデルの Ready/Absent/Failed 状態を表現。ロード失敗時は stderr にヒントを出力する
- P1（`HashMap::collect()` が最後のチャンクを保持していた問題）と P2（recency boost が cross-encoder スコアを上書きしていた問題）を合わせて修正した

## テスト計画

- [ ] `SAE_RERANK=1` 未設定で `hybrid_search` を実行し、既存の挙動が変わらないことを確認する
- [ ] `SAE_RERANK=1` を設定した状態で `hybrid_search` を実行し、reranker が動作してスコアが更新されることを確認する
- [ ] reranker モデルが存在しない状態で `SAE_RERANK=1` を設定し、stderr にヒントが出力されて検索が終了することを確認する
- [ ] `cargo test` で TC-010/042/043/044 が pass することを確認する
- [ ] 複数チャンクを持つ投稿に対し、先頭チャンク（最高ランク）が返されることを確認する（P1 検証）
- [ ] recency boost が cross-encoder スコアの適用後に反映されることを確認する（P2 検証）

Closes #53