### PR TITLE
refactor(storage): amici::storage::query_helpers へ migration（#86）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=138de41#138de41151e062efa0f7cec87ad8966dbf481256"
+source = "git+https://github.com/thkt/amici?rev=79f837f#79f837fed35f25ae675ddcdb76bbafb0604be02b"
 dependencies = [
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -2319,11 +2319,10 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
+source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
 dependencies = [
  "bytemuck",
  "hf-hub",
- "log",
  "mlx-rs",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -2333,13 +2332,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokenizers",
+ "tracing",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
+source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "138de41" }
+amici = { git = "https://github.com/thkt/amici", rev = "79f837f" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "ef26de2" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,7 +24,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "ef26de2", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 wiremock = "0.6"

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,9 +18,21 @@ use rurico::embed::EMBEDDING_DIMS;
 use rurico::storage as rurico_storage;
 use rurico::storage::{QueryNormalizationConfig, normalize_for_fts};
 
-pub(crate) use amici::storage::{
-    anon_placeholders, as_sql_params, collect_rows, fetch_by_in_clause, in_placeholders,
-};
+pub(crate) use amici::storage::{anon_placeholders, as_sql_params, in_placeholders};
+
+use amici::storage::collect_rows;
+
+/// `collect_rows` wrapper that fixes `E = StorageError`, removing the
+/// `::<_, _, _, StorageError>` turbofish that the bare helper would otherwise
+/// require at every `?`-binding callsite (both `rusqlite::Error` and
+/// `StorageError` satisfy `From<rusqlite::Error>`, leaving `E` ambiguous).
+pub(crate) fn collect_storage_rows<I, T, C>(rows: I) -> Result<C, StorageError>
+where
+    I: Iterator<Item = Result<T, rusqlite::Error>>,
+    C: FromIterator<T>,
+{
+    collect_rows(rows)
+}
 
 /// Shared `normalize_for_fts` configuration for index- and query-side calls.
 /// Divergence between sides makes FTS5 token streams disagree and silently
@@ -310,7 +322,7 @@ pub fn rechunk_post(
     let chunk_ids: Vec<i64> = {
         let mut stmt = conn.prepare_cached("SELECT id FROM chunks WHERE post_number = ?1")?;
         let rows = stmt.query_map([post_number], |row| row.get(0))?;
-        collect_rows::<_, _, _, StorageError>(rows)?
+        collect_storage_rows(rows)?
     };
 
     // SAVEPOINT works both standalone and within an outer transaction (sync).

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,7 +18,9 @@ use rurico::embed::EMBEDDING_DIMS;
 use rurico::storage as rurico_storage;
 use rurico::storage::{QueryNormalizationConfig, normalize_for_fts};
 
-pub(crate) use amici::storage::{anon_placeholders, as_sql_params, collect_rows, in_placeholders};
+pub(crate) use amici::storage::{
+    anon_placeholders, as_sql_params, collect_rows, fetch_by_in_clause, in_placeholders,
+};
 
 /// Shared `normalize_for_fts` configuration for index- and query-side calls.
 /// Divergence between sides makes FTS5 token streams disagree and silently

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,7 +18,7 @@ use rurico::embed::EMBEDDING_DIMS;
 use rurico::storage as rurico_storage;
 use rurico::storage::{QueryNormalizationConfig, normalize_for_fts};
 
-pub(crate) use amici::storage::{anon_placeholders, as_sql_params, in_placeholders};
+pub(crate) use amici::storage::{anon_placeholders, as_sql_params, collect_rows, in_placeholders};
 
 /// Shared `normalize_for_fts` configuration for index- and query-side calls.
 /// Divergence between sides makes FTS5 token streams disagree and silently
@@ -308,7 +308,7 @@ pub fn rechunk_post(
     let chunk_ids: Vec<i64> = {
         let mut stmt = conn.prepare_cached("SELECT id FROM chunks WHERE post_number = ?1")?;
         let rows = stmt.query_map([post_number], |row| row.get(0))?;
-        rows.collect::<Result<_, _>>()?
+        collect_rows::<_, _, _, StorageError>(rows)?
     };
 
     // SAVEPOINT works both standalone and within an outer transaction (sync).

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -4,7 +4,7 @@ use rurico::embed::ChunkedEmbedding;
 use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 
-use super::StorageError;
+use super::{StorageError, collect_rows};
 
 pub fn add_chunked_embeddings(
     conn: &Connection,
@@ -89,10 +89,9 @@ pub fn get_unembedded_chunks(
          WHERE e.chunk_id IS NULL \
          LIMIT ?1",
     )?;
-    let rows: Vec<(i64, String)> = stmt
-        .query_map([limit], |row| Ok((row.get(0)?, row.get(1)?)))?
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(rows)
+    let rows = stmt.query_map([limit], |row| Ok((row.get(0)?, row.get(1)?)))?;
+    let collected: Vec<(i64, String)> = collect_rows::<_, _, _, StorageError>(rows)?;
+    Ok(collected)
 }
 
 pub fn count_unembedded_chunks(conn: &Connection) -> Result<u32, StorageError> {

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -4,7 +4,7 @@ use rurico::embed::ChunkedEmbedding;
 use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 
-use super::{StorageError, collect_rows};
+use super::{StorageError, collect_rows, fetch_by_in_clause};
 
 pub fn add_chunked_embeddings(
     conn: &Connection,
@@ -67,16 +67,12 @@ fn existing_embedded_ids(
     conn: &Connection,
     chunk_ids: &[i64],
 ) -> Result<HashSet<i64>, StorageError> {
-    let sql = format!(
-        "SELECT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
-        super::in_placeholders(chunk_ids.len())
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let params = super::as_sql_params(chunk_ids);
-    let ids = stmt
-        .query_map(params.as_slice(), |row| row.get::<_, i64>(0))?
-        .collect::<Result<HashSet<_>, _>>()?;
-    Ok(ids)
+    fetch_by_in_clause(
+        conn,
+        chunk_ids,
+        "SELECT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({placeholders})",
+        |row| row.get::<_, i64>(0),
+    )
 }
 
 pub fn get_unembedded_chunks(
@@ -130,6 +126,17 @@ mod tests {
 
     fn make_multi_chunked(vals: &[f32]) -> ChunkedEmbedding {
         ChunkedEmbedding::new(vals.iter().map(|&v| vec![v; EMBEDDING_DIMS]).collect())
+    }
+
+    // T-300: existing_embedded_ids does not error on empty input (regression for IN () syntax)
+    #[test]
+    fn existing_embedded_ids_empty_input_returns_empty_set() {
+        let db = Db::open_memory().unwrap();
+        let ids = existing_embedded_ids(db.conn(), &[]).unwrap();
+        assert!(
+            ids.is_empty(),
+            "empty input should return empty set without SQL syntax error"
+        );
     }
 
     // T-173: add_chunked_embeddings stores embedding and clears unembedded queue

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -4,7 +4,9 @@ use rurico::embed::ChunkedEmbedding;
 use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 
-use super::{StorageError, collect_rows, fetch_by_in_clause};
+use amici::storage::fetch_by_in_clause;
+
+use super::{StorageError, collect_storage_rows};
 
 pub fn add_chunked_embeddings(
     conn: &Connection,
@@ -86,8 +88,7 @@ pub fn get_unembedded_chunks(
          LIMIT ?1",
     )?;
     let rows = stmt.query_map([limit], |row| Ok((row.get(0)?, row.get(1)?)))?;
-    let collected: Vec<(i64, String)> = collect_rows::<_, _, _, StorageError>(rows)?;
-    Ok(collected)
+    collect_storage_rows(rows)
 }
 
 pub fn count_unembedded_chunks(conn: &Connection) -> Result<u32, StorageError> {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use amici::storage::{
-    filter::{append_eq_filter, append_timestamp_day_cutoff_filter},
+    fetch_by_in_clause,
+    filter::{append_eq_filter, append_in_filter, append_timestamp_day_cutoff_filter},
     fts::clean_for_trigram,
 };
 use chrono::{DateTime, Utc};
@@ -13,7 +14,7 @@ use rusqlite::Connection;
 use rusqlite::types::ToSql;
 use tracing::warn;
 
-use super::{StorageError, collect_rows, fetch_by_in_clause};
+use super::{StorageError, collect_storage_rows};
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -231,9 +232,7 @@ pub(crate) fn fts_search(
             content: row.get(2)?,
         })
     })?;
-    let hits: Vec<FtsHit> = collect_rows::<_, _, _, StorageError>(rows)?;
-
-    Ok(hits)
+    collect_storage_rows(rows)
 }
 
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
@@ -258,7 +257,7 @@ pub(crate) fn vec_search(
         let rows = stmt.query_map(rusqlite::params![bytes, oversample], |row| {
             Ok((row.get(0)?, row.get(1)?))
         })?;
-        collect_rows::<_, _, _, StorageError>(rows)?
+        collect_storage_rows(rows)?
     };
 
     if knn_rows.is_empty() {
@@ -279,17 +278,14 @@ pub(crate) fn vec_search(
 
     // Step 2: batch-fetch chunk metadata for the deduplicated chunk_ids
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let mut sql = format!(
+    let mut sql = String::from(
         "SELECT c.id, c.post_number, c.section_title, c.content \
          FROM chunks c \
          JOIN posts p ON p.number = c.post_number \
-         WHERE c.id IN ({})",
-        super::anon_placeholders(chunk_ids.len())
+         WHERE 1 = 1",
     );
-    let mut params: Vec<Box<dyn ToSql>> = chunk_ids
-        .iter()
-        .map(|id| Box::new(*id) as Box<dyn ToSql>)
-        .collect();
+    let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+    append_in_filter(&mut sql, &mut params, "c.id", Some(&chunk_ids));
     append_search_filters(&mut sql, &mut params, filter);
 
     let mut stmt2 = conn.prepare(&sql)?;
@@ -303,8 +299,7 @@ pub(crate) fn vec_search(
             ),
         ))
     })?;
-    let meta: HashMap<i64, (u32, Option<String>, String)> =
-        collect_rows::<_, _, _, StorageError>(rows)?;
+    let meta: HashMap<i64, (u32, Option<String>, String)> = collect_storage_rows(rows)?;
 
     let mut hits: Vec<VecHit> = best
         .into_iter()

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -13,7 +13,7 @@ use rusqlite::Connection;
 use rusqlite::types::ToSql;
 use tracing::warn;
 
-use super::StorageError;
+use super::{StorageError, collect_rows};
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -241,17 +241,16 @@ pub(crate) fn fts_search(
     params.push(Box::new(limit));
 
     let mut stmt = conn.prepare(&sql)?;
-    let rows: Vec<FtsHit> = stmt
-        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
-            Ok(FtsHit {
-                post_number: row.get(0)?,
-                section_title: row.get(1)?,
-                content: row.get(2)?,
-            })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+        Ok(FtsHit {
+            post_number: row.get(0)?,
+            section_title: row.get(1)?,
+            content: row.get(2)?,
+        })
+    })?;
+    let hits: Vec<FtsHit> = collect_rows::<_, _, _, StorageError>(rows)?;
 
-    Ok(rows)
+    Ok(hits)
 }
 
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
@@ -273,10 +272,10 @@ pub(crate) fn vec_search(
              WHERE embedding MATCH ?1 AND k = ?2 \
              ORDER BY distance",
         )?;
-        stmt.query_map(rusqlite::params![bytes, oversample], |row| {
+        let rows = stmt.query_map(rusqlite::params![bytes, oversample], |row| {
             Ok((row.get(0)?, row.get(1)?))
-        })?
-        .collect::<Result<Vec<_>, _>>()?
+        })?;
+        collect_rows::<_, _, _, StorageError>(rows)?
     };
 
     if knn_rows.is_empty() {
@@ -311,18 +310,18 @@ pub(crate) fn vec_search(
     append_search_filters(&mut sql, &mut params, filter);
 
     let mut stmt2 = conn.prepare(&sql)?;
-    let meta: HashMap<i64, (u32, Option<String>, String)> = stmt2
-        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                (
-                    row.get::<_, u32>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                    row.get::<_, String>(3)?,
-                ),
-            ))
-        })?
-        .collect::<Result<HashMap<_, _>, _>>()?;
+    let rows = stmt2.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            (
+                row.get::<_, u32>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+            ),
+        ))
+    })?;
+    let meta: HashMap<i64, (u32, Option<String>, String)> =
+        collect_rows::<_, _, _, StorageError>(rows)?;
 
     let mut hits: Vec<VecHit> = best
         .into_iter()

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -13,7 +13,7 @@ use rusqlite::Connection;
 use rusqlite::types::ToSql;
 use tracing::warn;
 
