### PR TITLE
プローブ失敗時に破損モデルファイルを削除してリトライループを解消

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=5569a30#5569a30cc9a6509b5ce2b8220e95dc0257a35d2c"
+source = "git+https://github.com/thkt/rurico?rev=03275f7#03275f78ec1c1b677566a9c04d3cdad03e29b3d9"
 dependencies = [
  "bytemuck",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "03275f7" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 strsim = "0.11"
 
@@ -26,7 +26,7 @@ strsim = "0.11"
 wiremock = "0.6"
 tempfile = "3"
 serial_test = "3"
-rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "03275f7", features = ["test-support"] }
 
 [profile.release]
 opt-level = 3

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -1,4 +1,4 @@
-use rurico::embed::{Embedder, ModelId, ProbeStatus};
+use rurico::embed::{EmbedInitError, Embedder, ModelId, ProbeStatus};
 use sae::config::Config;
 
 use crate::{SaeError, require_db, resolve_client};
@@ -32,6 +32,11 @@ pub(crate) fn run_embed(config: &Config, team: &str, json: bool) -> Result<Strin
         }
         Err(e) => {
             spinner.cancel();
+            if matches!(e, EmbedInitError::ModelCorrupt { .. })
+                && let Err(del_err) = paths.delete_files()
+            {
+                tracing::warn!(error = %del_err, "failed to delete corrupt model files");
+            }
             return Err(SaeError::Other(format!("Model probe failed: {e}")));
         }
     }
@@ -86,6 +91,11 @@ pub(crate) fn run_model_download(json: bool) -> Result<String, SaeError> {
         }
         Err(e) => {
             spinner.cancel();
+            if matches!(e, EmbedInitError::ModelCorrupt { .. })
+                && let Err(del_err) = paths.delete_files()
+            {
+                tracing::warn!(error = %del_err, "failed to delete corrupt model files");
+            }
             return Err(SaeError::Other(format!("Model probe failed: {e}")));
         }
     }


### PR DESCRIPTION
## 概要

`Embedder::probe` が `ModelCorrupt` を返した際、破損ファイルがディスクに残り続け、次回実行でも `cached_artifacts` がキャッシュヒットしてプローブが再失敗するループが生じていた。プローブが `ModelCorrupt` を返したブランチでのみ `paths.delete_files()` を呼び出し、次回実行での再ダウンロードを保証する。

## 変更内容

- `src/commands/data.rs`: `EmbedInitError` をインポートし、`run_model_download` および `run_embed` の `ModelCorrupt` エラーブランチで `paths.delete_files()` を呼び出す
- `Cargo.toml`: rurico を rev `03275f7` に更新し、`VerifiedArtifacts::delete_files()` を取得

## 設計判断

- `ModelCorrupt` のみをトリガーにした理由: 他のエラー（ネットワーク失敗等）ではファイルが破損していない可能性が高く、削除すると無駄な再ダウンロードが生じる
- yomu #61 で確立したパターンと同一実装を採用し、ツール群の一貫性を維持

## テスト計画

- [ ] モデルファイルを意図的に破損させた状態で `sae embed` を実行し、`ModelCorrupt` エラーが返りファイルが削除されることを確認
- [ ] 再度実行して再ダウンロードが走り正常完了することを確認（ループしないこと）
- [ ] `ModelCorrupt` 以外のエラー時にはファイルが削除されないことを確認

Closes #55