### PR TITLE
refactor(logging): amici::logging::init_subscriber の採用

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6", features = ["test-support"] }

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ sae --json status
 
 > ⚠️ 破壊的変更（issue #91 / amici #34 migration）: 旧 schema (`1` / `2` / `4`) からの切り替え。スクリプト / CI で specific number に branch している場合は更新が必要。
 
+## ログ
+
+`tracing` ベース。`RUST_LOG` で制御する。
+
+| 環境 | filter | 例 |
+|---|---|---|
+| 未設定（default） | `sae=info,rurico=warn` | sae の通常ログ + rurico の degraded path warn |
+| 任意指定 | `RUST_LOG=<directives>` | env var の値が完全に default を上書き |
+
+degraded path（embedder/reranker fallback、MLX cache 復旧、probe timeout 等）は rurico 側で `tracing::warn!` を発行する。default filter で `rurico=warn` を含めることで operator が観測可能。
+
+> ⚠️ 破壊的変更（issue #85 / amici #36 migration）: 旧挙動「`RUST_LOG` 設定時も常に `sae=info` を layer」を廃止。`RUST_LOG` 設定時は env 優先、未設定時のみ default を使う。`RUST_LOG=sae=info` を export する運用へ移行が必要な場合は明示指定。
+
 ## 開発
 
 ### セットアップ

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@
 
 use std::env;
 use std::ffi;
-use std::io;
 use std::iter;
 use std::process::ExitCode;
 
 use amici::cli::exit_code::{CliError, codes};
 use amici::cli::{exit_error, hint_arrow, try_expand_shorthand};
+use amici::logging::init_subscriber;
 use clap::{Parser, Subcommand};
 use rurico::model_probe;
 use sae::config::Config;
@@ -219,13 +219,7 @@ async fn run(cli: Cli, config: Config) -> Result<String, SaeError> {
 async fn main() -> ExitCode {
     model_probe::handle_probe_if_needed();
 
-    tracing_subscriber::fmt()
-        .with_writer(io::stderr)
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("sae=info".parse().expect("hardcoded directive is valid")),
-        )
-        .init();
+    init_subscriber("sae=info");
 
     let cli = match parse_cli_args(env::args_os()) {
         Ok(cli) => cli,


### PR DESCRIPTION
## 概要

amici #36 / sae #85 migration。`src/main.rs` の自前 `tracing_subscriber::fmt()` 初期化を `amici::logging::init_subscriber("sae=info")` に置換。`tracing-subscriber` の direct 依存を Cargo.toml から削除（amici 経由で取得）。

これで rurico の degraded-path warn (`tracing::warn!` 経路) が operator に観測可能になる。amici 側で default filter に `rurico=warn` を merge する仕様。

## 破壊的変更

⚠️ `RUST_LOG` 設定時の挙動が変わる:

| | 旧挙動 | 新挙動 |
|---|---|---|
| `RUST_LOG` 未設定 | `sae=info` directive | `sae=info,rurico=warn` (rurico merge) |
| `RUST_LOG=foo=bar` 設定時 | `foo=bar,sae=info` (常に layer) | `foo=bar` (env が完全上書き) |

旧挙動「常に sae=info を layer」を維持したい運用者は明示的に `RUST_LOG=sae=info` を export する必要あり。

## 検証

- [x] `cargo test` 全 pass (lib + integration + redact)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] sae src 内 `tracing_subscriber::` 直参照 0 件
- [x] `cargo tree -i tracing-subscriber` で sae の direct consumer なし（amici 経由のみ）
- [x] `/polish` 実行: simplify (reuse/quality/efficiency) 全 clean、enhancer-code 変更なし

### Acceptance criteria のうち skip 判断

- [ ] ~~integration test: degraded シナリオで stderr に rurico 由来の warn 行が出ることを assert~~
  - amici #36 PR #40 で `init_subscriber` の rurico=warn merge を unit test 済み
  - sae 側で重ねるのは amici contract のテストになり、sae の wiring を test していない
  - judgment call で skip

## 関連

- Closes #85
- Refs #83 (parent tracking)
- 上流: thkt/rurico#89 (CLOSED, tracing 化), thkt/amici#36 (CLOSED, default filter rurico=warn merge)