### PR TITLE
フィルター構築を amici::storage::filter ヘルパーに委譲

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=9c45884#9c4588485627497b8c6e2ad2bab2985ffb00884f"
+source = "git+https://github.com/thkt/amici?rev=cb98cb0#cb98cb0a187872a71062733839c7a6274318406c"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -1447,9 +1447,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
+source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2278,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
+source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2327,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3775,9 +3775,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "9c45884" }
+amici = { git = "https://github.com/thkt/amici", rev = "cb98cb0" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,7 +24,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 wiremock = "0.6"

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use amici::storage::{append_eq_filter, fts::clean_for_trigram};
+use amici::storage::{
+    filter::{append_eq_filter, append_timestamp_day_cutoff_filter},
+    fts::clean_for_trigram,
+};
 use chrono::{DateTime, Utc};
 use rurico::reranker::Rerank;
 use rurico::storage::{f32_as_bytes, prepare_match_query, recency_decay, rrf_merge};
@@ -87,6 +90,8 @@ fn normalize_punctuation(query: &str) -> String {
         .join(" ")
 }
 
+/// `EXISTS + json_each` shape does not fit `amici::storage::filter::append_in_filter`
+/// (which emits `AND {col} IN (...)`), so the subquery is built inline.
 fn append_tags_filter(sql: &mut String, params: &mut Vec<Box<dyn ToSql>>, tags: Option<&[&str]>) {
     if let Some(tags) = tags
         && !tags.is_empty()
@@ -101,28 +106,22 @@ fn append_tags_filter(sql: &mut String, params: &mut Vec<Box<dyn ToSql>>, tags: 
     }
 }
 
-fn append_date_filter(
+fn append_search_filters(
     sql: &mut String,
     params: &mut Vec<Box<dyn ToSql>>,
-    before: bool,
-    value: Option<DateTime<Utc>>,
+    filter: &SearchFilter<'_>,
 ) {
-    let Some(dt) = value else { return };
-    // For `before`, advance one day and use `<` so the boundary day is fully
-    // included ("2025-01-15T23:59:59+09:00" < "2025-01-16" is TRUE).
-    let (op, date_str) = if before {
-        let next = dt
-            .date_naive()
-            .succ_opt()
-            .unwrap_or(dt.date_naive())
-            .format("%Y-%m-%d")
-            .to_string();
-        ("<", next)
-    } else {
-        (">=", dt.format("%Y-%m-%d").to_string())
-    };
-    sql.push_str(&format!(" AND p.updated_at {op} ?"));
-    params.push(Box::new(date_str));
+    append_tags_filter(sql, params, filter.tags);
+    append_eq_filter(sql, params, "p.category", filter.category);
+    append_eq_filter(sql, params, "p.created_by", filter.created_by);
+    let after = filter
+        .updated_after
+        .map(|dt| dt.format("%Y-%m-%d").to_string());
+    let before = filter
+        .updated_before
+        .map(|dt| dt.format("%Y-%m-%d").to_string());
+    append_timestamp_day_cutoff_filter(sql, params, "p.updated_at", false, after.as_deref());
+    append_timestamp_day_cutoff_filter(sql, params, "p.updated_at", true, before.as_deref());
 }
 
 fn truncate_snippet(s: &str, max_chars: usize) -> String {
@@ -231,11 +230,7 @@ pub(crate) fn fts_search(
     );
     let mut params: Vec<Box<dyn ToSql>> = vec![Box::new(match_query)];
 
-    append_tags_filter(&mut sql, &mut params, filter.tags);
-    append_eq_filter(&mut sql, &mut params, "p.category", filter.category);
-    append_eq_filter(&mut sql, &mut params, "p.created_by", filter.created_by);
-    append_date_filter(&mut sql, &mut params, false, filter.updated_after);
-    append_date_filter(&mut sql, &mut params, true, filter.updated_before);
+    append_search_filters(&mut sql, &mut params, filter);
     sql.push_str(" ORDER BY f.rank LIMIT ?");
     params.push(Box::new(limit));
 
@@ -307,11 +302,7 @@ pub(crate) fn vec_search(
         .iter()
         .map(|id| Box::new(*id) as Box<dyn ToSql>)
         .collect();
-    append_tags_filter(&mut sql, &mut params, filter.tags);
-    append_eq_filter(&mut sql, &mut params, "p.category", filter.category);
-    append_eq_filter(&mut sql, &mut params, "p.created_by", filter.created_by);
-    append_date_filter(&mut sql, &mut params, false, filter.updated_after);
-    append_date_filter(&mut sql, &mut params, true, filter.updated_before);
+    append_search_filters(&mut sql, &mut params, filter);
 
     let mut stmt2 = conn.prepare(&sql)?;
     let meta: HashMap<i64, (u32, Option<String>, String)> = stmt2
@@ -1380,6 +1371,50 @@ mod tests {
             "range 2025-01-01..2025-03-01 should include only post 1"
         );
         assert_eq!(results[0].post_number, 1);
+    }
+
+    // T-202: updated_before is inclusive of the cutoff day (day-inclusive --before)
+    #[test]
+    fn hybrid_search_updated_before_includes_boundary_day() {
+        let db = Db::open_memory().unwrap();
+        let post = test_post_dated(1, "2025-03-01T12:00:00+00:00");
+        storage::upsert_post(db.conn(), &post).unwrap();
+        storage::rechunk_post(db.conn(), 1, &post.body_md).unwrap();
+
+        let filter = SearchFilter {
+            updated_before: Some(date_utc("2025-03-01")),
+            ..Default::default()
+        };
+        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
+            .unwrap()
+            .results;
+        assert_eq!(
+            results.len(),
+            1,
+            "updated_before is inclusive of the boundary day (CLI: on or before)"
+        );
+    }
+
+    // T-203: updated_after is inclusive of the cutoff day (day-inclusive --after)
+    #[test]
+    fn hybrid_search_updated_after_includes_boundary_day() {
+        let db = Db::open_memory().unwrap();
+        let post = test_post_dated(1, "2025-03-01T12:00:00+00:00");
+        storage::upsert_post(db.conn(), &post).unwrap();
+        storage::rechunk_post(db.conn(), 1, &post.body_md).unwrap();
+
+        let filter = SearchFilter {
+            updated_after: Some(date_utc("2025-03-01")),
+            ..Default::default()
+        };
+        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
+            .unwrap()
+            .results;
+        assert_eq!(
+            results.len(),
+            1,
+            "updated_after cutoff day is inclusive against T-suffixed timestamps"
+        );
     }
 
     // T-107: hybrid_search with MockReranker applies cross-encoder scores to results


### PR DESCRIPTION
## 概要

ローカルの `append_date_filter`（+1-day ハック含む 30 行）と、`fts_search` / `vec_search` に散在していた 5 × 2 = 10 件のフィルター追加呼び出しを、`amici::storage::filter` ヘルパーに委譲する。day-inclusive な `--before` セマンティクスの所有権を amici 側に移し、sae のローカル実装を削除する。

## 変更内容

- `Cargo.toml`: amici rev `9c45884` → `cb98cb0`（`append_timestamp_day_cutoff_filter` 追加、amici#20 / amici#21）、rurico rev `e83581c` → `7b739d1`（amici の transitive dep と型を統一）
- `src/storage/search.rs`: ローカル `append_date_filter` を削除し、`append_search_filters` ヘルパーに集約（`fts_search` / `vec_search` それぞれ 5 行 → 1 行）。`append_timestamp_day_cutoff_filter` が内部で `< date(?, '+1 day')` を発行するため +1-day ハック不要
- `src/storage/search.rs`: T-202/T-203 テストを追加し、`updated_before` / `updated_after` の境界日（当日含む）セマンティクスを回帰テストで固定

## スコープ

- **含まない**: `append_tags_filter` は EXISTS + json_each 構造が `amici::append_in_filter`（`AND col IN (...)`）と非互換なためローカルのまま維持（doc コメントで理由を明記）

## 設計判断

- `append_search_filters` をローカルヘルパーとして定義（amici に移動しない）— 検索フィルターの組み合わせは sae 固有の関心事であり、amici に漏らすべきドメイン知識ではないため
- `< date(?, '+1 day')` は amici 側が隠蔽 — `EXPLAIN QUERY PLAN` で `SEARCH p USING COVERING INDEX idx_posts_updated (updated_at>? AND updated_at<?)` が維持されることを確認済み（SQLite が `date()` 呼び出しをフォールドしインデックス利用継続）

## 動作確認

1. `cargo test` — 37 storage::search + 31 commands + 3 sync_state、計 71 件パス
2. `cargo clippy --all-targets --all-features -- -D warnings` — 警告なし
3. `sae search --before <today>` でヒット件数が従来と同一であることを確認（day-inclusive セマンティクス維持）

## 関連

- Closes #73
- amici#20（`append_timestamp_day_cutoff_filter` 追加要求）
- amici#21（PR: cb98cb0 でマージ済み）