-use super::{StorageError, collect_rows};
+use super::{StorageError, collect_rows, fetch_by_in_clause};
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -137,38 +137,21 @@ fn batch_fetch_post_meta(
     conn: &Connection,
     post_numbers: &[u32],
 ) -> Result<HashMap<u32, PostMeta>, StorageError> {
-    if post_numbers.is_empty() {
-        return Ok(HashMap::new());
-    }
-    let sql = format!(
-        "SELECT number, name, url, updated_at FROM posts WHERE number IN ({})",
-        super::in_placeholders(post_numbers.len())
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let params = super::as_sql_params(post_numbers);
-    let rows = stmt
-        .query_map(params.as_slice(), |row| {
+    fetch_by_in_clause(
+        conn,
+        post_numbers,
+        "SELECT number, name, url, updated_at FROM posts WHERE number IN ({placeholders})",
+        |row| {
             Ok((
                 row.get::<_, u32>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-            ))
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(rows
-        .into_iter()
-        .map(|(n, name, url, updated_at)| {
-            (
-                n,
                 PostMeta {
-                    name,
-                    url,
-                    updated_at,
+                    name: row.get::<_, String>(1)?,
+                    url: row.get::<_, String>(2)?,
+                    updated_at: row.get::<_, String>(3)?,
                 },
-            )
-        })
-        .collect())
+            ))
+        },
+    )
 }
 
 const RECENCY_HALF_LIFE: f64 = 30.0;


### PR DESCRIPTION
## 概要

storage 層で重複していた row-collect / IN-query パターンを amici PR #38 で公開された `amici::storage::query_helpers` (`collect_rows` + `fetch_by_in_clause`) に置換する。amici 側で empty IN-clause の SQL syntax error を helper の早期 return で防ぐ仕様になり、`existing_embedded_ids` の潜在バグも副次的に解消。

## 変更内容

| 種別 | 内容 |
|---|---|
| 依存 | amici `138de41` → `79f837f`、rurico `ef26de2` → `0c0e0f6` に bump |
| 共通 helper 採用 | `collect_rows` を 5 site、`fetch_by_in_clause` を 2 site で採用 |
| 共通 filter 採用 | `vec_search` Step 2 で `append_in_filter` を採用（手書き IN clause + boxing を共通化） |
| sae-local wrapper | `collect_storage_rows` を `src/storage.rs` に追加（`E = StorageError` を fix し turbofish 解消） |
| バグ予防 | `existing_embedded_ids` の empty input regression test (T-300) 追加 |

## 検証

- `cargo test --lib`: 202 passed（T-300 含む）
- `cargo clippy --all-targets --all-features -- -D warnings`: pass
- `cargo fmt --check`: pass

## /polish レビュー結果

| Tool | findings | applied |
|---|---|---|
| simplify (reuse) | 1 | ✓ append_in_filter 採用 |
| simplify (readability) | 4 | ✓ collect_storage_rows wrapper / intermediate binding 削除 / re-export 整理 |
| simplify (efficiency) | 0 | - |
| Codex | 0 | - |
| CodeRabbit | 0 | - |

## 対象外

- `rechunk_post`（IN-clause 2 個で同 params shared）: helper パターンと不一致
- `append_tags_filter`: `EXISTS + json_each` 形で IN clause パターンと不一致
- `insert_new_embeddings`: enhancer-code が flag したが `commands/embed_batch.rs:74` で使用中、dead code ではない

## 参考

- 親 tracking: #83
- amici PR #38: query_helpers モジュール
- rurico #89: tracing migration

Closes #86