### PR TITLE
refactor(cli): amici::cli env_lookup と CliError trait の採用

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,18 @@ sae --json status
 
 ## Exit code
 
-| Code | 意味               | 例                                       |
-| ---- | ------------------ | ---------------------------------------- |
-| 0    | 正常終了           |                                          |
-| 1    | Operational エラー | API エラー、ネットワーク障害             |
-| 2    | Input エラー       | 不明なチーム、トークン未設定、未 harvest |
-| 4    | Internal エラー    | DB 破損、JSON シリアライズ失敗           |
+[sysexits.h](https://man.openbsd.org/sysexits.3) 慣例に準拠（amici #34 で全 CLI 共通化）。LLM / shell script はこの数値で retry policy を判別できる。
+
+| Code | 名前       | 意味             | 例                                       | 推奨 retry  |
+| ---- | ---------- | ---------------- | ---------------------------------------- | ----------- |
+| 0    | SUCCESS    | 正常終了         |                                          |             |
+| 64   | USAGE      | 入力エラー       | 不明なチーム、トークン未設定、未 harvest | しない      |
+| 70   | SOFTWARE   | 内部エラー       | JSON parse 失敗、想定外の例外            | しない      |
+| 73   | CANT_CREAT | データ層エラー   | DB open 失敗、ファイル作成不可           | 状況による  |
+| 74   | IO_ERR     | I/O エラー       | ファイル読み書き失敗                     | 状況による  |
+| 75   | TEMP_FAIL  | 一時的エラー     | esa API rate limit、ネットワーク障害     | する        |
+
+> ⚠️ 破壊的変更（issue #91 / amici #34 migration）: 旧 schema (`1` / `2` / `4`) からの切り替え。スクリプト / CI で specific number に branch している場合は更新が必要。
 
 ## 開発
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
-use std::env;
 use std::fmt;
 use std::time::Duration;
 
+use amici::cli::env_lookup;
 use reqwest::Client;
 use reqwest::header::{AUTHORIZATION, HeaderValue};
 use serde::de::DeserializeOwned;
@@ -155,13 +155,13 @@ impl EsaClient {
     }
 
     pub fn from_env() -> Result<Self, ClientError> {
-        Self::from_env_with(|k| env::var(k))
+        Self::from_env_with(env_lookup())
     }
 
     pub(crate) fn from_env_with(
-        get_var: impl Fn(&str) -> Result<String, env::VarError>,
+        get_var: impl Fn(&str) -> Option<String>,
     ) -> Result<Self, ClientError> {
-        let token = get_var("ESA_ACCESS_TOKEN").map_err(|_| ClientError::TokenNotSet)?;
+        let token = get_var("ESA_ACCESS_TOKEN").ok_or(ClientError::TokenNotSet)?;
         if token.is_empty() {
             return Err(ClientError::TokenNotSet);
         }
@@ -510,7 +510,7 @@ mod tests {
     // T-153: EsaClient::from_env returns TokenNotSet when ESA_ACCESS_TOKEN is absent
     #[test]
     fn from_env_missing_token() {
-        let err = EsaClient::from_env_with(|_| Err(env::VarError::NotPresent)).unwrap_err();
+        let err = EsaClient::from_env_with(|_| None).unwrap_err();
         assert!(matches!(err, ClientError::TokenNotSet));
     }
 
@@ -518,8 +518,8 @@ mod tests {
     #[test]
     fn from_env_empty_token() {
         let err = EsaClient::from_env_with(|key| match key {
-            "ESA_ACCESS_TOKEN" => Ok("".into()),
-            _ => Err(env::VarError::NotPresent),
+            "ESA_ACCESS_TOKEN" => Some("".into()),
+            _ => None,
         })
         .unwrap_err();
         assert!(matches!(err, ClientError::TokenNotSet));

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -78,6 +78,7 @@ pub(crate) fn run_search(
     after: Option<&str>,
     before: Option<&str>,
     no_embed: bool,
+    rerank_enabled: bool,
     json: bool,
 ) -> Result<String, SaeError> {
     let updated_after = parse_date_arg(after, "after")?;
@@ -124,7 +125,6 @@ pub(crate) fn run_search(
     } else {
         None
     };
-    let rerank_enabled = env::var("SAE_RERANK").as_deref() == Ok("1");
     let reranker: Option<ModelLoad<Box<dyn Rerank>>> = rerank_enabled.then(try_load_reranker);
     if let Some(ref r) = reranker {
         r.emit_load_hint(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
-use std::env;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
 
+use amici::cli::env_lookup;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -78,29 +78,30 @@ impl Config {
 }
 
 pub(crate) fn data_dir() -> Result<PathBuf, ConfigError> {
-    data_dir_with(|k| env::var(k))
+    data_dir_with(env_lookup())
 }
 
-fn data_dir_with(
-    get_var: impl Fn(&str) -> Result<String, env::VarError>,
-) -> Result<PathBuf, ConfigError> {
-    let base = get_var("XDG_DATA_HOME").map(PathBuf::from).or_else(|_| {
-        get_var("HOME")
-            .map(|h| PathBuf::from(h).join(".local").join("share"))
-            .map_err(|_| ConfigError::HomeDirNotFound)
-    })?;
+fn data_dir_with(get_var: impl Fn(&str) -> Option<String>) -> Result<PathBuf, ConfigError> {
+    let base = match get_var("XDG_DATA_HOME") {
+        Some(v) => PathBuf::from(v),
+        None => {
+            let home = get_var("HOME").ok_or(ConfigError::HomeDirNotFound)?;
+            PathBuf::from(home).join(".local").join("share")
+        }
+    };
     Ok(base.join("sae"))
 }
 
 fn config_dir() -> Result<PathBuf, ConfigError> {
-    let base = env::var("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .or_else(|_| dirs_fallback_config_home())?;
-    Ok(base.join("sae"))
+    config_dir_with(env_lookup())
 }
 
-fn dirs_fallback_config_home() -> Result<PathBuf, ConfigError> {
-    Ok(home_dir()?.join(".config"))
+fn config_dir_with(get_var: impl Fn(&str) -> Option<String>) -> Result<PathBuf, ConfigError> {
+    let base = match get_var("XDG_CONFIG_HOME") {
+        Some(v) => PathBuf::from(v),
+        None => home_dir_with(&get_var)?.join(".config"),
+    };
+    Ok(base.join("sae"))
 }
 
 /// esa team name: lowercase alphanumeric + hyphen, must start with alphanumeric.
@@ -122,10 +123,10 @@ pub fn validate_team_name(name: &str) -> Result<(), ConfigError> {
     Ok(())
 }
 
-fn home_dir() -> Result<PathBuf, ConfigError> {
-    env::var("HOME")
+fn home_dir_with(get_var: impl Fn(&str) -> Option<String>) -> Result<PathBuf, ConfigError> {
+    get_var("HOME")
         .map(PathBuf::from)
-        .map_err(|_| ConfigError::HomeDirNotFound)
+        .ok_or(ConfigError::HomeDirNotFound)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -152,7 +153,6 @@ pub enum ConfigError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env::VarError;
 
     // T-218: Config::default has empty teams, no default_team, and embed_budget=50
     #[test]
@@ -248,8 +248,8 @@ mod tests {
     #[test]
     fn data_dir_respects_xdg() {
         let dir = data_dir_with(|key| match key {
-            "XDG_DATA_HOME" => Ok("/tmp/test-xdg".into()),
-            _ => Err(VarError::NotPresent),
+            "XDG_DATA_HOME" => Some("/tmp/test-xdg".into()),
+            _ => None,
         })
         .unwrap();
         assert_eq!(dir, PathBuf::from("/tmp/test-xdg/sae"));
@@ -259,11 +259,40 @@ mod tests {
     #[test]
     fn data_dir_falls_back_to_home() {
         let dir = data_dir_with(|key| match key {
-            "HOME" => Ok("/home/testuser".into()),
-            _ => Err(VarError::NotPresent),
+            "HOME" => Some("/home/testuser".into()),
+            _ => None,
         })
         .unwrap();
         assert_eq!(dir, PathBuf::from("/home/testuser/.local/share/sae"));
+    }
+
+    // T-234: data_dir returns HomeDirNotFound when neither XDG_DATA_HOME nor HOME is set
+    #[test]
+    fn data_dir_missing_home_errors() {
+        let err = data_dir_with(|_| None).unwrap_err();
+        assert!(matches!(err, ConfigError::HomeDirNotFound));
+    }
+
+    // T-235: config_dir uses XDG_CONFIG_HOME when that environment variable is set
+    #[test]
+    fn config_dir_respects_xdg() {
+        let dir = config_dir_with(|key| match key {
+            "XDG_CONFIG_HOME" => Some("/tmp/test-config".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(dir, PathBuf::from("/tmp/test-config/sae"));
+    }
+
+    // T-236: config_dir falls back to $HOME/.config/sae when XDG_CONFIG_HOME is unset
+    #[test]
+    fn config_dir_falls_back_to_home() {
+        let dir = config_dir_with(|key| match key {
+            "HOME" => Some("/home/testuser".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(dir, PathBuf::from("/home/testuser/.config/sae"));
     }
 
     // T-229: validate_team_name accepts lowercase alphanumeric names with hyphens

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ pub mod storage;
 pub mod sync;
 pub mod tools;
 
-pub use tools::{Sae, SaeError, exit_code_for};
+pub use tools::{Sae, SaeError};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,12 @@ use std::io;
 use std::iter;
 use std::process::ExitCode;
 
+use amici::cli::exit_code::{CliError, codes};
 use amici::cli::{exit_error, hint_arrow, try_expand_shorthand};
 use clap::{Parser, Subcommand};
 use rurico::model_probe;
 use sae::config::Config;
-use sae::tools::{CreateArgs, Sae, SaeError, SearchArgs, UpdateArgs, exit_code_for};
+use sae::tools::{CreateArgs, Sae, SaeError, SearchArgs, UpdateArgs};
 
 #[derive(Parser)]
 #[command(name = "sae", about = "esa semantic search CLI")]
@@ -226,12 +227,22 @@ async fn main() -> ExitCode {
         )
         .init();
 
-    let cli = parse_cli_args(env::args_os()).unwrap_or_else(|e| e.exit());
+    let cli = match parse_cli_args(env::args_os()) {
+        Ok(cli) => cli,
+        Err(e) => {
+            let _ = e.print();
+            return ExitCode::from(if e.use_stderr() {
+                codes::USAGE
+            } else {
+                codes::SUCCESS
+            });
+        }
+    };
     let config = match Config::load() {
         Ok(c) => c,
         Err(e) => {
             exit_error(&e.to_string());
-            return exit_code_for(&e.into());
+            return SaeError::from(e).exit_code();
         }
     };
     match run(cli, config).await {
@@ -243,7 +254,7 @@ async fn main() -> ExitCode {
         }
         Err(e) => {
             exit_error(&e.to_string());
-            exit_code_for(&e)
+            e.exit_code()
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3,6 +3,8 @@ use std::io;
 use std::process::ExitCode;
 
 use amici::cli::embed_with_spinners;
+use amici::cli::env_lookup;
+use amici::cli::exit_code::{CliError, codes};
 use amici::model::download_and_verify_model;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use rurico::embed::{Artifacts, ModelId, cached_artifacts};
@@ -94,11 +96,20 @@ pub struct UpdateArgs {
 
 pub struct Sae {
     config: Config,
+    rerank_enabled: bool,
 }
 
 impl Sae {
     pub fn new(config: Config) -> Self {
-        Self { config }
+        Self::with_env(config, env_lookup())
+    }
+
+    pub(crate) fn with_env(config: Config, get_var: impl Fn(&str) -> Option<String>) -> Self {
+        let rerank_enabled = get_var("SAE_RERANK").as_deref() == Some("1");
+        Self {
+            config,
+            rerank_enabled,
+        }
     }
 
     pub fn config(&self) -> &Config {
@@ -230,6 +241,7 @@ impl Sae {
             args.after.as_deref(),
             args.before.as_deref(),
             args.no_embed,
+            self.rerank_enabled,
             json,
         )
     }
@@ -280,16 +292,26 @@ pub(crate) fn require_db(config: &Config, team: &str) -> Result<Db, SaeError> {
     Ok(Db::open(&db_path)?)
 }
 
-pub fn exit_code_for(e: &SaeError) -> ExitCode {
-    match e {
-        SaeError::Input(_) | SaeError::Config(_) => ExitCode::from(2),
-        SaeError::Client(ClientError::TokenNotSet) => ExitCode::from(2),
-        SaeError::Sync(SyncError::Client(ClientError::TokenNotSet)) => ExitCode::from(2),
-        SaeError::Storage(_) | SaeError::Sync(SyncError::Storage(_)) | SaeError::Json(_) => {
-            ExitCode::from(4)
-        }
-        SaeError::Client(_) | SaeError::Sync(_) | SaeError::Io(_) | SaeError::Other(_) => {
-            ExitCode::FAILURE
+impl CliError for SaeError {
+    fn exit_code(&self) -> ExitCode {
+        match self {
+            Self::Input(_) | Self::Config(_) => ExitCode::from(codes::USAGE),
+            Self::Client(ClientError::TokenNotSet)
+            | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => {
+                ExitCode::from(codes::USAGE)
+            }
+            Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => {
+                ExitCode::from(codes::CANT_CREAT)
+            }
+            // Api(_) is non-retryable (HTTP 4xx after retry_wait returned None).
+            // Json/Other are internal/data shape errors. All map to SOFTWARE (no retry).
+            Self::Json(_)
+            | Self::Other(_)
+            | Self::Client(ClientError::Api(_))
+            | Self::Sync(SyncError::Client(ClientError::Api(_))) => ExitCode::from(codes::SOFTWARE),
+            Self::Io(_) => ExitCode::from(codes::IO_ERR),
+            // Remaining Client/Sync paths (Network, MaxRetries) are retry-eligible.
+            Self::Client(_) | Self::Sync(_) => ExitCode::from(codes::TEMP_FAIL),
         }
     }
 }
@@ -301,5 +323,116 @@ fn require_embed_model() -> Result<Artifacts, SaeError> {
             "Model not found. Run 'sae model download' first.".to_owned(),
         )),
         Err(e) => Err(SaeError::Other(format!("Failed to check model cache: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_code(err: &SaeError, expected: u8) {
+        assert_eq!(
+            format!("{:?}", err.exit_code()),
+            format!("{:?}", ExitCode::from(expected))
+        );
+    }
+
+    // T-237: Input variant maps to USAGE (sysexits 64)
+    #[test]
+    fn exit_code_input_is_usage() {
+        assert_code(&SaeError::Input("bad".into()), codes::USAGE);
+    }
+
+    // T-238: Config variant maps to USAGE (sysexits 64)
+    #[test]
+    fn exit_code_config_is_usage() {
+        assert_code(
+            &SaeError::Config(ConfigError::NoTeamSpecified),
+            codes::USAGE,
+        );
+    }
+
+    // T-239: Client(TokenNotSet) maps to USAGE (sysexits 64)
+    #[test]
+    fn exit_code_token_not_set_is_usage() {
+        assert_code(&SaeError::Client(ClientError::TokenNotSet), codes::USAGE);
+    }
+
+    // T-240: Storage variant maps to CANT_CREAT (sysexits 73)
+    #[test]
+    fn exit_code_storage_is_cant_creat() {
+        assert_code(
+            &SaeError::Storage(StorageError::Open("missing".into())),
+            codes::CANT_CREAT,
+        );
+    }
+
+    // T-241: Json variant maps to SOFTWARE (sysexits 70)
+    #[test]
+    fn exit_code_json_is_software() {
+        let err: serde_json::Error = serde_json::from_str::<i32>("not json").unwrap_err();
+        assert_code(&SaeError::Json(err), codes::SOFTWARE);
+    }
+
+    // T-242: Other variant maps to SOFTWARE (sysexits 70)
+    #[test]
+    fn exit_code_other_is_software() {
+        assert_code(&SaeError::Other("unexpected".into()), codes::SOFTWARE);
+    }
+
+    // T-243: Io variant maps to IO_ERR (sysexits 74)
+    #[test]
+    fn exit_code_io_is_io_err() {
+        assert_code(&SaeError::Io(io::Error::other("disk full")), codes::IO_ERR);
+    }
+
+    // T-244: Client(MaxRetries) maps to TEMP_FAIL (sysexits 75) for retry
+    #[test]
+    fn exit_code_client_max_retries_is_temp_fail() {
+        assert_code(
+            &SaeError::Client(ClientError::MaxRetries(5)),
+            codes::TEMP_FAIL,
+        );
+    }
+
+    // T-245: Client(Api) maps to SOFTWARE (sysexits 70) — non-retryable HTTP 4xx
+    #[test]
+    fn exit_code_client_api_is_software() {
+        assert_code(
+            &SaeError::Client(ClientError::Api("404 Not Found".into())),
+            codes::SOFTWARE,
+        );
+    }
+
+    // T-300: Sae::with_env enables rerank when SAE_RERANK="1"
+    #[test]
+    fn with_env_enables_rerank_when_one() {
+        let sae = Sae::with_env(Config::default(), |key| match key {
+            "SAE_RERANK" => Some("1".into()),
+            _ => None,
+        });
+        assert!(sae.rerank_enabled);
+    }
+
+    // T-301: Sae::with_env disables rerank when SAE_RERANK is absent
+    #[test]
+    fn with_env_disables_rerank_when_absent() {
+        let sae = Sae::with_env(Config::default(), |_| None);
+        assert!(!sae.rerank_enabled);
+    }
+
+    // T-302: Sae::with_env disables rerank for any non-"1" value (e.g. "0", "true")
+    #[test]
+    fn with_env_disables_rerank_for_non_one_values() {
+        for value in ["0", "true", "yes", ""] {
+            let sae = Sae::with_env(Config::default(), |key| match key {
+                "SAE_RERANK" => Some(value.into()),
+                _ => None,
+            });
+            assert!(
+                !sae.rerank_enabled,
+                "SAE_RERANK={value:?} should not enable rerank"
+            );
+        }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -309,8 +309,15 @@ impl CliError for SaeError {
             | Self::Other(_)
             | Self::Client(ClientError::Api(_))
             | Self::Sync(SyncError::Client(ClientError::Api(_))) => ExitCode::from(codes::SOFTWARE),
+            // reqwest decode failures are schema/payload issues, not transient network.
+            Self::Client(ClientError::Network(e))
+            | Self::Sync(SyncError::Client(ClientError::Network(e)))
+                if e.is_decode() =>
+            {
+                ExitCode::from(codes::SOFTWARE)
+            }
             Self::Io(_) => ExitCode::from(codes::IO_ERR),
-            // Remaining Client/Sync paths (Network, MaxRetries) are retry-eligible.
+            // Remaining Client/Sync paths (Network connect/timeout, MaxRetries) are retry-eligible.
             Self::Client(_) | Self::Sync(_) => ExitCode::from(codes::TEMP_FAIL),
         }
     }
@@ -331,10 +338,7 @@ mod tests {
     use super::*;
 
     fn assert_code(err: &SaeError, expected: u8) {
-        assert_eq!(
-            format!("{:?}", err.exit_code()),
-            format!("{:?}", ExitCode::from(expected))
-        );
+        assert_eq!(err.exit_code(), ExitCode::from(expected));
     }
 
     // T-237: Input variant maps to USAGE (sysexits 64)
@@ -401,6 +405,42 @@ mod tests {
         assert_code(
             &SaeError::Client(ClientError::Api("404 Not Found".into())),
             codes::SOFTWARE,
+        );
+    }
+
+    // T-246: Sync(Client(TokenNotSet)) maps to USAGE (sysexits 64)
+    #[test]
+    fn exit_code_sync_token_not_set_is_usage() {
+        assert_code(
+            &SaeError::Sync(SyncError::Client(ClientError::TokenNotSet)),
+            codes::USAGE,
+        );
+    }
+
+    // T-247: Sync(Storage) maps to CANT_CREAT (sysexits 73)
+    #[test]
+    fn exit_code_sync_storage_is_cant_creat() {
+        assert_code(
+            &SaeError::Sync(SyncError::Storage(StorageError::Open("missing".into()))),
+            codes::CANT_CREAT,
+        );
+    }
+
+    // T-248: Sync(Client(Api)) maps to SOFTWARE (sysexits 70) — non-retryable HTTP 4xx
+    #[test]
+    fn exit_code_sync_client_api_is_software() {
+        assert_code(
+            &SaeError::Sync(SyncError::Client(ClientError::Api("404 Not Found".into()))),
+            codes::SOFTWARE,
+        );
+    }
+
+    // T-249: Sync(Client(MaxRetries)) maps to TEMP_FAIL (sysexits 75) for retry
+    #[test]
+    fn exit_code_sync_client_max_retries_is_temp_fail() {
+        assert_code(
+            &SaeError::Sync(SyncError::Client(ClientError::MaxRetries(5))),
+            codes::TEMP_FAIL,
         );
     }
 


### PR DESCRIPTION
## 概要

- amici #34 migration: `env::var` DI を `amici::cli::env_lookup()` (`Option<String>` signature) に統一、`pub fn exit_code_for(&SaeError)` を `impl CliError for SaeError` (sysexits codes) に置換
- `Sae` struct に `rerank_enabled` field を追加、`Sae::with_env(config, env_lookup())` で yomu sister CLI pattern と整列
- Codex review 反映: clap parse error → `USAGE (64)`、`Client::Api` → `SOFTWARE (70)`、`reqwest::Error::is_decode()` → `SOFTWARE (70)`

## 破壊的変更

⚠️ exit code 数値が変わる（README/CHANGELOG に記述ナシのため後方互換不要で進行）:

| 旧  | 新                | variant                                          |
| --- | ----------------- | ------------------------------------------------ |
| 1   | 70 / 74 / 75      | `Other` / `Io` / `Client(Network/MaxRetries)`    |
| 2   | 64                | `Input` / `Config` / `Client(TokenNotSet)`       |
| 4   | 70 / 73           | `Json` / `Storage`                               |

詳細は README の Exit code 表を参照。

## 検証

- [x] `cargo test --lib` 全 pass (221 tests)
- [x] `cargo test` 全 pass (lib 221 + integration 33 + redact 3)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `env::var(` 直読み 0 件（`amici::cli::env_lookup` 経由のみ）
- [x] `pub fn exit_code_for` 削除、`impl CliError for SaeError` 追加
- [x] sister CLI (yomu) pattern との整列確認

## 関連

- Closes #91
- Refs #83 (parent tracking)
- Follow-up: #92 (model download network failure mapping)