### PR TITLE
--no-embed flag で embedding をスキップ

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ sae embed myteam
 
 # 以降の検索は FTS + ベクトルのハイブリッド
 sae search "認証フローの設計方針"
+
+# embedder のロードコストを避けて FTS のみで検索（CI / スクリプト用途）
+sae search "認証" --no-embed
 ```
 
 ### 同期状態の確認

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -69,6 +69,7 @@ fn spawn_background_harvest(team: &str) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_search(
     config: &Config,
     query: &str,
@@ -76,19 +77,25 @@ pub(crate) fn run_search(
     limit: u32,
     after: Option<&str>,
     before: Option<&str>,
+    no_embed: bool,
     json: bool,
 ) -> Result<String, SaeError> {
     let updated_after = parse_date_arg(after, "after")?;
     let updated_before = parse_date_arg(before, "before")?;
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
-    let embedder = try_load_embedder();
-    if let Err(reason) = embedder
-        && let Some(note) = degraded_reason_user_note(*reason)
-    {
-        tracing::warn!("{note}");
-    }
-    let embed_info = if let Ok(emb) = embedder {
+    let embedder = if no_embed {
+        None
+    } else {
+        let result = try_load_embedder();
+        if let Err(reason) = result
+            && let Some(note) = degraded_reason_user_note(*reason)
+        {
+            tracing::warn!("{note}");
+        }
+        result.as_ref().ok()
+    };
+    let embed_info = if let Some(emb) = embedder {
         match auto_embed_pending_with(&db, SEARCH_EMBED_BUDGET, |texts| {
             emb.embed_documents_batch(texts)
                 .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
@@ -106,7 +113,7 @@ pub(crate) fn run_search(
     } else {
         None
     };
-    let query_embedding = if let Ok(e) = embedder {
+    let query_embedding = if let Some(e) = embedder {
         match e.embed_query(query) {
             Ok(v) => Some(v),
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,6 +483,31 @@ mod tests {
         }
     }
 
+    // T-244: search args + --no-embed → no_embed=true
+    #[test]
+    fn search_with_no_embed_parses_flag() {
+        let cli = parse_cli_args(["sae", "search", "認証", "--no-embed"]).unwrap();
+        match cli.command {
+            Command::Search { args } => {
+                assert_eq!(args.query.as_deref(), Some("認証"), "query should match");
+                assert!(args.no_embed, "no_embed should be true");
+            }
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-245: search args without --no-embed → no_embed defaults to false
+    #[test]
+    fn search_without_no_embed_defaults_to_false() {
+        let cli = parse_cli_args(["sae", "search", "認証"]).unwrap();
+        match cli.command {
+            Command::Search { args } => {
+                assert!(!args.no_embed, "no_embed should default to false");
+            }
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
     // T-001: `sae model download` parses to Command::Model { ModelCommand::Download }
     #[test]
     fn model_download_parses_correctly() {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -32,6 +32,9 @@ pub struct SearchArgs {
     /// Filter: updated on or before this date (YYYY-MM-DD)
     #[arg(long, value_name = "DATE")]
     pub before: Option<String>,
+    /// Skip embedding lookups; use FTS only. Avoids embedder load cost.
+    #[arg(long)]
+    pub no_embed: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -226,6 +229,7 @@ impl Sae {
             args.limit,
             args.after.as_deref(),
             args.before.as_deref(),
+            args.no_embed,
             json,
         )
     }


### PR DESCRIPTION
## What & Why

`sae search` に `--no-embed` flag を追加し、embedder のロードコストを避けて FTS のみで検索可能に。
recall / yomu と命名統一し、3ツール共通の `--no-embed` UX 規約を確立する（CI / スクリプト用途、精度比較・デバッグ等の意図的 FTS-only 検索）。

## Changes

- `SearchArgs` に `no_embed: bool` 追加（`src/tools.rs`）
- `run_search()` に `no_embed` 引数追加。`true` 時は `try_load_embedder()` をスキップし、既存の `embedder=None` フォールバック経路（`auto_embed_pending_with` も自動的に skip）に乗せる（`src/commands/search.rs`）
- T-244 / T-245 で clap parse のテスト追加（`src/main.rs`）
- README に CI / スクリプト用途の使用例追加（`README.md`）

## Scope

- **Not included**: `run_search()` の引数構造体化（call site=1 のため YAGNI、別 issue で対応可）

## Design Decisions

- **`embedder` の型を `&Result<...>` から `Option<&_>` に変更**: `no_embed=true` 時の早期 `None` 返却を素直に表現するため。`degraded_reason_user_note` は `as_ref().ok()` 変換前の else-block 内で消費しており情報欠損なし。
- **`--no-embed` 時の degraded warning 抑止**: `try_load_embedder()` 自体を呼ばないため、モデル load 失敗時の `tracing::warn!(degraded_reason)` も発生しない。ユーザが opt-out したケースなので意図通りの挙動。
- **`#[allow(clippy::too_many_arguments)]`**: 引数 7→8 に増加。call site=1 の `Sae::search` のみのため、引数構造体化は YAGNI 判定。

## How to Test

1. `cargo test --bin sae no_embed` → T-244 / T-245 が pass
2. `cargo test` → 既存 237 テスト全 pass を確認
3. `sae search --help` で `--no-embed` 行が表示されること
4. `sae search "認証" --no-embed` が embedder ロードなしで FTS 結果を返すこと（要 indexed DB）

## Related

- Closes #72
