### PR TITLE
dependabot を有効化して CI actions と cargo 依存の自動更新を受ける

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What & Why

`.github/dependabot.yml` を追加して、GitHub Actions と Cargo 依存の weekly 自動更新 PR を受け取る仕組みを有効化する。SHA pin 老朽化と Cargo 依存の手動更新運用を解消し、セキュリティアラート抜け漏れを防ぐ。

## Changes

- `.github/dependabot.yml` を新規追加（amici / rurico と完全一致）。`github-actions` と `cargo` の 2 ecosystem を weekly で監視。cargo の minor/patch は 1 PR にグルーピング、major のみ個別 PR
- ラベル `dependencies` / `ci` / `rust` を新規作成（amici / rurico と同色・同説明）
- 重複していた既存ラベル `deps` を削除（影響: closed issue #31 のみ、PR 紐付けなし）

## Scope

- **Not included**: 既存 workflow の SHA や Cargo 依存の即時更新は行わない（Dependabot 起動後の weekly PR で対応）

## Design Decisions

- 設定内容を amici / rurico と完全一致させる構成を採用。CLI ツール群で運用ノウハウを揃え、横展開コストとレビュー負荷を下げるため

## How to Test

1. マージ後、GitHub Repository Settings > Code security and analysis で Dependabot version updates が「Enabled」と表示されることを確認
2. 翌週以降、`dependencies` ラベル付きの自動更新 PR が作成されることを確認

## Related

- Closes #74
- 参考: thkt/rurico#49
