### PR TITLE
fix(cli): model download HTTP 失敗を TEMP_FAIL exit code にマップ

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ sae --json status
 
 [sysexits.h](https://man.openbsd.org/sysexits.3) 慣例に準拠（amici #34 で全 CLI 共通化）。LLM / shell script はこの数値で retry policy を判別できる。
 
-| Code | 名前       | 意味             | 例                                       | 推奨 retry  |
-| ---- | ---------- | ---------------- | ---------------------------------------- | ----------- |
-| 0    | SUCCESS    | 正常終了         |                                          |             |
-| 64   | USAGE      | 入力エラー       | 不明なチーム、トークン未設定、未 harvest | しない      |
-| 70   | SOFTWARE   | 内部エラー       | JSON parse 失敗、想定外の例外            | しない      |
-| 73   | CANT_CREAT | データ層エラー   | DB open 失敗、ファイル作成不可           | 状況による  |
-| 74   | IO_ERR     | I/O エラー       | ファイル読み書き失敗                     | 状況による  |
-| 75   | TEMP_FAIL  | 一時的エラー     | esa API rate limit、ネットワーク障害     | する        |
+| Code | 名前       | 意味             | 例                                                       | 推奨 retry  |
+| ---- | ---------- | ---------------- | -------------------------------------------------------- | ----------- |
+| 0    | SUCCESS    | 正常終了         |                                                          |             |
+| 64   | USAGE      | 入力エラー       | 不明なチーム、トークン未設定、未 harvest                 | しない      |
+| 70   | SOFTWARE   | 内部エラー       | JSON parse 失敗、想定外の例外、model 検証失敗            | しない      |
+| 73   | CANT_CREAT | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
+| 74   | IO_ERR     | I/O エラー       | ファイル読み書き失敗                                     | 状況による  |
+| 75   | TEMP_FAIL  | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout) | する  |
 
 > ⚠️ 破壊的変更（issue #91 / amici #34 migration）: 旧 schema (`1` / `2` / `4`) からの切り替え。スクリプト / CI で specific number に branch している場合は更新が必要。
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5,8 +5,8 @@ use std::process::ExitCode;
 use amici::cli::embed_with_spinners;
 use amici::cli::env_lookup;
 use amici::cli::exit_code::{CliError, codes};
-use amici::model::download_and_verify_model;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
+use amici::model::{ModelDownloadError, download_and_verify_model};
 use rurico::embed::{Artifacts, ModelId, cached_artifacts};
 
 use crate::client::{ClientError, EsaClient};
@@ -189,7 +189,7 @@ impl Sae {
     }
 
     pub fn model_download(json: bool) -> Result<String, SaeError> {
-        download_and_verify_model().map_err(|e| SaeError::Other(e.to_string()))?;
+        download_and_verify_model()?;
         output::model_download(json)
     }
 
@@ -265,6 +265,8 @@ pub enum SaeError {
     Json(#[from] serde_json::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    ModelDownload(#[from] ModelDownloadError),
     /// User action required (e.g., run harvest or model download first)
     #[error("{0}")]
     Input(String),
@@ -317,6 +319,14 @@ impl CliError for SaeError {
                 ExitCode::from(codes::SOFTWARE)
             }
             Self::Io(_) => ExitCode::from(codes::IO_ERR),
+            // HTTP download failures are transient (retry); backend/verification failures are not.
+            // Explicit arms (no wildcard) so future amici variants force a compile-time review here.
+            Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => {
+                ExitCode::from(codes::TEMP_FAIL)
+            }
+            Self::ModelDownload(
+                ModelDownloadError::BackendUnavailable | ModelDownloadError::ProbeFailed(_),
+            ) => ExitCode::from(codes::SOFTWARE),
             // Remaining Client/Sync paths (Network connect/timeout, MaxRetries) are retry-eligible.
             Self::Client(_) | Self::Sync(_) => ExitCode::from(codes::TEMP_FAIL),
         }
@@ -404,6 +414,35 @@ mod tests {
     fn exit_code_client_api_is_software() {
         assert_code(
             &SaeError::Client(ClientError::Api("404 Not Found".into())),
+            codes::SOFTWARE,
+        );
+    }
+
+    // T-303: ModelDownload(DownloadFailed) maps to TEMP_FAIL (sysexits 75) — transient HTTP failure
+    #[test]
+    fn exit_code_model_download_failed_is_temp_fail() {
+        assert_code(
+            &SaeError::ModelDownload(ModelDownloadError::DownloadFailed(
+                "connection reset".into(),
+            )),
+            codes::TEMP_FAIL,
+        );
+    }
+
+    // T-304: ModelDownload(BackendUnavailable) maps to SOFTWARE (sysexits 70) — non-retryable hardware mismatch
+    #[test]
+    fn exit_code_model_download_backend_unavailable_is_software() {
+        assert_code(
+            &SaeError::ModelDownload(ModelDownloadError::BackendUnavailable),
+            codes::SOFTWARE,
+        );
+    }
+
+    // T-305: ModelDownload(ProbeFailed) maps to SOFTWARE (sysexits 70) — verification failure, retry won't help
+    #[test]
+    fn exit_code_model_download_probe_failed_is_software() {
+        assert_code(
+            &SaeError::ModelDownload(ModelDownloadError::ProbeFailed("hash mismatch".into())),
             codes::SOFTWARE,
         );
     }


### PR DESCRIPTION
## 概要

sae #92 fix。`Sae::model_download` の失敗を `SaeError::Other(String)` で stringify していた経路を `SaeError::ModelDownload(#[from] ModelDownloadError)` の typed variant に切替、exit code を amici #34 sysexits 慣例に整合させる。

LLM / shell script は exit code から retry policy を判別する想定だが、現状はネットワーク障害も検証失敗も同じ `SOFTWARE (70)` になっていたため retry を諦める判断を下していた。

## 変更内容

### exit code マッピング

| `ModelDownloadError` variant | 現状 | After |
|---|---|---|
| `DownloadFailed(_)` (HTTP 429 / 5xx / timeout) | `Other` 経由で `SOFTWARE (70)` | `TEMP_FAIL (75)` |
| `BackendUnavailable` (Apple Silicon 不一致等) | `Other` 経由で `SOFTWARE (70)` | `SOFTWARE (70)` |
| `ProbeFailed(_)` (ハッシュ不一致 / 検証失敗) | `Other` 経由で `SOFTWARE (70)` | `SOFTWARE (70)` |

### match arm の wildcard 廃止

`Self::ModelDownload(_)` の wildcard ではなく `BackendUnavailable | ProbeFailed(_)` を明示列挙。amici 側で新 variant が追加された際、sae 側で compile error として出てくるため retry-policy review を強制できる。

### Sae::model_download の簡略化

```rust
// Before
download_and_verify_model().map_err(|e| SaeError::Other(e.to_string()))?;

// After
download_and_verify_model()?;
```

`#[from]` impl で自動変換、`String` allocation も削減。

## 検証

- [x] `cargo test --lib` 全 pass (224 tests, T-303/T-304/T-305 追加)
- [x] `cargo test` 全 pass (lib + integration + redact + doc)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `/polish` 実行: simplify (reuse/quality/efficiency)、Codex、CodeRabbit 全完了、actionable findings 全反映済み

## 関連

- Closes #92
- 上流: amici `ModelDownloadError`（既に rev `79f837f` で利用可能）
- follow-up: yomu / recall も同パターン（`download_and_verify_model()` を Internal/Other で wrap してる）が残るが、別 repo 横展開として yomu #150 / recall #61 の延長で扱う