### PR TITLE
feat(envelope): ADR-0060 envelope 型と SaeError アクセサメソッド (Phase 2.1, #100)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,0 +1,215 @@
+//! Output envelopes per ADR-0060.
+//!
+//! Phase 2.1 introduces the type definitions and `SaeError` accessor methods
+//! (`error_code`, `next_step`, `candidates`, `retryable`). Phase 2.2 wires the
+//! renderers (`render_json_success` / `render_json_error`) through the `--json`
+//! path. This module exposes no observable behavior change on its own.
+//!
+//! `#![allow(dead_code)]` covers the envelope structs that are unused until
+//! Phase 2.2 wires them; remove the allow when wiring lands.
+#![allow(dead_code)]
+
+use serde::Serialize;
+
+/// JSON-serializable error classification per ADR-0060.
+///
+/// The variant set covers the 5 sysexits codes `SaeError` currently produces.
+/// `DATA_ERROR (65)` and `NOT_FOUND (66)` are absent because no sae operation
+/// maps to them today; they will be reconsidered when this type lifts into
+/// amici alongside yomu / recall (ADR-0060 Phase 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum ErrorCode {
+    UsageError,
+    Software,
+    CantCreat,
+    IoError,
+    TempFailure,
+}
+
+impl ErrorCode {
+    /// sysexits.h exit code mapped per ADR-0060.
+    pub(crate) fn exit_code(self) -> u8 {
+        match self {
+            Self::UsageError => 64,
+            Self::Software => 70,
+            Self::CantCreat => 73,
+            Self::IoError => 74,
+            Self::TempFailure => 75,
+        }
+    }
+}
+
+/// Success envelope per ADR-0060 (`{ data, degraded, notes }`).
+#[derive(Debug, Serialize)]
+pub(crate) struct SuccessEnvelope {
+    pub data: serde_json::Value,
+    pub degraded: bool,
+    pub notes: Vec<String>,
+}
+
+/// Error envelope per ADR-0060 (`{ error: { code, message, ... } }`).
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorEnvelope {
+    pub error: ErrorPayload,
+}
+
+/// Error payload nested under [`ErrorEnvelope::error`].
+///
+/// `next_step` and `candidates` are skipped from JSON when absent/empty
+/// to keep the envelope compact when no structured guidance applies.
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorPayload {
+    pub code: ErrorCode,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_step: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<String>,
+    pub retryable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-EN001: error_code_serializes_screaming_snake_case
+    #[test]
+    fn error_code_serializes_screaming_snake_case() {
+        let pairs = [
+            (ErrorCode::UsageError, r#""USAGE_ERROR""#),
+            (ErrorCode::Software, r#""SOFTWARE""#),
+            (ErrorCode::CantCreat, r#""CANT_CREAT""#),
+            (ErrorCode::IoError, r#""IO_ERROR""#),
+            (ErrorCode::TempFailure, r#""TEMP_FAILURE""#),
+        ];
+        for (code, expected) in pairs {
+            let actual = serde_json::to_string(&code).unwrap();
+            assert_eq!(
+                actual, expected,
+                "code {code:?} should serialize as {expected}"
+            );
+        }
+    }
+
+    // T-EN002: error_code_exit_code_matches_sysexits
+    #[test]
+    fn error_code_exit_code_matches_sysexits() {
+        assert_eq!(ErrorCode::UsageError.exit_code(), 64);
+        assert_eq!(ErrorCode::Software.exit_code(), 70);
+        assert_eq!(ErrorCode::CantCreat.exit_code(), 73);
+        assert_eq!(ErrorCode::IoError.exit_code(), 74);
+        assert_eq!(ErrorCode::TempFailure.exit_code(), 75);
+    }
+
+    // T-EN003: error_payload_omits_optional_next_step_when_none
+    #[test]
+    fn error_payload_omits_optional_next_step_when_none() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: "Missing query".into(),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !json.contains("next_step"),
+            "next_step should be omitted when None, got: {json}"
+        );
+    }
+
+    // T-EN004: error_payload_omits_candidates_when_empty
+    #[test]
+    fn error_payload_omits_candidates_when_empty() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: "invalid".into(),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !json.contains("candidates"),
+            "candidates should be omitted when empty, got: {json}"
+        );
+    }
+
+    // T-EN005: error_payload_serializes_present_optional_fields
+    #[test]
+    fn error_payload_serializes_present_optional_fields() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: "did you mean".into(),
+            next_step: Some("Pass <QUERY>".into()),
+            candidates: vec!["query".into(), "queries".into()],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            json.contains(r#""next_step":"Pass <QUERY>""#),
+            "got: {json}"
+        );
+        assert!(
+            json.contains(r#""candidates":["query","queries"]"#),
+            "got: {json}"
+        );
+    }
+
+    // T-EN006: error_envelope_wraps_payload_under_error_key
+    #[test]
+    fn error_envelope_wraps_payload_under_error_key() {
+        let env = ErrorEnvelope {
+            error: ErrorPayload {
+                code: ErrorCode::UsageError,
+                message: "Missing query".into(),
+                next_step: None,
+                candidates: vec![],
+                retryable: false,
+            },
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.starts_with(r#"{"error":"#),
+            "envelope must start with `{{\"error\":`, got: {json}"
+        );
+        assert!(
+            json.contains(r#""code":"USAGE_ERROR""#),
+            "payload must contain code, got: {json}"
+        );
+    }
+
+    // T-EN007: success_envelope_serializes_required_fields
+    #[test]
+    fn success_envelope_serializes_required_fields() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!({"markdown": "hello"}),
+            degraded: false,
+            notes: vec![],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.contains(r#""data":{"markdown":"hello"}"#),
+            "got: {json}"
+        );
+        assert!(json.contains(r#""degraded":false"#), "got: {json}");
+        assert!(json.contains(r#""notes":[]"#), "got: {json}");
+    }
+
+    // T-EN008: success_envelope_surfaces_degradation_with_notes
+    #[test]
+    fn success_envelope_surfaces_degradation_with_notes() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!(null),
+            degraded: true,
+            notes: vec!["semantic search unavailable, falling back to FTS".into()],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(json.contains(r#""degraded":true"#), "got: {json}");
+        assert!(
+            json.contains(r#""notes":["semantic search unavailable, falling back to FTS"]"#),
+            "got: {json}"
+        );
+    }
+}

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -9,14 +9,15 @@
 //! Phase 2.2 wires them; remove the allow when wiring lands.
 #![allow(dead_code)]
 
+use amici::cli::exit_code::codes;
 use serde::Serialize;
 
 /// JSON-serializable error classification per ADR-0060.
 ///
-/// The variant set covers the 5 sysexits codes `SaeError` currently produces.
-/// `DATA_ERROR (65)` and `NOT_FOUND (66)` are absent because no sae operation
-/// maps to them today; they will be reconsidered when this type lifts into
-/// amici alongside yomu / recall (ADR-0060 Phase 3).
+/// Covers every sysexits code `SaeError` currently produces. `DATA_ERROR (65)`
+/// and `NOT_FOUND (66)` are absent because no sae operation maps to them today;
+/// they will be reconsidered when this type lifts into amici alongside yomu /
+/// recall (ADR-0060 Phase 3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
@@ -28,19 +29,20 @@ pub(crate) enum ErrorCode {
 }
 
 impl ErrorCode {
-    /// sysexits.h exit code mapped per ADR-0060.
+    /// Delegates to `amici::cli::exit_code::codes::*` so the sysexits numbers
+    /// are single-sourced in amici; T-EN002 still pins them as a regression net.
     pub(crate) fn exit_code(self) -> u8 {
         match self {
-            Self::UsageError => 64,
-            Self::Software => 70,
-            Self::CantCreat => 73,
-            Self::IoError => 74,
-            Self::TempFailure => 75,
+            Self::UsageError => codes::USAGE,
+            Self::Software => codes::SOFTWARE,
+            Self::CantCreat => codes::CANT_CREAT,
+            Self::IoError => codes::IO_ERR,
+            Self::TempFailure => codes::TEMP_FAIL,
         }
     }
 }
 
-/// Success envelope per ADR-0060 (`{ data, degraded, notes }`).
+/// Serialized to stdout when `--json` is set (Phase 2.2).
 #[derive(Debug, Serialize)]
 pub(crate) struct SuccessEnvelope {
     pub data: serde_json::Value,
@@ -48,7 +50,8 @@ pub(crate) struct SuccessEnvelope {
     pub notes: Vec<String>,
 }
 
-/// Error envelope per ADR-0060 (`{ error: { code, message, ... } }`).
+/// Serialized to stderr when `--json` is set and the command failed (Phase 2.2).
+/// Wrapping the payload under `error` lets consumers branch on root key.
 #[derive(Debug, Serialize)]
 pub(crate) struct ErrorEnvelope {
     pub error: ErrorPayload,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub(crate) mod chunker;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub(crate) mod envelope;
 pub mod io;
 pub(crate) mod output;
 pub(crate) mod redact;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -277,25 +277,21 @@ pub enum SaeError {
 }
 
 impl SaeError {
-    /// Builds the `Input` variant for "no data for team". Production sites
-    /// MUST use this constructor (not `SaeError::Input(format!(...))`) so
-    /// the canonical prefix `next_step()` keys off stays in sync.
-    pub fn input_no_data_for_team(team: &str) -> Self {
+    /// Production sites MUST use this constructor (not `SaeError::Input(format!(...))`)
+    /// so the canonical prefix `next_step()` keys off stays in sync.
+    pub(crate) fn input_no_data_for_team(team: &str) -> Self {
         Self::Input(format!(
             "No data for team '{team}'. Run `sae harvest {team}` first."
         ))
     }
 
-    /// Builds the `Input` variant for "model not found". Production sites
-    /// MUST use this constructor (not `SaeError::Input(...)`) so the
-    /// canonical prefix `next_step()` keys off stays in sync.
-    pub fn input_model_not_found() -> Self {
+    /// Production sites MUST use this constructor (not `SaeError::Input(...)`)
+    /// so the canonical prefix `next_step()` keys off stays in sync.
+    pub(crate) fn input_model_not_found() -> Self {
         Self::Input("Model not found. Run 'sae model download' first.".to_owned())
     }
 
-    /// Returns the [`ErrorCode`] classification per ADR-0060.
-    ///
-    /// [`CliError::exit_code`] delegates here so the mapping is single-sourced.
+    /// [`CliError::exit_code`] delegates here so the sysexits mapping is single-sourced.
     pub(crate) fn error_code(&self) -> ErrorCode {
         match self {
             Self::Input(_) | Self::Config(_) => ErrorCode::UsageError,
@@ -323,13 +319,11 @@ impl SaeError {
         }
     }
 
-    /// Returns the structured next-step suggestion per ADR-0060.
-    ///
-    /// Phase 2.1 returns template strings (`Run \`sae harvest <team>\``). The
-    /// template form ships now; concrete values (`Run \`sae harvest gaji\``)
-    /// would require parsing the message back, which is fragile, and the
-    /// agent-facing template is unambiguous.
-    pub fn next_step(&self) -> Option<&'static str> {
+    /// Phase 2.1 returns template strings (`Run \`sae harvest <team>\``).
+    /// Concrete values (`Run \`sae harvest gaji\``) would require parsing the
+    /// message back, which is fragile; the agent-facing template is unambiguous.
+    #[allow(dead_code)] // Phase 2.2 wires this through the JSON error renderer.
+    pub(crate) fn next_step(&self) -> Option<&'static str> {
         match self {
             Self::Input(s) if s.starts_with("No data for team ") => {
                 Some("Run `sae harvest <team>` to fetch posts.")
@@ -344,7 +338,11 @@ impl SaeError {
             | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => {
                 Some("Set `ESA_ACCESS_TOKEN=<token>` and retry.")
             }
-            Self::Sync(SyncError::Client(ClientError::MaxRetries(_))) => {
+            // Direct API commands (get/create/update/archive/ship) bubble
+            // ClientError::MaxRetries as Self::Client(_); harvest wraps it
+            // under Sync. Both share the same retry guidance.
+            Self::Client(ClientError::MaxRetries(_))
+            | Self::Sync(SyncError::Client(ClientError::MaxRetries(_))) => {
                 Some("Retry after the rate-limit window resets.")
             }
             Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => {
@@ -364,19 +362,17 @@ impl SaeError {
         }
     }
 
-    /// Returns candidate suggestions for the user (e.g., known team names).
-    ///
     /// Phase 2.1 always returns empty. Phase 2.2 may populate config-derived
     /// candidates for `NoTeamSpecified`/`UnknownTeam` once `Config` is
     /// available at the call site.
-    pub fn candidates(&self) -> Vec<String> {
+    #[allow(dead_code)] // Phase 2.2 wires this through the JSON error renderer.
+    pub(crate) fn candidates(&self) -> Vec<String> {
         Vec::new()
     }
 
-    /// Returns whether retrying the operation can plausibly succeed.
-    ///
     /// Mirrors the `TempFailure` classification from [`Self::error_code`].
-    pub fn retryable(&self) -> bool {
+    #[allow(dead_code)] // Phase 2.2 wires this through the JSON error renderer.
+    pub(crate) fn retryable(&self) -> bool {
         matches!(self.error_code(), ErrorCode::TempFailure)
     }
 }
@@ -648,6 +644,18 @@ mod tests {
         );
     }
 
+    // T-325: next_step_client_max_retries_matches_sync_variant
+    // Direct API commands (get/create/update/archive/ship) surface MaxRetries
+    // as Self::Client; harvest wraps it under Sync. Both must give the same hint.
+    #[test]
+    fn next_step_client_max_retries_matches_sync_variant() {
+        let err = SaeError::Client(ClientError::MaxRetries(5));
+        assert_eq!(
+            err.next_step(),
+            Some("Retry after the rate-limit window resets.")
+        );
+    }
+
     // T-316: next_step_model_download_failed
     #[test]
     fn next_step_model_download_failed() {
@@ -717,9 +725,10 @@ mod tests {
             SaeError::Config(ConfigError::NoTeamSpecified),
             SaeError::Other("internal".into()),
         ] {
-            assert!(
-                err.candidates().is_empty(),
-                "Phase 2.1 returns empty Vec for every variant"
+            assert_eq!(
+                err.candidates(),
+                Vec::<String>::new(),
+                "Phase 2.1 returns empty Vec for {err:?}"
             );
         }
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 
 use amici::cli::embed_with_spinners;
 use amici::cli::env_lookup;
-use amici::cli::exit_code::{CliError, codes};
+use amici::cli::exit_code::CliError;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use amici::model::{ModelDownloadError, download_and_verify_model};
 use rurico::embed::{Artifacts, ModelId, cached_artifacts};
@@ -12,6 +12,7 @@ use rurico::embed::{Artifacts, ModelId, cached_artifacts};
 use crate::client::{ClientError, EsaClient};
 use crate::commands;
 use crate::config::{Config, ConfigError};
+use crate::envelope::ErrorCode;
 use crate::output;
 use crate::storage::{Db, EmbedResult, StorageError, count_unembedded_chunks};
 use crate::sync::{self, SyncError};
@@ -275,6 +276,111 @@ pub enum SaeError {
     Other(String),
 }
 
+impl SaeError {
+    /// Builds the `Input` variant for "no data for team". Production sites
+    /// MUST use this constructor (not `SaeError::Input(format!(...))`) so
+    /// the canonical prefix `next_step()` keys off stays in sync.
+    pub fn input_no_data_for_team(team: &str) -> Self {
+        Self::Input(format!(
+            "No data for team '{team}'. Run `sae harvest {team}` first."
+        ))
+    }
+
+    /// Builds the `Input` variant for "model not found". Production sites
+    /// MUST use this constructor (not `SaeError::Input(...)`) so the
+    /// canonical prefix `next_step()` keys off stays in sync.
+    pub fn input_model_not_found() -> Self {
+        Self::Input("Model not found. Run 'sae model download' first.".to_owned())
+    }
+
+    /// Returns the [`ErrorCode`] classification per ADR-0060.
+    ///
+    /// [`CliError::exit_code`] delegates here so the mapping is single-sourced.
+    pub(crate) fn error_code(&self) -> ErrorCode {
+        match self {
+            Self::Input(_) | Self::Config(_) => ErrorCode::UsageError,
+            Self::Client(ClientError::TokenNotSet)
+            | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => ErrorCode::UsageError,
+            Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => ErrorCode::CantCreat,
+            Self::Json(_)
+            | Self::Other(_)
+            | Self::Client(ClientError::Api(_))
+            | Self::Sync(SyncError::Client(ClientError::Api(_))) => ErrorCode::Software,
+            Self::Client(ClientError::Network(e))
+            | Self::Sync(SyncError::Client(ClientError::Network(e)))
+                if e.is_decode() =>
+            {
+                ErrorCode::Software
+            }
+            Self::Io(_) => ErrorCode::IoError,
+            Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => ErrorCode::TempFailure,
+            Self::ModelDownload(
+                ModelDownloadError::BackendUnavailable | ModelDownloadError::ProbeFailed(_),
+            ) => ErrorCode::Software,
+            // Remaining Client/Sync (Network connect/timeout, MaxRetries) are retry-eligible.
+            // Explicit arms (no wildcard) so future amici variants force a compile-time review.
+            Self::Client(_) | Self::Sync(_) => ErrorCode::TempFailure,
+        }
+    }
+
+    /// Returns the structured next-step suggestion per ADR-0060.
+    ///
+    /// Phase 2.1 returns template strings (`Run \`sae harvest <team>\``). The
+    /// template form ships now; concrete values (`Run \`sae harvest gaji\``)
+    /// would require parsing the message back, which is fragile, and the
+    /// agent-facing template is unambiguous.
+    pub fn next_step(&self) -> Option<&'static str> {
+        match self {
+            Self::Input(s) if s.starts_with("No data for team ") => {
+                Some("Run `sae harvest <team>` to fetch posts.")
+            }
+            Self::Input(s) if s.starts_with("Model not found") => {
+                Some("Run `sae model download` to fetch the embedding model.")
+            }
+            Self::Config(ConfigError::NoTeamSpecified) => {
+                Some("Pass --team <name> or set `SAE_TEAM=<name>`.")
+            }
+            Self::Client(ClientError::TokenNotSet)
+            | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => {
+                Some("Set `ESA_ACCESS_TOKEN=<token>` and retry.")
+            }
+            Self::Sync(SyncError::Client(ClientError::MaxRetries(_))) => {
+                Some("Retry after the rate-limit window resets.")
+            }
+            Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => {
+                Some("Retry `sae model download`; the failure is transient.")
+            }
+            // Explicit catch-all arms per variant. Adding a new SaeError variant
+            // must force a compile-time review (no wildcard).
+            Self::Input(_)
+            | Self::Config(_)
+            | Self::Client(_)
+            | Self::Storage(_)
+            | Self::Sync(_)
+            | Self::Json(_)
+            | Self::Io(_)
+            | Self::ModelDownload(_)
+            | Self::Other(_) => None,
+        }
+    }
+
+    /// Returns candidate suggestions for the user (e.g., known team names).
+    ///
+    /// Phase 2.1 always returns empty. Phase 2.2 may populate config-derived
+    /// candidates for `NoTeamSpecified`/`UnknownTeam` once `Config` is
+    /// available at the call site.
+    pub fn candidates(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Returns whether retrying the operation can plausibly succeed.
+    ///
+    /// Mirrors the `TempFailure` classification from [`Self::error_code`].
+    pub fn retryable(&self) -> bool {
+        matches!(self.error_code(), ErrorCode::TempFailure)
+    }
+}
+
 pub(crate) fn resolve_client<'a>(
     config: &'a Config,
     team: Option<&'a str>,
@@ -287,64 +393,29 @@ pub(crate) fn resolve_client<'a>(
 pub(crate) fn require_db(config: &Config, team: &str) -> Result<Db, SaeError> {
     let db_path = config.team_db_path(team)?;
     if !db_path.exists() {
-        return Err(SaeError::Input(format!(
-            "No data for team '{team}'. Run `sae harvest {team}` first."
-        )));
+        return Err(SaeError::input_no_data_for_team(team));
     }
     Ok(Db::open(&db_path)?)
 }
 
 impl CliError for SaeError {
     fn exit_code(&self) -> ExitCode {
-        match self {
-            Self::Input(_) | Self::Config(_) => ExitCode::from(codes::USAGE),
-            Self::Client(ClientError::TokenNotSet)
-            | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => {
-                ExitCode::from(codes::USAGE)
-            }
-            Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => {
-                ExitCode::from(codes::CANT_CREAT)
-            }
-            // Api(_) is non-retryable (HTTP 4xx after retry_wait returned None).
-            // Json/Other are internal/data shape errors. All map to SOFTWARE (no retry).
-            Self::Json(_)
-            | Self::Other(_)
-            | Self::Client(ClientError::Api(_))
-            | Self::Sync(SyncError::Client(ClientError::Api(_))) => ExitCode::from(codes::SOFTWARE),
-            // reqwest decode failures are schema/payload issues, not transient network.
-            Self::Client(ClientError::Network(e))
-            | Self::Sync(SyncError::Client(ClientError::Network(e)))
-                if e.is_decode() =>
-            {
-                ExitCode::from(codes::SOFTWARE)
-            }
-            Self::Io(_) => ExitCode::from(codes::IO_ERR),
-            // HTTP download failures are transient (retry); backend/verification failures are not.
-            // Explicit arms (no wildcard) so future amici variants force a compile-time review here.
-            Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => {
-                ExitCode::from(codes::TEMP_FAIL)
-            }
-            Self::ModelDownload(
-                ModelDownloadError::BackendUnavailable | ModelDownloadError::ProbeFailed(_),
-            ) => ExitCode::from(codes::SOFTWARE),
-            // Remaining Client/Sync paths (Network connect/timeout, MaxRetries) are retry-eligible.
-            Self::Client(_) | Self::Sync(_) => ExitCode::from(codes::TEMP_FAIL),
-        }
+        ExitCode::from(self.error_code().exit_code())
     }
 }
 
 fn require_embed_model() -> Result<Artifacts, SaeError> {
     match cached_artifacts(ModelId::default()) {
         Ok(Some(p)) => Ok(p),
-        Ok(None) => Err(SaeError::Input(
-            "Model not found. Run 'sae model download' first.".to_owned(),
-        )),
+        Ok(None) => Err(SaeError::input_model_not_found()),
         Err(e) => Err(SaeError::Other(format!("Failed to check model cache: {e}"))),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use amici::cli::exit_code::codes;
+
     use super::*;
 
     fn assert_code(err: &SaeError, expected: u8) {
@@ -511,6 +582,144 @@ mod tests {
             assert!(
                 !sae.rerank_enabled,
                 "SAE_RERANK={value:?} should not enable rerank"
+            );
+        }
+    }
+
+    // T-310: input_no_data_for_team_pins_next_step_harvest_hint
+    #[test]
+    fn input_no_data_for_team_pins_next_step_harvest_hint() {
+        let err = SaeError::input_no_data_for_team("gaji");
+        assert_eq!(
+            err.next_step(),
+            Some("Run `sae harvest <team>` to fetch posts."),
+            "constructor and next_step must stay in sync"
+        );
+    }
+
+    // T-311: input_model_not_found_pins_next_step_download_hint
+    #[test]
+    fn input_model_not_found_pins_next_step_download_hint() {
+        let err = SaeError::input_model_not_found();
+        assert_eq!(
+            err.next_step(),
+            Some("Run `sae model download` to fetch the embedding model."),
+            "constructor and next_step must stay in sync"
+        );
+    }
+
+    // T-312: next_step_config_no_team_specified
+    #[test]
+    fn next_step_config_no_team_specified() {
+        let err = SaeError::Config(ConfigError::NoTeamSpecified);
+        assert_eq!(
+            err.next_step(),
+            Some("Pass --team <name> or set `SAE_TEAM=<name>`.")
+        );
+    }
+
+    // T-313: next_step_client_token_not_set
+    #[test]
+    fn next_step_client_token_not_set() {
+        let err = SaeError::Client(ClientError::TokenNotSet);
+        assert_eq!(
+            err.next_step(),
+            Some("Set `ESA_ACCESS_TOKEN=<token>` and retry.")
+        );
+    }
+
+    // T-314: next_step_sync_client_token_not_set
+    #[test]
+    fn next_step_sync_client_token_not_set() {
+        let err = SaeError::Sync(SyncError::Client(ClientError::TokenNotSet));
+        assert_eq!(
+            err.next_step(),
+            Some("Set `ESA_ACCESS_TOKEN=<token>` and retry.")
+        );
+    }
+
+    // T-315: next_step_sync_client_max_retries
+    #[test]
+    fn next_step_sync_client_max_retries() {
+        let err = SaeError::Sync(SyncError::Client(ClientError::MaxRetries(5)));
+        assert_eq!(
+            err.next_step(),
+            Some("Retry after the rate-limit window resets.")
+        );
+    }
+
+    // T-316: next_step_model_download_failed
+    #[test]
+    fn next_step_model_download_failed() {
+        let err = SaeError::ModelDownload(ModelDownloadError::DownloadFailed("HTTP 503".into()));
+        assert_eq!(
+            err.next_step(),
+            Some("Retry `sae model download`; the failure is transient.")
+        );
+    }
+
+    // T-317: next_step_input_without_recognized_prefix_returns_none
+    #[test]
+    fn next_step_input_without_recognized_prefix_returns_none() {
+        let err = SaeError::Input(
+            "Invalid date '--from 2025-xx-xx': expected YYYY-MM-DD (e.g. 2025-01-01)".into(),
+        );
+        assert_eq!(err.next_step(), None);
+    }
+
+    // T-318: next_step_other_returns_none
+    #[test]
+    fn next_step_other_returns_none() {
+        let err = SaeError::Other("internal".into());
+        assert_eq!(err.next_step(), None);
+    }
+
+    // T-319: next_step_storage_returns_none
+    #[test]
+    fn next_step_storage_returns_none() {
+        let err = SaeError::Storage(StorageError::Open("missing".into()));
+        assert_eq!(err.next_step(), None);
+    }
+
+    // T-320: retryable_true_for_model_download_failed
+    #[test]
+    fn retryable_true_for_model_download_failed() {
+        let err = SaeError::ModelDownload(ModelDownloadError::DownloadFailed("HTTP 503".into()));
+        assert!(err.retryable(), "DownloadFailed must be retryable");
+    }
+
+    // T-321: retryable_true_for_sync_max_retries
+    #[test]
+    fn retryable_true_for_sync_max_retries() {
+        let err = SaeError::Sync(SyncError::Client(ClientError::MaxRetries(5)));
+        assert!(err.retryable(), "MaxRetries must be retryable");
+    }
+
+    // T-322: retryable_false_for_storage
+    #[test]
+    fn retryable_false_for_storage() {
+        let err = SaeError::Storage(StorageError::Open("missing".into()));
+        assert!(!err.retryable(), "Storage must not be retryable");
+    }
+
+    // T-323: retryable_false_for_input
+    #[test]
+    fn retryable_false_for_input() {
+        let err = SaeError::Input("bad".into());
+        assert!(!err.retryable(), "Input must not be retryable");
+    }
+
+    // T-324: candidates_returns_empty_in_phase_2_1
+    #[test]
+    fn candidates_returns_empty_in_phase_2_1() {
+        for err in [
+            SaeError::Input("anything".into()),
+            SaeError::Config(ConfigError::NoTeamSpecified),
+            SaeError::Other("internal".into()),
+        ] {
+            assert!(
+                err.candidates().is_empty(),
+                "Phase 2.1 returns empty Vec for every variant"
             );
         }
     }


### PR DESCRIPTION
## 概要

ADR-0060 Phase 2.1 for #100 ([監査コメント](https://github.com/thkt/sae/issues/100#issuecomment-4425622919))。

**スコープ: 型定義 + アクセサメソッドのみ。本 PR で観測可能な振る舞いは変わらない。** `--json` は依然 envelope 化前の shape を出力する。Phase 2.2 (#3) で `render_json_success` / `render_json_error` が wiring されて初めて agent-readable envelope が出力される。

## 追加内容

### `src/envelope.rs` (新規)

- `ErrorCode` enum (5 variants: `UsageError` / `Software` / `CantCreat` / `IoError` / `TempFailure`)
- `ErrorCode::exit_code()` — `amici::cli::exit_code::codes::*` に delegate (sysexits 単一ソース化)
- `SuccessEnvelope { data, degraded, notes }`
- `ErrorEnvelope { error: ErrorPayload }`
- `ErrorPayload { code, message, next_step, candidates, retryable }` — `next_step` / `candidates` は absent/empty 時 JSON から省略
- `T-EN001` 〜 `T-EN008` (8 unit test)

### `src/tools.rs` 改修

- `impl SaeError`:
  - `input_no_data_for_team(team)` / `input_model_not_found()` — canonical constructor。`next_step()` が prefix match する文字列を pin する目的で、生 `SaeError::Input(format!(...))` を置換
  - `error_code()` — `SaeError` → `ErrorCode` 分類
  - `next_step()` — Phase 2.1 は **template 形式** (`Run \`sae harvest <team>\``) を返す。concrete (`Run \`sae harvest gaji\``) はメッセージ再パースが脆弱なため defer。Direct API commands (get/create/update/archive/ship) の `Client(MaxRetries)` も harvest の `Sync(Client(MaxRetries))` と同じ retry hint を返す
  - `candidates()` — Phase 2.1 は常に空 `Vec`。Phase 2.2 で config 既知 team を populate 予定
  - `retryable()` — `error_code() == TempFailure` の derive
- `impl CliError for SaeError::exit_code()` — `error_code().exit_code()` に delegate (sysexits マッピング単一ソース化)。既存 19 tests pass で振る舞い不変を確認
- 新 unit test 16 本 (T-310 〜 T-325)

## 検証

- `cargo test --lib`: 251 pass (227 → 251, +24)
- `cargo clippy --all-targets`: clean
- 既存 `T-237` 〜 `T-305` の `CliError::exit_code` テストが全 pass → delegation refactor で振る舞い不変

## Phase 計画 (#100)

- ✅ Phase 1: BrokenPipe handling (#110, merged)
- ✅ Phase 2.1: envelope types + `SaeError` 拡張 (本 PR)
- ⬜ Phase 2.2: `--json` wiring + `degraded` / `notes`

Phase 3 (将来) で sae / yomu / recall 3 ツール揃った時点で envelope / `write_output` ヘルパーの amici 昇格を別 issue で起票予定。

## 設計判断メモ

- `pub(crate)` visibility: envelope 型と `SaeError` のアクセサ 4 種 (`error_code` / `next_step` / `candidates` / `retryable`) はすべて `pub(crate)`。Phase 2.2 の renderer は lib.rs 内に置く想定 (main.rs は envelope-free) のため
- `#[allow(dead_code)]`: `envelope` モジュールと `next_step` / `candidates` / `retryable` メソッドに付与。Phase 2.2 wiring 時に外す (各位置にコメント有)
- `next_step()` の per-variant 明示 catch-all: `_ =>` を使わず全 variant を列挙。新規 `SaeError` 追加時に compile error で気付かせるため
- `input_no_data_for_team` / `input_model_not_found` constructor: `SaeError::Input(format!(...))` を直接書くと next_step prefix match と drift する。`T-310` / `T-311` で constructor↔`next_step` round-trip を pin

Refs: #100, ADR-0060