### PR TITLE
feat(io): BrokenPipe を SUCCESS として扱う stdout 出力 (ADR-0060 Phase 1, #100)

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,50 @@
+use std::io::{self, Write};
+
+/// Write `output` to `w`, ensuring exactly one trailing newline.
+pub fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
+    w.write_all(output.as_bytes())?;
+    if !output.ends_with('\n') {
+        w.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+
+    use super::write_output;
+
+    /// T-W001: write_output appends newline when output lacks trailing newline
+    #[test]
+    fn write_output_appends_newline_when_missing() {
+        let mut buf = Vec::new();
+        write_output(&mut buf, "hello").unwrap();
+        assert_eq!(&buf, b"hello\n");
+    }
+
+    /// T-W002: write_output preserves single trailing newline
+    #[test]
+    fn write_output_preserves_existing_newline() {
+        let mut buf = Vec::new();
+        write_output(&mut buf, "hello\n").unwrap();
+        assert_eq!(&buf, b"hello\n");
+    }
+
+    /// T-W003: write_output propagates BrokenPipe error from writer
+    #[test]
+    fn write_output_propagates_broken_pipe() {
+        struct BrokenPipeWriter;
+        impl Write for BrokenPipeWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::from(io::ErrorKind::BrokenPipe))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let mut w = BrokenPipeWriter;
+        let err = write_output(&mut w, "hello").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -15,7 +15,7 @@ mod tests {
 
     use super::write_output;
 
-    /// T-W001: write_output appends newline when output lacks trailing newline
+    // T-W001: write_output_appends_newline_when_missing
     #[test]
     fn write_output_appends_newline_when_missing() {
         let mut buf = Vec::new();
@@ -23,7 +23,7 @@ mod tests {
         assert_eq!(&buf, b"hello\n");
     }
 
-    /// T-W002: write_output preserves single trailing newline
+    // T-W002: write_output_preserves_existing_newline (does not double it)
     #[test]
     fn write_output_preserves_existing_newline() {
         let mut buf = Vec::new();
@@ -31,7 +31,7 @@ mod tests {
         assert_eq!(&buf, b"hello\n");
     }
 
-    /// T-W003: write_output propagates BrokenPipe error from writer
+    // T-W003: write_output_propagates_broken_pipe
     #[test]
     fn write_output_propagates_broken_pipe() {
         struct BrokenPipeWriter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub(crate) mod chunker;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod io;
 pub(crate) mod output;
 pub(crate) mod redact;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::ffi;
+use std::io::{ErrorKind, stdout};
 use std::iter;
 use std::process::ExitCode;
 
@@ -10,6 +11,7 @@ use amici::cli::{exit_error, hint_arrow, try_expand_shorthand};
 use amici::logging::init_subscriber;
 use clap::{Parser, Subcommand};
 use sae::config::Config;
+use sae::io::write_output;
 use sae::tools::{CreateArgs, Sae, SaeError, SearchArgs, UpdateArgs};
 
 #[derive(Parser)]
@@ -240,10 +242,19 @@ async fn main() -> ExitCode {
     };
     match run(cli, config).await {
         Ok(output) => {
-            if !output.is_empty() {
-                println!("{output}");
+            if output.is_empty() {
+                ExitCode::SUCCESS
+            } else {
+                let mut handle = stdout().lock();
+                match write_output(&mut handle, &output) {
+                    Ok(()) => ExitCode::SUCCESS,
+                    Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+                    Err(e) => {
+                        exit_error(&format!("write to stdout failed: {e}"));
+                        ExitCode::from(codes::IO_ERR)
+                    }
+                }
             }
-            ExitCode::SUCCESS
         }
         Err(e) => {
             exit_error(&e.to_string());


### PR DESCRIPTION
## 概要

ADR-0060 Phase 1 for #100 ([監査コメント](https://github.com/thkt/sae/issues/100#issuecomment-4425622919))。

`sae::io::write_output` を追加し、main の success path を `stdout().lock()` 経由に切り替え。`ErrorKind::BrokenPipe` を SUCCESS に丸める (scout PR thkt/scout#74 と同形)。`sae status | head -0`, `... | true` 等の shell pipeline が `failed printing to stdout: Broken pipe (os error 32)` で panic しなくなる。

**Scope: stdout のみ。** `exit_error` / `eprintln!` を経由する stderr path は本 PR では未対応 — scout #74 と同じトレードオフ。stderr BrokenPipe は Phase 2.2 で `emit_error` 導入時に同時対応予定。

## 実機検証

Before (main @ b6f38bf):
- `./target/release/sae status | true` → exit 101, panic at `io/stdio.rs:1165` (`failed printing to stdout: Broken pipe (os error 32)`)
- `./target/release/sae status | head -0` → exit 101

After (this branch):
- `./target/release/sae status | true` → exit 0
- `./target/release/sae status | head -0` → exit 0

## テスト計画

- [x] `cargo test --all` pass (既存 224 + 新規 3 unit test = T-W001/W002/W003)
- [x] `cargo clippy --all-targets` clean
- [x] 実機 BrokenPipe 検証 (`| true` / `| head -0` 両方)

## Phase 計画 (sae #100)

- ✅ Phase 1: BrokenPipe handling (本 PR)
- ⬜ Phase 2.1: envelope types + `SaeError` 拡張
- ⬜ Phase 2.2: `--json` wiring + `degraded`/`notes`

Phase 3 (将来) で sae / yomu / recall 3 ツール揃った時点で envelope / `write_output` ヘルパーの amici 昇格を別 issue で起票予定。

Refs: #100, ADR-0060