### PR TITLE
chore(ci): clippy --all-targets を CI で強制 + pre-commit hook 追加

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+# sae pre-commit hook: enforce fmt + clippy --all-targets before commit.
+#
+# Install (one-time per clone):
+#   git config --local core.hooksPath .githooks
+#
+# Skip for one commit:
+#   git commit --no-verify
+
+set -e
+
+# Only run when Rust / config / CI files are staged (covers add, modify, delete, rename).
+if git diff --cached --name-only | grep -qE '\.rs$|Cargo\.(toml|lock)$|\.github/'; then
+    echo "▶ pre-commit: cargo fmt -- --check"
+    cargo fmt -- --check
+
+    echo "▶ pre-commit: cargo clippy --all-targets --all-features -- -D warnings"
+    cargo clippy --all-targets --all-features -- -D warnings
+
+    echo "✔ pre-commit checks passed"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo test
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check

--- a/README.md
+++ b/README.md
@@ -119,3 +119,23 @@ sae --json status
 | 1    | Operational エラー | API エラー、ネットワーク障害             |
 | 2    | Input エラー       | 不明なチーム、トークン未設定、未 harvest |
 | 4    | Internal エラー    | DB 破損、JSON シリアライズ失敗           |
+
+## 開発
+
+### セットアップ
+
+clone 後に1度だけ実行:
+
+```sh
+git config --local core.hooksPath .githooks
+```
+
+`cargo fmt --check` と `cargo clippy --all-targets --all-features -- -D warnings` を commit 前に走らせる pre-commit hook が有効になる。違反があると commit は中止される。1コミットだけスキップしたいときは `git commit --no-verify`。
+
+### よく使うコマンド
+
+```sh
+cargo test                                                # 全テスト
+cargo clippy --all-targets --all-features -- -D warnings  # lint（CI と同じ）
+cargo fmt -- --check                                      # フォーマット確認
+```


### PR DESCRIPTION
## 概要

issue #84 の実装。sae の CI に `cargo clippy --all-targets --all-features` を強制し、pre-commit hook で開発者ローカルの早期検出を整備。

## 変更内容

1. `.github/workflows/ci.yml`: Clippy step に `--all-targets --all-features` 追加
2. `.githooks/pre-commit`: 新規（yomu PR #148 に準拠）
   - `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` を commit 前に実行
   - install: `git config --local core.hooksPath .githooks`
3. `README.md`: 「開発」セクション追加（Setup + Common commands）

## 検証

- cargo test: 36 tests passed
- cargo fmt --check: pass
- cargo clippy --all-targets --all-features -- -D warnings: pass

## 次ステップ

merge 後、main branch protection を設定（task #6）。

Closes #84