### PR TITLE
embed のバッチサイズを 128 から 512 に引き上げる

### DIFF
--- a/src/commands/embed_batch.rs
+++ b/src/commands/embed_batch.rs
@@ -4,7 +4,7 @@ use crate::storage;
 use crate::storage::embed::insert_new_embeddings;
 use crate::tools::SaeError;
 
-pub(crate) const BATCH_SIZE: u32 = 128;
+pub(crate) const BATCH_SIZE: u32 = 512;
 
 pub(crate) struct BatchResult {
     pub(crate) added: u32,


### PR DESCRIPTION
## What & Why

embed のバッチサイズを 128 → 512 に増やし、SQLite I/O とバッチ間オーバーヘッドを削減する。24GB Apple Silicon Mac での実測ベース。

## Changes

- `src/commands/embed_batch.rs`: const `BATCH_SIZE` を `128` → `512` に変更（1 行）

## Empirical Measurement

24GB Apple Silicon Mac, mlx-rs embedder, gaji team DB:

| BATCH_SIZE | Memory | Speed |
| --- | --- | --- |
| 128 | 3.5 GB | baseline |
| 512 | 5.3 GB | わずかに高速化 |

- Memory delta: +1.8 GB（許容範囲内）
- 速度向上は限定的だが、バッチ間オーバーヘッド削減で **無駄ではない**
- 1024 / 2048 は試していない（GPU 並列度がほぼ飽和しており、効果頭打ちが見えたため）

## Design Decisions

- 速度向上が限定的でも、SQLite I/O / バッチ間オーバーヘッドの削減効果は維持される
- メモリ余裕がある環境（24GB+）では 512 を採用
- メモリ制約のある環境向けに `--batch-size` フラグ化する余地は別 issue で検討可能

## Scope

- **Not included**: BATCH_SIZE の CLI フラグ / 環境変数化（YAGNI、必要が出たら別 PR で対応）

## How to Test

1. `cargo install --path . --force` で再ビルド
2. `sae harvest <team>` & `sae embed <team>` を実行
3. メモリ使用量がベースライン +1〜2GB 程度に収まることを確認
4. 既存テストが pass すること: `cargo test`

## Related

- ad-hoc tuning（Issue 紐付けなし）
