### PR TITLE
sae search に --after/--before 日付フィルターを追加

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -19,8 +19,12 @@ pub(crate) fn run_search(
     query: &str,
     team: Option<&str>,
     limit: u32,
+    after: Option<&str>,
+    before: Option<&str>,
     json: bool,
 ) -> Result<String, SaeError> {
+    let updated_after = parse_date_arg(after, "after")?;
+    let updated_before = parse_date_arg(before, "before")?;
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
     let embedder = try_load_embedder();
@@ -66,13 +70,18 @@ pub(crate) fn run_search(
         .as_ref()
         .and_then(|r| r.as_ref())
         .map(|b| b.as_ref() as &dyn Rerank);
+    let filter = sae::storage::SearchFilter {
+        updated_after,
+        updated_before,
+        ..Default::default()
+    };
     let results = sae::storage::hybrid_search(
         db.conn(),
         query,
         query_embedding.as_deref(),
         limit,
         chrono::Utc::now(),
-        &sae::storage::SearchFilter::default(),
+        &filter,
         reranker_ref,
     )?;
     let semantic = query_embedding.is_some();
@@ -128,6 +137,21 @@ fn spawn_background_harvest(team: &str) {
     {
         tracing::debug!(error = %e, "background harvest spawn failed");
     }
+}
+
+fn parse_date_arg(
+    s: Option<&str>,
+    flag: &str,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, SaeError> {
+    let Some(s) = s else {
+        return Ok(None);
+    };
+    let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|_| {
+        SaeError::Input(format!(
+            "Invalid date '--{flag} {s}': expected YYYY-MM-DD (e.g. 2025-01-01)"
+        ))
+    })?;
+    Ok(Some(date.and_hms_opt(0, 0, 0).unwrap().and_utc()))
 }
 
 pub(crate) fn resolve_search_query(query: Option<String>) -> Result<String, SaeError> {
@@ -386,6 +410,36 @@ mod tests {
         assert!(
             msg.contains("Pass QUERY"),
             "error should include placeholder: {err}"
+        );
+    }
+
+    // TC-059: parse_date_arg returns None when no value provided
+    #[test]
+    fn parse_date_arg_returns_none_when_absent() {
+        assert!(parse_date_arg(None, "after").unwrap().is_none());
+    }
+
+    // TC-060: parse_date_arg parses valid YYYY-MM-DD into DateTime<Utc>
+    #[test]
+    fn parse_date_arg_parses_valid_date() {
+        let dt = parse_date_arg(Some("2025-06-30"), "after")
+            .unwrap()
+            .unwrap();
+        assert_eq!(dt.format("%Y-%m-%d").to_string(), "2025-06-30");
+    }
+
+    // TC-061: parse_date_arg returns Input error for non-ISO8601 date
+    #[test]
+    fn parse_date_arg_rejects_invalid_date() {
+        let err = parse_date_arg(Some("30/06/2025"), "after").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Invalid date"),
+            "error should describe the problem: {msg}"
+        );
+        assert!(
+            msg.contains("YYYY-MM-DD"),
+            "error should show expected format: {msg}"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,8 @@ Examples:
     #[command(after_help = "\
 Examples:
   sae search \"認証\" --team myteam --limit 5
+  sae search \"認証\" --after 2025-01-01
+  sae search \"認証\" --after 2025-01-01 --before 2025-06-30
   echo \"認証\" | sae search
   sae search -")]
     Search {
@@ -52,6 +54,12 @@ Examples:
         /// Max results (1-100)
         #[arg(long, default_value = "10")]
         limit: u32,
+        /// Filter: updated on or after this date (YYYY-MM-DD)
+        #[arg(long, value_name = "DATE")]
+        after: Option<String>,
+        /// Filter: updated on or before this date (YYYY-MM-DD)
+        #[arg(long, value_name = "DATE")]
+        before: Option<String>,
     },
     /// Get a post by number
     #[command(after_help = "\
@@ -247,9 +255,23 @@ async fn run(cli: Cli, config: Config) -> Result<String, SaeError> {
         Command::Harvest { team, full } => {
             commands::data::run_harvest(&config, &team, full, json).await?
         }
-        Command::Search { query, team, limit } => {
+        Command::Search {
+            query,
+            team,
+            limit,
+            after,
+            before,
+        } => {
             let query = commands::search::resolve_search_query(query)?;
-            commands::search::run_search(&config, &query, team.as_deref(), limit, json)?
+            commands::search::run_search(
+                &config,
+                &query,
+                team.as_deref(),
+                limit,
+                after.as_deref(),
+                before.as_deref(),
+                json,
+            )?
         }
         Command::Get {
             number,

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -29,6 +29,8 @@ pub struct SearchFilter<'a> {
     pub tags: Option<&'a [&'a str]>,
     pub category: Option<&'a str>,
     pub created_by: Option<&'a str>,
+    pub updated_after: Option<chrono::DateTime<chrono::Utc>>,
+    pub updated_before: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 pub fn fts_search(
@@ -59,6 +61,8 @@ pub fn fts_search(
     append_tags_filter(&mut sql, &mut params, filter.tags);
     append_eq_filter(&mut sql, &mut params, "p.category", filter.category);
     append_eq_filter(&mut sql, &mut params, "p.created_by", filter.created_by);
+    append_date_filter(&mut sql, &mut params, false, filter.updated_after);
+    append_date_filter(&mut sql, &mut params, true, filter.updated_before);
     sql.push_str(" ORDER BY f.rank LIMIT ?");
     params.push(Box::new(limit));
 
@@ -135,6 +139,8 @@ pub fn vec_search(
     append_tags_filter(&mut sql, &mut params, filter.tags);
     append_eq_filter(&mut sql, &mut params, "p.category", filter.category);
     append_eq_filter(&mut sql, &mut params, "p.created_by", filter.created_by);
+    append_date_filter(&mut sql, &mut params, false, filter.updated_after);
+    append_date_filter(&mut sql, &mut params, true, filter.updated_before);
 
     let mut stmt2 = conn.prepare(&sql)?;
     let meta: HashMap<i64, (u32, Option<String>, String)> = stmt2
@@ -322,6 +328,30 @@ fn append_eq_filter(
         sql.push_str(&format!(" AND {column} = ?"));
         params.push(Box::new(v.to_string()));
     }
+}
+
+fn append_date_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    before: bool,
+    value: Option<chrono::DateTime<chrono::Utc>>,
+) {
+    let Some(dt) = value else { return };
+    // For `before`, advance one day and use `<` so the boundary day is fully
+    // included ("2025-01-15T23:59:59+09:00" < "2025-01-16" is TRUE).
+    let (op, date_str) = if before {
+        let next = dt
+            .date_naive()
+            .succ_opt()
+            .unwrap_or(dt.date_naive())
+            .format("%Y-%m-%d")
+            .to_string();
+        ("<", next)
+    } else {
+        (">=", dt.format("%Y-%m-%d").to_string())
+    };
+    sql.push_str(&format!(" AND p.updated_at {op} ?"));
+    params.push(Box::new(date_str));
 }
 
 fn apply_recency_boost(
@@ -1348,6 +1378,117 @@ mod tests {
             results.iter().all(|r| r.post_number == 1),
             "category=backend should only match post 1"
         );
+    }
+
+    fn test_post_dated(number: u32, updated_at: &str) -> storage::EsaPostRow {
+        let mut row = storage::test_post_row(number);
+        row.name = format!("ガイド {number}");
+        row.full_name = format!("dev/ガイド{number}");
+        row.body_md = "# ガイド\n設定方法を解説".to_string();
+        row.updated_at = updated_at.to_string();
+        row
+    }
+
+    fn setup_db_with_dated_posts(db: &Db) {
+        // post 1: 2025-01-10 (old)
+        // post 2: 2025-06-15 (new)
+        for (num, date) in [
+            (1u32, "2025-01-10T00:00:00+00:00"),
+            (2, "2025-06-15T00:00:00+00:00"),
+        ] {
+            let post = test_post_dated(num, date);
+            storage::upsert_post(db.conn(), &post).unwrap();
+            storage::rechunk_post(db.conn(), num, &post.body_md).unwrap();
+        }
+    }
+
+    fn date_utc(s: &str) -> chrono::DateTime<chrono::Utc> {
+        chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+    }
+
+    // TC-056: updated_after filters out posts with updated_at before threshold
+    #[test]
+    fn hybrid_search_updated_after_excludes_old_posts() {
+        let db = Db::open_memory().unwrap();
+        setup_db_with_dated_posts(&db);
+
+        let filter = SearchFilter {
+            updated_after: Some(date_utc("2025-03-01")),
+            ..Default::default()
+        };
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            chrono::Utc::now(),
+            &filter,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1, "only the newer post should be returned");
+        assert_eq!(results[0].post_number, 2);
+    }
+
+    // TC-057: updated_before filters out posts with updated_at after threshold
+    #[test]
+    fn hybrid_search_updated_before_excludes_new_posts() {
+        let db = Db::open_memory().unwrap();
+        setup_db_with_dated_posts(&db);
+
+        let filter = SearchFilter {
+            updated_before: Some(date_utc("2025-03-01")),
+            ..Default::default()
+        };
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            chrono::Utc::now(),
+            &filter,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1, "only the older post should be returned");
+        assert_eq!(results[0].post_number, 1);
+    }
+
+    // TC-058: updated_after and updated_before combined apply AND condition
+    #[test]
+    fn hybrid_search_date_range_returns_matching_posts_only() {
+        let db = Db::open_memory().unwrap();
+        setup_db_with_dated_posts(&db);
+
+        // Range that covers only post 1 (2025-01-10)
+        let filter = SearchFilter {
+            updated_after: Some(date_utc("2025-01-01")),
+            updated_before: Some(date_utc("2025-03-01")),
+            ..Default::default()
+        };
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            chrono::Utc::now(),
+            &filter,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            results.len(),
+            1,
+            "range 2025-01-01..2025-03-01 should include only post 1"
+        );
+        assert_eq!(results[0].post_number, 1);
     }
 
     // TC-044: hybrid_search with MockReranker applies cross-encoder scores to results


### PR DESCRIPTION
## 概要

- `sae search` に `--after` / `--before` フラグを追加し、`updated_at` 基準で結果を絞り込めるようにした（GitHub Issue #56）
- `YYYY-MM-DD` 形式のみ受け付け、埋め込み計算・DB アクセスの前に早期バリデーションを実施
- `--before` は「翌日 `<` 」比較で境界日を正しく含む（ISO-8601 TEXT の `<=` 比較では当日が除外されるため）
- 既存の `append_*_filter` パターンに従い `append_date_filter` ヘルパーを追加

## テスト計画

- [ ] `sae search <query> --after 2025-01-01` で 2025-01-01 以降のエントリのみ返ること（TC-056）
- [ ] `sae search <query> --before 2025-06-01` で 2025-06-01 を含む当日までのエントリが返ること（TC-057）
- [ ] `--after` と `--before` の組み合わせが正しく動作すること（TC-058）
- [ ] `--after 2025-13-01` など無効な日付で早期エラーが返ること（TC-059/060/061）
- [ ] フラグなしの既存の検索動作が変わらないこと