### PR TITLE
refactor(storage): migrate_v5 の通知を amici::migration 経由化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,11 +34,12 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=466b4cb#466b4cb87cf68ae8768ec8a20571b3cd1aa376a8"
+source = "git+https://github.com/thkt/amici?rev=2dd9a52#2dd9a5221b91de6215dade71dd9404ab8abbba22"
 dependencies = [
  "rurico",
  "rusqlite",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -86,7 +87,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +98,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -640,7 +641,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -709,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1707,7 +1708,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2321,7 +2322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2380,7 +2381,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2633,7 +2634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2787,7 +2788,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3293,11 +3294,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3306,7 +3307,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3471,7 +3472,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3812,6 +3813,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "466b4cb" }
+amici = { git = "https://github.com/thkt/amici", rev = "2dd9a52" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -19,6 +19,7 @@ use rurico::storage as rurico_storage;
 
 const SCHEMA_VERSION: u32 = 5;
 
+use amici::migration::notify_schema_change;
 pub(crate) use amici::storage::{anon_placeholders, as_sql_params, in_placeholders};
 
 const DDL_FTS: &str = "\
@@ -121,10 +122,8 @@ pub(crate) fn migrate_v5(conn: &Connection, from_version: u32) -> Result<(), Sto
     set_schema_version(&tx, 5)?;
     tx.commit()?;
     if from_version > 0 {
-        warn!(
-            from = from_version,
-            "schema upgraded to v5: embeddings cleared, please re-run `sae embed`"
-        );
+        let _span = tracing::info_span!("migration", from = from_version).entered();
+        notify_schema_change("sae", "embeddings", 0, "sae embed");
     }
     Ok(())
 }


### PR DESCRIPTION
## 概要

- `migrate_v5` の schema 変更通知を `amici::migration::notify_schema_change` 経由に置換
- 3ツール（sae / yomu / recall）間で通知メッセージフォーマットを統一する第一弾
- `from = from_version` 情報は `info_span!("migration")` 経由で保持
- amici rev を `2dd9a52`（post-#7 merge）に bump

## 動機

Issue #64 対応。amici#7 で `amici::migration::notify_schema_change` が追加されたので、sae 側の `tracing::warn!` を共通ヘルパー経由に切り替え。

## テスト計画

- [x] `cargo build` 通過
- [x] `cargo test` 245 passed / 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo fmt --check` 通過
- [ ] merge 後、yomu / recall 側も同様パターンで追従（別 PR）

Closes #64