### PR TITLE
rurico を 73c5b69 / amici を 48bc7ea へ bump し破壊的変更に追従

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,9 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=79f837f#79f837fed35f25ae675ddcdb76bbafb0604be02b"
+source = "git+https://github.com/thkt/amici?rev=48bc7ea#48bc7eacfb80eb18f5be3900ca058260ff54d246"
 dependencies = [
+ "bytemuck",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rurico",
@@ -2308,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
+source = "git+https://github.com/thkt/rurico?rev=73c5b69#73c5b691e341e4068f04ec75a72cbf79208ca856"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2328,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
+source = "git+https://github.com/thkt/rurico?rev=73c5b69#73c5b691e341e4068f04ec75a72cbf79208ca856"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2478,6 +2479,7 @@ name = "sae"
 version = "0.1.0"
 dependencies = [
  "amici",
+ "bytemuck",
  "chrono",
  "clap",
  "reqwest 0.13.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "79f837f" }
+amici = { git = "https://github.com/thkt/amici", rev = "48bc7ea" }
+bytemuck = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.13", features = ["json"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "73c5b69" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -23,7 +24,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "73c5b69", features = ["test-support"] }
 serial_test = "3"
 tempfile = "3"
 wiremock = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use amici::cli::exit_code::{CliError, codes};
 use amici::cli::{exit_error, hint_arrow, try_expand_shorthand};
 use amici::logging::init_subscriber;
 use clap::{Parser, Subcommand};
-use rurico::model_probe;
 use sae::config::Config;
 use sae::tools::{CreateArgs, Sae, SaeError, SearchArgs, UpdateArgs};
 
@@ -217,7 +216,7 @@ async fn run(cli: Cli, config: Config) -> Result<String, SaeError> {
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    model_probe::handle_probe_if_needed();
+    rurico::handle_probe_if_needed();
 
     init_subscriber("sae=info");
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -41,6 +41,13 @@ pub(crate) fn query_norm_config() -> QueryNormalizationConfig {
     QueryNormalizationConfig::default()
 }
 
+/// Zero-copy `&[f32] → &[u8]` for binding embedding vectors to sqlite-vec.
+/// Replaces `rurico::storage::f32_as_bytes` after its removal upstream;
+/// rurico's `compile_error!` for non-little-endian targets is transitive.
+pub(crate) fn f32_as_bytes(v: &[f32]) -> &[u8] {
+    bytemuck::cast_slice(v)
+}
+
 const DDL_FTS: &str = "\
     CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(\
         section_title, content, tokenize='trigram'\

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -1,12 +1,11 @@
 use std::collections::HashSet;
 
 use rurico::embed::ChunkedEmbedding;
-use rurico::storage::f32_as_bytes;
 use rusqlite::Connection;
 
 use amici::storage::fetch_by_in_clause;
 
-use super::{StorageError, collect_storage_rows};
+use super::{StorageError, collect_storage_rows, f32_as_bytes};
 
 pub fn add_chunked_embeddings(
     conn: &Connection,

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::f64::consts::LN_2;
 
 use amici::storage::{
     fetch_by_in_clause,
@@ -7,14 +8,12 @@ use amici::storage::{
 };
 use chrono::{DateTime, Utc};
 use rurico::reranker::Rerank;
-use rurico::storage::{
-    f32_as_bytes, normalize_for_fts, prepare_match_query, recency_decay, rrf_merge,
-};
+use rurico::storage::{normalize_for_fts, prepare_match_query};
 use rusqlite::Connection;
 use rusqlite::types::ToSql;
 use tracing::warn;
 
-use super::{StorageError, collect_storage_rows};
+use super::{StorageError, collect_storage_rows, f32_as_bytes};
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -158,6 +157,37 @@ fn batch_fetch_post_meta(
 const RECENCY_HALF_LIFE: f64 = 30.0;
 const RECENCY_WEIGHT: f64 = 0.2;
 const SECS_PER_DAY: f64 = 86_400.0;
+const RRF_K: f64 = 60.0;
+
+/// Reciprocal Rank Fusion: rank-only merge of two ranked lists.
+/// Replaces `rurico::storage::rrf_merge` after its removal upstream
+/// (folded into `retrieval::WeightedRrf::default()`). sae keeps the
+/// pre-rerank rank-only fusion here because applying recency in the
+/// merge step would change the recency-after-rerank semantics.
+fn rrf_merge(fts_hits: &[(u32, f64)], vec_hits: &[(u32, f64)]) -> Vec<(u32, f64)> {
+    let mut scores: HashMap<u32, f64> = HashMap::new();
+    for (rank, (key, _)) in fts_hits.iter().enumerate() {
+        *scores.entry(*key).or_default() += 1.0 / (RRF_K + rank as f64);
+    }
+    for (rank, (key, _)) in vec_hits.iter().enumerate() {
+        *scores.entry(*key).or_default() += 1.0 / (RRF_K + rank as f64);
+    }
+    let mut results: Vec<(u32, f64)> = scores.into_iter().collect();
+    results.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    results
+}
+
+/// Exponential recency decay: 1.0 at age=0, 0.5 at one half-life.
+/// Replaces `rurico::storage::recency_decay` after it was demoted to
+/// `pub(crate)` upstream. Applied after the cross-encoder rerank, so
+/// `WeightedRrf::merge_with_recency` (which acts pre-rerank) cannot
+/// be substituted without changing observable ranking.
+fn recency_decay(age_days: f64, half_life_days: f64) -> f64 {
+    if half_life_days <= 0.0 {
+        return 0.0;
+    }
+    (-LN_2 * age_days.max(0.0) / half_life_days).exp()
+}
 
 fn apply_recency_boost(
     merged: Vec<(u32, f64)>,


### PR DESCRIPTION
## What & Why

rurico/amici の rev を最新へアップデートし、upstream の破壊的変更に追従する。`rurico::storage` から削除された helper (rrf_merge / recency_decay / f32_as_bytes) を sae 内に再実装し、`handle_probe_if_needed` の crate root 移動にも合わせる。

## Changes

- `amici`: `79f837f` → `48bc7ea`(破壊的 API 変更なし、eval-harness 内部更新)
- `rurico`: `0c0e0f6` → `73c5b69`(storage 系 helper 削除を含む破壊的変更)
- `bytemuck = "1"` を direct dep に追加 — 旧 `f32_as_bytes` の置換ルート (README 推奨)
- `src/storage.rs`: `pub(crate) fn f32_as_bytes` を `bytemuck::cast_slice` 経由で再実装
- `src/storage/search.rs`: `rrf_merge` / `recency_decay` を file-private fn として再実装
- `src/main.rs`: `handle_probe_if_needed` の呼び出しを crate root 経由に変更

## Scope

- **Not included**: `LazyReranker` の sae 採用。`hybrid_search` は `Option<&dyn Rerank>` で呼び出し側が制御するため、「ロード済みだが未使用」状況が発生せず lazy 化の利得なし
- **Not included**: `WeightedRrf::merge_with_recency` への移行。sae は cross-encoder スコアに multiplicative で recency boost する semantic だが、`merge_with_recency` は merge 段階で additive boost → `reranker.score_batch` の戻り値で score が上書きされ recency が消失する。eval harness が sae 側に無く A/B 比較できないため見送り

## Design Decisions

- **rrf_merge を sae 内に再実装**: rurico `b35df06` の旧実装と bit-equal (RRF_K=60、key 昇順 tie-break 保持)。`WeightedRrf::default()` でも代替可能だが、`(u32, f64)` 入力を `Candidate { doc_id: String, ... }` に変換するコスト + recency semantic 保持のため inline 化
- **f32_as_bytes は storage parent module に配置**: `embed.rs` と `search.rs` 両方で使われるため `storage.rs` に集約 (`collect_storage_rows` と同じパターン)。`unsafe_code = "forbid"` 維持のため `bytemuck::cast_slice` 経由

## How to Test

1. `cargo check --all-targets` → エラーなし
2. `cargo clippy --all-targets --all-features -- -D warnings` → 警告なし
3. `cargo test` → 260 件全パス (lib 224 + bin 33 + integration 3)
4. `cargo fmt --all -- --check` → 差分なし

## Related

- IDR: `.claude/workspace/planning/2026-05-11/idr-02.md`
