### PR TITLE
feat(envelope): ADR-0060 --json 配線 + degraded / notes (Phase 2.2, #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-05-12
+
+ADR-0060 agent-friendly CLI envelope (Phase 1 + 2.1 + 2.2).
+
+### Added
+
+- Global `--json` flag emits a stable envelope shape on stdout / stderr.
+  - Success: `{"data": ..., "degraded": bool, "notes": [...]}`.
+  - Error: `{"error": {"code": ..., "message": ..., "retryable": bool, ...}}`.
+- `degraded=true` + `notes=["semantic search unavailable, falling back to FTS"]`
+  surface when semantic search silently falls back to FTS because the embedder
+  failed to load. `--no-embed` (intentional FTS) stays `degraded=false`.
+- `dry_run` output is consistently envelope-wrapped regardless of `--json`.
+- `tests/cli_integration.rs` spawns the real binary to verify envelope shape,
+  exit codes, and stream routing end-to-end.
+
+### Changed
+
+- **BREAKING**: every `Sae::*` method now returns
+  `Result<CommandOutput, SaeError>` instead of `Result<String, SaeError>`.
+- `output::*` formatters no longer take `json: bool`; the renderer is decided
+  in `main.rs` from the pre-scanned `--json` flag (so it survives clap parse
+  failures and gates both success and error paths).
+- `--help` / `--version` print the usual text and exit 0 even with `--json`
+  set; the synthetic envelope is reserved for actual usage errors.
+- Stdout writes survive `SIGPIPE` (`| head -0`, `| true`) without panicking
+  (exit `SUCCESS` on `BrokenPipe`).
+- JSON usage error messages carry only the first line of the clap blurb;
+  the usage block and subcommand list no longer pollute `error.message`.
+
+### Internal
+
+- `SaeError::to_error_envelope()` bundles `error_code`, `next_step`,
+  `candidates`, and `retryable` into a single struct for the JSON renderer,
+  avoiding a `tools` ↔ `envelope` import cycle.
+- `ErrorCode::exit_code()` delegates to `amici::cli::exit_code::codes::*`,
+  single-sourcing the sysexits mapping with `T-EN002` as a regression net.
+
+[Unreleased]: https://github.com/thkt/sae/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/thkt/sae/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,7 +2476,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sae"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "amici",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sae"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.95"
 description = "esa semantic search CLI"

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -1,5 +1,6 @@
 use crate::client::UpdatePostParams;
 use crate::config::Config;
+use crate::envelope::CommandOutput;
 use crate::output;
 use crate::tools::{SaeError, resolve_client};
 
@@ -20,8 +21,7 @@ pub(crate) async fn run_archive(
     number: u32,
     team: Option<&str>,
     dry_run: bool,
-    json: bool,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     let (team, client) = resolve_client(config, team)?;
     let post = client.get_post(team, number).await?;
     let new_category = match archive_category(post.category.as_deref()) {
@@ -34,7 +34,7 @@ pub(crate) async fn run_archive(
             }));
         }
         None => {
-            return output::action_result("Already archived", &post, json);
+            return output::action_result("Already archived", &post);
         }
     };
     if dry_run {
@@ -49,7 +49,7 @@ pub(crate) async fn run_archive(
         ..Default::default()
     };
     let post = client.update_post(team, number, &params).await?;
-    output::action_result("Archived", &post, json)
+    output::action_result("Archived", &post)
 }
 
 pub(crate) async fn run_ship(
@@ -57,8 +57,7 @@ pub(crate) async fn run_ship(
     number: u32,
     team: Option<&str>,
     dry_run: bool,
-    json: bool,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     if dry_run {
         return output::dry_run(&serde_json::json!({
             "number": number,
@@ -71,7 +70,7 @@ pub(crate) async fn run_ship(
         ..Default::default()
     };
     let post = client.update_post(team, number, &params).await?;
-    output::action_result("Shipped", &post, json)
+    output::action_result("Shipped", &post)
 }
 
 #[cfg(test)]

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -3,6 +3,7 @@ use std::io::{self, Read};
 
 use crate::client::{CreatePostParams, UpdatePostParams};
 use crate::config::Config;
+use crate::envelope::CommandOutput;
 
 use crate::output;
 use crate::tools::{CreateArgs, SaeError, UpdateArgs, resolve_client};
@@ -12,18 +13,16 @@ pub(crate) async fn run_get(
     number: u32,
     team: Option<&str>,
     with_body: bool,
-    json: bool,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     let (team, client) = resolve_client(config, team)?;
     let post = client.get_post(team, number).await?;
-    output::get(&post, json, with_body)
+    output::get(&post, with_body)
 }
 
 pub(crate) async fn run_create(
     config: &Config,
     args: CreateArgs,
-    json: bool,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     if args.dry_run {
         return output::dry_run(&serde_json::json!({
@@ -43,14 +42,13 @@ pub(crate) async fn run_create(
         wip: args.wip,
     };
     let post = client.create_post(team, &params).await?;
-    output::action_result("Created", &post, json)
+    output::action_result("Created", &post)
 }
 
 pub(crate) async fn run_update(
     config: &Config,
     args: UpdateArgs,
-    json: bool,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     let tags: Option<Vec<String>> = if args.tag.is_empty() {
         None
@@ -75,7 +73,7 @@ pub(crate) async fn run_update(
         ..Default::default()
     };
     let post = client.update_post(team, args.number, &params).await?;
-    output::action_result("Updated", &post, json)
+    output::action_result("Updated", &post)
 }
 
 pub(crate) fn resolve_body(

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -3,6 +3,7 @@ use std::io::{self, IsTerminal, Read};
 use std::process::{Command, Stdio};
 
 use crate::config::Config;
+use crate::envelope::CommandOutput;
 use crate::storage;
 use amici::model::{ModelLoad, record_degraded};
 use rurico::embed::ChunkedEmbedding;
@@ -78,20 +79,22 @@ pub(crate) fn run_search(
     before: Option<&str>,
     no_embed: bool,
     rerank_enabled: bool,
-    json: bool,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     let updated_after = parse_date_arg(after, "after")?;
     let updated_before = parse_date_arg(before, "before")?;
     let team = config.resolve_team(team)?;
     let db = require_db(config, team)?;
-    let embedder = if no_embed {
-        None
+    // `embedder_load_failed` distinguishes intentional FTS (`no_embed`) from
+    // a silent fallback (loader returned `DegradedReason`). Only the latter
+    // populates `degraded=true` + notes in the success envelope.
+    let (embedder, embedder_load_failed) = if no_embed {
+        (None, false)
     } else {
         let result = try_load_embedder();
         if let Err(reason) = result {
             record_degraded(*reason, "search: embedder load");
         }
-        result.as_ref().ok()
+        (result.as_ref().ok(), result.is_err())
     };
     let embed_info = if let Some(emb) = embedder {
         match auto_embed_pending_with(&db, SEARCH_EMBED_BUDGET, |texts| {
@@ -151,7 +154,13 @@ pub(crate) fn run_search(
         tracing::warn!("{w}");
     }
     let semantic = query_embedding.is_some();
-    let output = output::search(&search_output.results, query, json, semantic, embed_info)?;
+    let output = output::search(
+        &search_output.results,
+        query,
+        semantic,
+        embedder_load_failed,
+        embed_info,
+    )?;
     const PREFETCH_TTL_SECS: u64 = 5 * 60;
     if !storage::sync_harvested_within(db.conn(), PREFETCH_TTL_SECS) {
         spawn_background_harvest(team);

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,16 +1,13 @@
 use std::path::Path;
 
 use crate::config::{Config, validate_team_name};
+use crate::envelope::CommandOutput;
 use crate::output;
 use crate::storage;
 use crate::storage::TeamStatus;
 use crate::tools::SaeError;
 
-pub(crate) fn run_status(
-    config: &Config,
-    team: Option<&str>,
-    json: bool,
-) -> Result<String, SaeError> {
+pub(crate) fn run_status(config: &Config, team: Option<&str>) -> Result<CommandOutput, SaeError> {
     let target_teams: Vec<&str> = if let Some(t) = team {
         vec![config.resolve_team(Some(t))?]
     } else {
@@ -28,7 +25,7 @@ pub(crate) fn run_status(
             .collect()
     };
     let statuses = collect_team_statuses(config, &target_teams);
-    output::status(&statuses, json)
+    output::status(&statuses)
 }
 
 fn collect_team_statuses(config: &Config, teams: &[&str]) -> Vec<TeamStatus> {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,13 +1,14 @@
 //! Output envelopes per ADR-0060.
 //!
-//! Phase 2.1 introduces the type definitions and `SaeError` accessor methods
-//! (`error_code`, `next_step`, `candidates`, `retryable`). Phase 2.2 wires the
-//! renderers (`render_json_success` / `render_json_error`) through the `--json`
-//! path. This module exposes no observable behavior change on its own.
+//! `CommandOutput` is the canonical return type for every command runner.
+//! It carries both the default-mode rendering (`markdown`) and a machine
+//! payload (`data`), plus a `degraded` flag and `notes` describing why
+//! the result diverged from the ideal path (e.g. semantic search fell
+//! back to FTS).
 //!
-//! `#![allow(dead_code)]` covers the envelope structs that are unused until
-//! Phase 2.2 wires them; remove the allow when wiring lands.
-#![allow(dead_code)]
+//! `render_json_success` / `render_json_error` map these into the wire
+//! envelopes ([`SuccessEnvelope`] / [`ErrorEnvelope`]) emitted when
+//! `--json` is set.
 
 use amici::cli::exit_code::codes;
 use serde::Serialize;
@@ -42,7 +43,45 @@ impl ErrorCode {
     }
 }
 
-/// Serialized to stdout when `--json` is set (Phase 2.2).
+/// Canonical return type for command runners.
+///
+/// `markdown` is the human-facing rendering surfaced when `--json` is absent.
+/// `data` is the machine payload mirrored into [`SuccessEnvelope::data`] when
+/// `--json` is set. `degraded` + `notes` surface deviations from the ideal
+/// path (e.g. semantic search unavailable → FTS fallback) so agents can react.
+pub struct CommandOutput {
+    pub markdown: String,
+    pub data: serde_json::Value,
+    pub degraded: bool,
+    pub notes: Vec<String>,
+}
+
+impl CommandOutput {
+    pub(crate) fn ok(markdown: String, data: serde_json::Value) -> Self {
+        Self {
+            markdown,
+            data,
+            degraded: false,
+            notes: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_notes(
+        markdown: String,
+        data: serde_json::Value,
+        degraded: bool,
+        notes: Vec<String>,
+    ) -> Self {
+        Self {
+            markdown,
+            data,
+            degraded,
+            notes,
+        }
+    }
+}
+
+/// Serialized to stdout when `--json` is set.
 #[derive(Debug, Serialize)]
 pub(crate) struct SuccessEnvelope {
     pub data: serde_json::Value,
@@ -50,7 +89,7 @@ pub(crate) struct SuccessEnvelope {
     pub notes: Vec<String>,
 }
 
-/// Serialized to stderr when `--json` is set and the command failed (Phase 2.2).
+/// Serialized to stderr when `--json` is set and the command failed.
 /// Wrapping the payload under `error` lets consumers branch on root key.
 #[derive(Debug, Serialize)]
 pub(crate) struct ErrorEnvelope {
@@ -70,6 +109,24 @@ pub(crate) struct ErrorPayload {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub candidates: Vec<String>,
     pub retryable: bool,
+}
+
+/// Serializes a successful result to the wire envelope.
+pub(crate) fn render_json_success(out: &CommandOutput) -> String {
+    let env = SuccessEnvelope {
+        data: out.data.clone(),
+        degraded: out.degraded,
+        notes: out.notes.clone(),
+    };
+    serde_json::to_string(&env).expect("SuccessEnvelope is always serializable")
+}
+
+/// Serializes a prepared error envelope to the wire format.
+///
+/// The caller assembles [`ErrorEnvelope`] via `SaeError::to_error_envelope` so
+/// this module stays free of a `SaeError` import (avoids a tools↔envelope cycle).
+pub(crate) fn render_json_error(env: &ErrorEnvelope) -> String {
+    serde_json::to_string(env).expect("ErrorEnvelope is always serializable")
 }
 
 #[cfg(test)]
@@ -214,5 +271,50 @@ mod tests {
             json.contains(r#""notes":["semantic search unavailable, falling back to FTS"]"#),
             "got: {json}"
         );
+    }
+
+    // T-EN009: render_json_success_serializes_command_output
+    #[test]
+    fn render_json_success_serializes_command_output() {
+        let out = CommandOutput::ok("hello".into(), serde_json::json!({"posts": 5}));
+        let json = render_json_success(&out);
+        assert!(json.contains(r#""data":{"posts":5}"#), "got: {json}");
+        assert!(json.contains(r#""degraded":false"#), "got: {json}");
+        assert!(json.contains(r#""notes":[]"#), "got: {json}");
+    }
+
+    // T-EN010: render_json_success_surfaces_notes
+    #[test]
+    fn render_json_success_surfaces_notes() {
+        let out = CommandOutput::with_notes(
+            "result".into(),
+            serde_json::json!([]),
+            true,
+            vec!["semantic search unavailable, falling back to FTS".into()],
+        );
+        let json = render_json_success(&out);
+        assert!(json.contains(r#""degraded":true"#), "got: {json}");
+        assert!(
+            json.contains(r#""semantic search unavailable, falling back to FTS""#),
+            "got: {json}"
+        );
+    }
+
+    // T-EN011: render_json_error_wraps_payload
+    #[test]
+    fn render_json_error_wraps_payload() {
+        let env = ErrorEnvelope {
+            error: ErrorPayload {
+                code: ErrorCode::TempFailure,
+                message: "rate limited".into(),
+                next_step: Some("Retry after the rate-limit window resets.".into()),
+                candidates: vec![],
+                retryable: true,
+            },
+        };
+        let json = render_json_error(&env);
+        assert!(json.starts_with(r#"{"error":"#), "got: {json}");
+        assert!(json.contains(r#""code":"TEMP_FAILURE""#), "got: {json}");
+        assert!(json.contains(r#""retryable":true"#), "got: {json}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub(crate) mod chunker;
 pub mod client;
 pub mod commands;
 pub mod config;
-pub(crate) mod envelope;
+pub mod envelope;
 pub mod io;
 pub(crate) mod output;
 pub(crate) mod redact;
@@ -10,4 +10,53 @@ pub mod storage;
 pub mod sync;
 pub mod tools;
 
+pub use envelope::CommandOutput;
 pub use tools::{Sae, SaeError};
+
+/// Renders [`CommandOutput`] for stdout. With `json_mode` set, emits the
+/// `SuccessEnvelope`; otherwise the default-mode markdown.
+pub fn render_success(out: &CommandOutput, json_mode: bool) -> String {
+    if json_mode {
+        envelope::render_json_success(out)
+    } else {
+        out.markdown.clone()
+    }
+}
+
+/// Renders a `SaeError` for stderr. JSON mode wraps it via `to_error_envelope`.
+pub fn render_error(err: &SaeError, json_mode: bool) -> String {
+    if json_mode {
+        envelope::render_json_error(&err.to_error_envelope())
+    } else {
+        err.to_string()
+    }
+}
+
+/// Renders a clap parse error. JSON mode emits a synthetic `UsageError` envelope
+/// so agents see the same shape they get for runtime failures.
+///
+/// Only the first non-empty line of the clap message lands in the envelope; the
+/// usage block and subcommand list that follow are noisy for machine consumers.
+pub fn render_parse_error(e: &clap::Error, json_mode: bool) -> String {
+    if json_mode {
+        let raw = e.to_string();
+        let message = raw
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("")
+            .trim()
+            .to_owned();
+        let env = envelope::ErrorEnvelope {
+            error: envelope::ErrorPayload {
+                code: envelope::ErrorCode::UsageError,
+                message,
+                next_step: None,
+                candidates: vec![],
+                retryable: false,
+            },
+        };
+        envelope::render_json_error(&env)
+    } else {
+        e.to_string()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use clap::{Parser, Subcommand};
 use sae::config::Config;
 use sae::io::write_output;
 use sae::tools::{CreateArgs, Sae, SaeError, SearchArgs, UpdateArgs};
+use sae::{CommandOutput, render_error, render_parse_error, render_success};
 
 #[derive(Parser)]
 #[command(name = "sae", about = "esa semantic search CLI")]
@@ -182,38 +183,87 @@ where
     Cli::try_parse_from(args)
 }
 
-async fn run(cli: Cli, config: Config) -> Result<String, SaeError> {
-    let json = cli.json;
+/// Returns true if argv contains `--json`. Scanned before clap parse so the
+/// flag survives clap parse failures and gates the error rendering path.
+fn json_mode_from_argv<I, T>(args: I) -> bool
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<ffi::OsStr>,
+{
+    args.into_iter().any(|a| a.as_ref() == "--json")
+}
+
+async fn run(cli: Cli, config: Config) -> Result<CommandOutput, SaeError> {
     if let Command::Model { command } = cli.command {
         return match command {
-            ModelCommand::Download => Sae::model_download(json),
+            ModelCommand::Download => Sae::model_download(),
         };
     }
     let sae = Sae::new(config);
     match cli.command {
-        Command::Harvest { team, full } => sae.harvest(&team, full, json).await,
-        Command::Search { args } => sae.search(args, json),
+        Command::Harvest { team, full } => sae.harvest(&team, full).await,
+        Command::Search { args } => sae.search(args),
         Command::Get {
             number,
             team,
             with_body,
-        } => sae.get(number, team.as_deref(), with_body, json).await,
-        Command::Create { args } => sae.create(args, json).await,
-        Command::Update { args } => sae.update(args, json).await,
-        Command::Embed { team } => sae.embed(&team, json),
+        } => sae.get(number, team.as_deref(), with_body).await,
+        Command::Create { args } => sae.create(args).await,
+        Command::Update { args } => sae.update(args).await,
+        Command::Embed { team } => sae.embed(&team),
         Command::Archive {
             number,
             team,
             dry_run,
-        } => sae.archive(number, team.as_deref(), dry_run, json).await,
+        } => sae.archive(number, team.as_deref(), dry_run).await,
         Command::Ship {
             number,
             team,
             dry_run,
-        } => sae.ship(number, team.as_deref(), dry_run, json).await,
-        Command::Status { team } => sae.status(team.as_deref(), json),
+        } => sae.ship(number, team.as_deref(), dry_run).await,
+        Command::Status { team } => sae.status(team.as_deref()),
         Command::Model { .. } => unreachable!("handled before Sae::new()"),
     }
+}
+
+fn emit_success(out: &CommandOutput, json_mode: bool) -> ExitCode {
+    let body = render_success(out, json_mode);
+    if body.is_empty() {
+        return ExitCode::SUCCESS;
+    }
+    let mut handle = stdout().lock();
+    match write_output(&mut handle, &body) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+        Err(e) => {
+            exit_error(&format!("write to stdout failed: {e}"));
+            ExitCode::from(codes::IO_ERR)
+        }
+    }
+}
+
+fn emit_error(err: &SaeError, json_mode: bool) {
+    if json_mode {
+        eprintln!("{}", render_error(err, true));
+    } else {
+        exit_error(&err.to_string());
+    }
+}
+
+fn handle_parse_error(e: &clap::Error, json_mode: bool) -> ExitCode {
+    // `--help` / `--version` come back as `Err` with `use_stderr() == false`.
+    // Print them as-is regardless of `--json` so the exit code (SUCCESS) and
+    // the rendered payload (help text) agree.
+    if !e.use_stderr() {
+        let _ = e.print();
+        return ExitCode::SUCCESS;
+    }
+    if json_mode {
+        eprintln!("{}", render_parse_error(e, true));
+    } else {
+        let _ = e.print();
+    }
+    ExitCode::from(codes::USAGE)
 }
 
 #[tokio::main]
@@ -222,42 +272,26 @@ async fn main() -> ExitCode {
 
     init_subscriber("sae=info");
 
+    // Pre-scan argv so `--json` survives a clap parse failure (e.g. missing
+    // required arg). Otherwise the error renderer can't pick the JSON path.
+    let json_mode = json_mode_from_argv(env::args_os().skip(1));
+
     let cli = match parse_cli_args(env::args_os()) {
         Ok(cli) => cli,
-        Err(e) => {
-            let _ = e.print();
-            return ExitCode::from(if e.use_stderr() {
-                codes::USAGE
-            } else {
-                codes::SUCCESS
-            });
-        }
+        Err(e) => return handle_parse_error(&e, json_mode),
     };
     let config = match Config::load() {
         Ok(c) => c,
         Err(e) => {
-            exit_error(&e.to_string());
-            return SaeError::from(e).exit_code();
+            let err: SaeError = e.into();
+            emit_error(&err, json_mode);
+            return err.exit_code();
         }
     };
     match run(cli, config).await {
-        Ok(output) => {
-            if output.is_empty() {
-                ExitCode::SUCCESS
-            } else {
-                let mut handle = stdout().lock();
-                match write_output(&mut handle, &output) {
-                    Ok(()) => ExitCode::SUCCESS,
-                    Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
-                    Err(e) => {
-                        exit_error(&format!("write to stdout failed: {e}"));
-                        ExitCode::from(codes::IO_ERR)
-                    }
-                }
-            }
-        }
+        Ok(out) => emit_success(&out, json_mode),
         Err(e) => {
-            exit_error(&e.to_string());
+            emit_error(&e, json_mode);
             e.exit_code()
         }
     }
@@ -698,5 +732,21 @@ mod tests {
                 "subcommand '{cmd}' should not be rewritten as Search shorthand"
             );
         }
+    }
+
+    // T-300: json_mode_from_argv detects --json flag
+    #[test]
+    fn json_mode_detects_flag_in_argv() {
+        assert!(json_mode_from_argv(["--json", "status"]));
+        assert!(json_mode_from_argv(["status", "--json"]));
+        assert!(json_mode_from_argv(["search", "--json", "query"]));
+    }
+
+    // T-301: json_mode_from_argv returns false when --json absent
+    #[test]
+    fn json_mode_returns_false_when_absent() {
+        assert!(!json_mode_from_argv(["status"]));
+        assert!(!json_mode_from_argv(["search", "query"]));
+        assert!(!json_mode_from_argv::<[&str; 0], _>([]));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,18 +1,13 @@
 use crate::client::EsaPost;
+use crate::envelope::CommandOutput;
 use crate::storage::{EmbedResult, SearchResult, SyncStatus, TeamStatus};
 use crate::sync::HarvestResult;
 use crate::tools::SaeError;
 
-fn format_json<T: serde::Serialize + ?Sized>(val: &T) -> Result<String, SaeError> {
-    Ok(serde_json::to_string(val)?)
-}
-
-pub(crate) fn harvest(result: &HarvestResult, json: bool) -> Result<String, SaeError> {
-    if json {
-        format_json(result)
-    } else {
-        Ok(result.to_string())
-    }
+pub(crate) fn harvest(result: &HarvestResult) -> Result<CommandOutput, SaeError> {
+    let markdown = result.to_string();
+    let data = serde_json::to_value(result)?;
+    Ok(CommandOutput::ok(markdown, data))
 }
 
 pub(crate) struct EmbedInfo {
@@ -24,18 +19,17 @@ pub(crate) struct EmbedInfo {
 pub(crate) fn search(
     results: &[SearchResult],
     query: &str,
-    json: bool,
     semantic: bool,
+    embedder_load_failed: bool,
     embed_info: Option<EmbedInfo>,
-) -> Result<String, SaeError> {
+) -> Result<CommandOutput, SaeError> {
     let search_mode = if semantic { "hybrid" } else { "fts" };
-    if json {
-        format_json(&serde_json::json!({
-            "search_mode": search_mode,
-            "results": results,
-        }))
-    } else if results.is_empty() {
-        Ok(format!("No results for '{query}'"))
+    let data = serde_json::json!({
+        "search_mode": search_mode,
+        "results": results,
+    });
+    let markdown = if results.is_empty() {
+        format!("No results for '{query}'")
     } else {
         let mut lines = Vec::new();
         if !semantic {
@@ -66,24 +60,32 @@ pub(crate) fn search(
                 ));
             }
         }
-        Ok(lines.join("\n"))
+        lines.join("\n")
+    };
+    if embedder_load_failed {
+        Ok(CommandOutput::with_notes(
+            markdown,
+            data,
+            true,
+            vec!["semantic search unavailable, falling back to FTS".to_owned()],
+        ))
+    } else {
+        Ok(CommandOutput::ok(markdown, data))
     }
 }
 
-pub(crate) fn get(post: &EsaPost, json: bool, with_body: bool) -> Result<String, SaeError> {
-    if json {
-        if with_body {
-            format_json(post)
-        } else {
-            let mut val = serde_json::to_value(post)?;
-            if let Some(obj) = val.as_object_mut() {
-                obj.remove("body_md");
-            }
-            format_json(&val)
-        }
+pub(crate) fn get(post: &EsaPost, with_body: bool) -> Result<CommandOutput, SaeError> {
+    let markdown = format_post_frontmatter(post);
+    let data = if with_body {
+        serde_json::to_value(post)?
     } else {
-        Ok(format_post_frontmatter(post))
-    }
+        let mut val = serde_json::to_value(post)?;
+        if let Some(obj) = val.as_object_mut() {
+            obj.remove("body_md");
+        }
+        val
+    };
+    Ok(CommandOutput::ok(markdown, data))
 }
 
 fn format_post_frontmatter(post: &EsaPost) -> String {
@@ -122,91 +124,81 @@ fn format_post_frontmatter(post: &EsaPost) -> String {
     lines.join("\n")
 }
 
-pub(crate) fn action_result(action: &str, post: &EsaPost, json: bool) -> Result<String, SaeError> {
-    if json {
-        format_json(post)
-    } else {
-        Ok(format!(
-            "{action}: {} (#{}) {}",
-            post.name, post.number, post.url
-        ))
-    }
+pub(crate) fn action_result(action: &str, post: &EsaPost) -> Result<CommandOutput, SaeError> {
+    let markdown = format!("{action}: {} (#{}) {}", post.name, post.number, post.url);
+    let data = serde_json::to_value(post)?;
+    Ok(CommandOutput::ok(markdown, data))
 }
 
-pub(crate) fn embed(
-    result: &EmbedResult,
-    total_chunks: u32,
-    json: bool,
-) -> Result<String, SaeError> {
-    if json {
-        format_json(result)
-    } else if result.chunks_embedded == 0 {
+pub(crate) fn embed(result: &EmbedResult, total_chunks: u32) -> Result<CommandOutput, SaeError> {
+    let markdown = if result.chunks_embedded == 0 {
         if total_chunks == 0 {
-            Ok("Nothing to embed".to_owned())
+            "Nothing to embed".to_owned()
         } else {
-            Ok(format!("All {total_chunks} chunks already embedded"))
+            format!("All {total_chunks} chunks already embedded")
         }
     } else {
-        Ok(format!("Embedded {} chunks", result.chunks_embedded))
-    }
+        format!("Embedded {} chunks", result.chunks_embedded)
+    };
+    let data = serde_json::to_value(result)?;
+    Ok(CommandOutput::ok(markdown, data))
 }
 
-/// Always emits JSON regardless of `--json` flag. Dry-run output is for machine consumption.
-pub(crate) fn dry_run(payload: &serde_json::Value) -> Result<String, SaeError> {
-    format_json(payload)
+/// Dry-run is always envelope-wrapped (consistent shape regardless of `--json`).
+/// `markdown` carries the pretty-printed payload for default-mode visibility.
+pub(crate) fn dry_run(payload: &serde_json::Value) -> Result<CommandOutput, SaeError> {
+    let markdown = serde_json::to_string_pretty(payload)?;
+    Ok(CommandOutput::ok(markdown, payload.clone()))
 }
 
-pub(crate) fn model_download(json: bool) -> Result<String, SaeError> {
-    if json {
-        format_json(&serde_json::json!({"status": "ok"}))
-    } else {
-        Ok("Model downloaded and verified".to_owned())
-    }
+pub(crate) fn model_download() -> Result<CommandOutput, SaeError> {
+    Ok(CommandOutput::ok(
+        "Model downloaded and verified".to_owned(),
+        serde_json::json!({"status": "ok"}),
+    ))
 }
 
-pub(crate) fn status(statuses: &[TeamStatus], json: bool) -> Result<String, SaeError> {
-    if json {
-        format_json(statuses)
-    } else {
-        let mut lines = Vec::new();
-        for ts in statuses {
-            lines.push(format!("--- {} ---", ts.team));
-            match ts.status {
-                SyncStatus::Error => {
+pub(crate) fn status(statuses: &[TeamStatus]) -> Result<CommandOutput, SaeError> {
+    let mut lines = Vec::new();
+    for ts in statuses {
+        lines.push(format!("--- {} ---", ts.team));
+        match ts.status {
+            SyncStatus::Error => {
+                lines.push(format!(
+                    "  Error: {}",
+                    ts.error.as_deref().unwrap_or("unknown error")
+                ));
+            }
+            SyncStatus::NotSynced => {
+                if let Some(ref path) = ts.db_path {
+                    lines.push(format!("  Not yet synced (no DB at {path})"));
+                } else {
+                    lines.push("  Not yet synced".to_owned());
+                }
+            }
+            SyncStatus::Synced => {
+                lines.push(format!("  Posts: {}", ts.posts));
+                if ts.pending_embed > 0 {
                     lines.push(format!(
-                        "  Error: {}",
-                        ts.error.as_deref().unwrap_or("unknown error")
+                        "  Pending embed: {} chunks (run 'sae embed {}' to index)",
+                        ts.pending_embed, ts.team
                     ));
                 }
-                SyncStatus::NotSynced => {
-                    if let Some(ref path) = ts.db_path {
-                        lines.push(format!("  Not yet synced (no DB at {path})"));
-                    } else {
-                        lines.push("  Not yet synced".to_owned());
-                    }
-                }
-                SyncStatus::Synced => {
-                    lines.push(format!("  Posts: {}", ts.posts));
-                    if ts.pending_embed > 0 {
-                        lines.push(format!(
-                            "  Pending embed: {} chunks (run 'sae embed {}' to index)",
-                            ts.pending_embed, ts.team
-                        ));
-                    }
-                    if let Some(ref s) = ts.sync_state {
-                        lines.push(format!(
-                            "  Last sync: {} (total: {}, local: {})",
-                            s.updated_at, s.total_count, s.local_count
-                        ));
-                        if let Some(pg) = s.last_page {
-                            lines.push(format!("  Checkpoint: page {pg} (interrupted)"));
-                        }
+                if let Some(ref s) = ts.sync_state {
+                    lines.push(format!(
+                        "  Last sync: {} (total: {}, local: {})",
+                        s.updated_at, s.total_count, s.local_count
+                    ));
+                    if let Some(pg) = s.last_page {
+                        lines.push(format!("  Checkpoint: page {pg} (interrupted)"));
                     }
                 }
             }
         }
-        Ok(lines.join("\n"))
     }
+    let markdown = lines.join("\n");
+    let data = serde_json::to_value(statuses)?;
+    Ok(CommandOutput::ok(markdown, data))
 }
 
 #[cfg(test)]
@@ -256,55 +248,57 @@ mod tests {
         }
     }
 
-    // T-079: status human-readable empty list → empty string
+    // T-079: status human-readable empty list → empty markdown
     #[test]
     fn status_human_empty_returns_empty_string() {
-        let out = status(&[], false).unwrap();
-        assert!(out.is_empty(), "empty list should produce empty output");
+        let out = status(&[]).unwrap();
+        assert!(
+            out.markdown.is_empty(),
+            "empty list should produce empty markdown"
+        );
     }
 
     // T-080: status human-readable synced team → expected lines
     #[test]
     fn status_human_synced_contains_expected_lines() {
-        let out = status(&[make_synced("team-a", 10)], false).unwrap();
-        assert!(out.contains("--- team-a ---"));
-        assert!(out.contains("Posts: 10"));
-        assert!(out.contains("Last sync: 2025-01-01 00:00:00"));
+        let out = status(&[make_synced("team-a", 10)]).unwrap();
+        assert!(out.markdown.contains("--- team-a ---"));
+        assert!(out.markdown.contains("Posts: 10"));
+        assert!(out.markdown.contains("Last sync: 2025-01-01 00:00:00"));
     }
 
     // T-081: status human-readable not-synced team → expected lines
     #[test]
     fn status_human_not_synced_contains_expected_lines() {
-        let out = status(&[make_not_synced("team-b")], false).unwrap();
-        assert!(out.contains("--- team-b ---"));
-        assert!(out.contains("Not yet synced"));
+        let out = status(&[make_not_synced("team-b")]).unwrap();
+        assert!(out.markdown.contains("--- team-b ---"));
+        assert!(out.markdown.contains("Not yet synced"));
     }
 
-    // T-082: embed json → chunks_embedded field
+    // T-082: embed json data carries chunks_embedded
     #[test]
     fn embed_json_contains_chunks_embedded() {
         let result = EmbedResult {
             chunks_embedded: 42,
         };
-        let out = embed(&result, 42, true).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["chunks_embedded"], 42);
+        let out = embed(&result, 42).unwrap();
+        assert_eq!(out.data["chunks_embedded"], 42);
     }
 
     // T-083: embed human-readable with done=0 → "Nothing to embed"
     #[test]
     fn embed_human_zero_done_returns_nothing_to_embed() {
         let result = EmbedResult { chunks_embedded: 0 };
-        let out = embed(&result, 0, false).unwrap();
-        assert_eq!(out, "Nothing to embed");
+        let out = embed(&result, 0).unwrap();
+        assert_eq!(out.markdown, "Nothing to embed");
     }
 
     // T-084: embed human-readable chunks > 0 → "Embedded N chunks"
     #[test]
     fn embed_human_nonzero_returns_embedded_count() {
         let result = EmbedResult { chunks_embedded: 5 };
-        let out = embed(&result, 5, false).unwrap();
-        assert_eq!(out, "Embedded 5 chunks");
+        let out = embed(&result, 5).unwrap();
+        assert_eq!(out.markdown, "Embedded 5 chunks");
     }
 
     // T-085: status error variant — error field displayed
@@ -340,21 +334,19 @@ mod tests {
         assert_eq!(v["sync_state"]["last_page"], 3);
     }
 
-    // T-087: search json includes search_mode hybrid
+    // T-087: search data includes search_mode hybrid
     #[test]
     fn search_json_hybrid_includes_search_mode() {
-        let out = search(&[], "test", true, true, None).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["search_mode"], "hybrid");
-        assert!(v["results"].is_array());
+        let out = search(&[], "test", true, false, None).unwrap();
+        assert_eq!(out.data["search_mode"], "hybrid");
+        assert!(out.data["results"].is_array());
     }
 
-    // T-088: search json includes search_mode fts
+    // T-088: search data includes search_mode fts
     #[test]
     fn search_json_fts_includes_search_mode() {
-        let out = search(&[], "test", true, false, None).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["search_mode"], "fts");
+        let out = search(&[], "test", false, false, None).unwrap();
+        assert_eq!(out.data["search_mode"], "fts");
     }
 
     // T-089: search human fts fallback shows notice
@@ -370,7 +362,7 @@ mod tests {
             match_source: MatchSource::Fts,
         }];
         let out = search(&results, "q", false, false, None).unwrap();
-        assert!(out.contains("semantic search unavailable"));
+        assert!(out.markdown.contains("semantic search unavailable"));
     }
 
     // T-090: search human hybrid does not show fallback notice
@@ -385,7 +377,27 @@ mod tests {
             score: 0.5,
             match_source: MatchSource::Fts,
         }];
-        let out = search(&results, "q", false, true, None).unwrap();
-        assert!(!out.contains("semantic search unavailable"));
+        let out = search(&results, "q", true, false, None).unwrap();
+        assert!(!out.markdown.contains("semantic search unavailable"));
+    }
+
+    // T-260: search degraded fallback populates notes
+    #[test]
+    fn search_degraded_fallback_populates_notes() {
+        let out = search(&[], "q", false, true, None).unwrap();
+        assert!(
+            out.degraded,
+            "embedder_load_failed=true should set degraded"
+        );
+        assert_eq!(out.notes.len(), 1);
+        assert!(out.notes[0].contains("semantic search unavailable"));
+    }
+
+    // T-261: search no-embed (FTS without load failure) leaves notes empty
+    #[test]
+    fn search_no_embed_does_not_degrade() {
+        let out = search(&[], "q", false, false, None).unwrap();
+        assert!(!out.degraded);
+        assert!(out.notes.is_empty());
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -12,7 +12,7 @@ use rurico::embed::{Artifacts, ModelId, cached_artifacts};
 use crate::client::{ClientError, EsaClient};
 use crate::commands;
 use crate::config::{Config, ConfigError};
-use crate::envelope::ErrorCode;
+use crate::envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload};
 use crate::output;
 use crate::storage::{Db, EmbedResult, StorageError, count_unembedded_chunks};
 use crate::sync::{self, SyncError};
@@ -117,15 +117,15 @@ impl Sae {
         &self.config
     }
 
-    pub async fn harvest(&self, team: &str, full: bool, json: bool) -> Result<String, SaeError> {
+    pub async fn harvest(&self, team: &str, full: bool) -> Result<CommandOutput, SaeError> {
         let (team, client) = resolve_client(&self.config, Some(team))?;
         let db_path = self.config.team_db_path(team)?;
         let db = Db::open(&db_path)?;
         let result = sync::harvest(&client, &db, team, full).await?;
-        output::harvest(&result, json)
+        output::harvest(&result)
     }
 
-    pub fn embed(&self, team: &str, json: bool) -> Result<String, SaeError> {
+    pub fn embed(&self, team: &str) -> Result<CommandOutput, SaeError> {
         let team = self.config.resolve_team(Some(team))?;
         let db = require_db(&self.config, team)?;
         let paths = require_embed_model()?;
@@ -182,16 +182,15 @@ impl Sae {
                         chunks_embedded: all.added,
                     },
                     all.total_chunks,
-                    json,
                 )
             }
-            None => output::embed(&EmbedResult { chunks_embedded: 0 }, 0, json),
+            None => output::embed(&EmbedResult { chunks_embedded: 0 }, 0),
         }
     }
 
-    pub fn model_download(json: bool) -> Result<String, SaeError> {
+    pub fn model_download() -> Result<CommandOutput, SaeError> {
         download_and_verify_model()?;
-        output::model_download(json)
+        output::model_download()
     }
 
     pub async fn get(
@@ -199,17 +198,16 @@ impl Sae {
         number: u32,
         team: Option<&str>,
         with_body: bool,
-        json: bool,
-    ) -> Result<String, SaeError> {
-        commands::post::run_get(&self.config, number, team, with_body, json).await
+    ) -> Result<CommandOutput, SaeError> {
+        commands::post::run_get(&self.config, number, team, with_body).await
     }
 
-    pub async fn create(&self, args: CreateArgs, json: bool) -> Result<String, SaeError> {
-        commands::post::run_create(&self.config, args, json).await
+    pub async fn create(&self, args: CreateArgs) -> Result<CommandOutput, SaeError> {
+        commands::post::run_create(&self.config, args).await
     }
 
-    pub async fn update(&self, args: UpdateArgs, json: bool) -> Result<String, SaeError> {
-        commands::post::run_update(&self.config, args, json).await
+    pub async fn update(&self, args: UpdateArgs) -> Result<CommandOutput, SaeError> {
+        commands::post::run_update(&self.config, args).await
     }
 
     pub async fn archive(
@@ -217,9 +215,8 @@ impl Sae {
         number: u32,
         team: Option<&str>,
         dry_run: bool,
-        json: bool,
-    ) -> Result<String, SaeError> {
-        commands::archive::run_archive(&self.config, number, team, dry_run, json).await
+    ) -> Result<CommandOutput, SaeError> {
+        commands::archive::run_archive(&self.config, number, team, dry_run).await
     }
 
     pub async fn ship(
@@ -227,12 +224,11 @@ impl Sae {
         number: u32,
         team: Option<&str>,
         dry_run: bool,
-        json: bool,
-    ) -> Result<String, SaeError> {
-        commands::archive::run_ship(&self.config, number, team, dry_run, json).await
+    ) -> Result<CommandOutput, SaeError> {
+        commands::archive::run_ship(&self.config, number, team, dry_run).await
     }
 
-    pub fn search(&self, args: SearchArgs, json: bool) -> Result<String, SaeError> {
+    pub fn search(&self, args: SearchArgs) -> Result<CommandOutput, SaeError> {
         let query = resolve_search_query(args.query)?;
         commands::search::run_search(
             &self.config,
@@ -243,12 +239,11 @@ impl Sae {
             args.before.as_deref(),
             args.no_embed,
             self.rerank_enabled,
-            json,
         )
     }
 
-    pub fn status(&self, team: Option<&str>, json: bool) -> Result<String, SaeError> {
-        commands::status::run_status(&self.config, team, json)
+    pub fn status(&self, team: Option<&str>) -> Result<CommandOutput, SaeError> {
+        commands::status::run_status(&self.config, team)
     }
 }
 
@@ -319,10 +314,9 @@ impl SaeError {
         }
     }
 
-    /// Phase 2.1 returns template strings (`Run \`sae harvest <team>\``).
+    /// Returns template strings (`Run \`sae harvest <team>\``).
     /// Concrete values (`Run \`sae harvest gaji\``) would require parsing the
     /// message back, which is fragile; the agent-facing template is unambiguous.
-    #[allow(dead_code)] // Phase 2.2 wires this through the JSON error renderer.
     pub(crate) fn next_step(&self) -> Option<&'static str> {
         match self {
             Self::Input(s) if s.starts_with("No data for team ") => {
@@ -362,18 +356,32 @@ impl SaeError {
         }
     }
 
-    /// Phase 2.1 always returns empty. Phase 2.2 may populate config-derived
-    /// candidates for `NoTeamSpecified`/`UnknownTeam` once `Config` is
-    /// available at the call site.
-    #[allow(dead_code)] // Phase 2.2 wires this through the JSON error renderer.
+    /// Always returns empty for now. Future revisions may populate
+    /// config-derived candidates for `NoTeamSpecified`/`UnknownTeam` once
+    /// `Config` is threaded into the call site.
     pub(crate) fn candidates(&self) -> Vec<String> {
         Vec::new()
     }
 
     /// Mirrors the `TempFailure` classification from [`Self::error_code`].
-    #[allow(dead_code)] // Phase 2.2 wires this through the JSON error renderer.
     pub(crate) fn retryable(&self) -> bool {
         matches!(self.error_code(), ErrorCode::TempFailure)
+    }
+
+    /// Bundles [`Self::error_code`], [`Self::next_step`], [`Self::candidates`],
+    /// [`Self::retryable`], and the formatted message into an [`ErrorEnvelope`]
+    /// for `--json` rendering. Kept here so the envelope module avoids a
+    /// dependency on `SaeError` (which would form a cycle).
+    pub(crate) fn to_error_envelope(&self) -> ErrorEnvelope {
+        ErrorEnvelope {
+            error: ErrorPayload {
+                code: self.error_code(),
+                message: self.to_string(),
+                next_step: self.next_step().map(String::from),
+                candidates: self.candidates(),
+                retryable: self.retryable(),
+            },
+        }
     }
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,120 @@
+//! End-to-end checks for the `--json` envelope shape.
+//!
+//! Spawns the real binary so the envelope rendering, exit code, and stream
+//! routing (stdout vs stderr) are all exercised together.
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::tempdir;
+
+/// Path to the binary cargo just built for this test run.
+fn sae_bin() -> PathBuf {
+    let mut path = env::current_exe().unwrap();
+    // current_exe → target/<profile>/deps/cli_integration-<hash>
+    path.pop(); // → target/<profile>/deps
+    path.pop(); // → target/<profile>
+    path.push(format!("sae{}", env::consts::EXE_SUFFIX));
+    path
+}
+
+/// Builds a `Command` with isolated HOME/XDG dirs so the binary sees an
+/// empty config (no leakage from the developer's real `~/.config/sae`).
+fn sae_command(home: &Path) -> Command {
+    let mut cmd = Command::new(sae_bin());
+    cmd.env_clear()
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"))
+        .env("PATH", env::var_os("PATH").unwrap_or_default());
+    cmd
+}
+
+// T-CI001: `sae --json` (missing subcommand) → JSON UsageError envelope on stderr
+#[test]
+fn missing_subcommand_with_json_emits_usage_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(!output.status.success(), "should exit non-zero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env: serde_json::Value = stderr
+        .lines()
+        .find_map(|line| serde_json::from_str(line).ok())
+        .unwrap_or_else(|| panic!("no JSON line on stderr; got: {stderr}"));
+    assert_eq!(env["error"]["code"], "USAGE_ERROR");
+    assert!(
+        env["error"]["message"].is_string(),
+        "error.message must be present"
+    );
+}
+
+// T-CI002: `sae --json status` (empty config) → SuccessEnvelope on stdout
+#[test]
+fn status_with_json_emits_success_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "status"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(
+        output.status.success(),
+        "status with empty config should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let env: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("stdout not JSON: {e}; {stdout}"));
+    assert!(env.get("data").is_some(), "envelope must have `data`");
+    assert!(
+        env.get("degraded").is_some(),
+        "envelope must have `degraded`"
+    );
+    assert!(env.get("notes").is_some(), "envelope must have `notes`");
+    assert_eq!(env["degraded"], false);
+    assert_eq!(env["notes"], serde_json::json!([]));
+}
+
+// T-CI003: default mode (no --json) emits markdown, not JSON
+#[test]
+fn status_without_json_emits_markdown() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["status"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&stdout).is_err() || stdout.trim().is_empty(),
+        "default mode should not emit JSON; got: {stdout}"
+    );
+}
+
+// T-CI004: `sae --json --help` prints help on stdout, exits SUCCESS
+// (clap returns Err with use_stderr()=false; --json must NOT override this)
+#[test]
+fn help_with_json_exits_success_with_help_text() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "--help"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(
+        output.status.success(),
+        "--help should exit 0 even with --json; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Usage:"),
+        "help text should land on stdout; got: {stdout}"
+    );
+}


### PR DESCRIPTION
## 概要

ADR-0060 Phase 2.2 for #100。`--json` を全 command runner に配線し、`SuccessEnvelope` / `ErrorEnvelope` を agent-readable shape で出力する。

**スコープ: `--json` の振る舞いが変わる。** 既存の Phase 1 (#110) と Phase 2.1 (#111) で用意したパーツを wiring する仕上げ commit。SemVer 0.x で `Sae::*` の戻り値が `Result<String, SaeError>` → `Result<CommandOutput, SaeError>` に変わるため、本 PR で `0.2.0` を切る。

## 追加・変更内容

### `src/envelope.rs` 拡張

- `CommandOutput { markdown, data, degraded, notes }` — 全 command runner の canonical 戻り値型 (`pub`)
- `render_json_success(&CommandOutput) -> String` — `SuccessEnvelope` serialize
- `render_json_error(&ErrorEnvelope) -> String` — `ErrorEnvelope` serialize
- `#![allow(dead_code)]` 全削除
- 新 unit test 3 本 (`T-EN009` 〜 `T-EN011`)

### `src/tools.rs` 改修

- `Sae::*` 10 メソッドが `Result<CommandOutput, SaeError>` を返す
- `SaeError::to_error_envelope()` — `error_code` / `next_step` / `candidates` / `retryable` を `ErrorEnvelope` にバンドル。`tools` ↔ `envelope` の循環依存を回避するため `tools` 側に配置
- `next_step()` / `candidates()` / `retryable()` の `#[allow(dead_code)]` 剥がし

### `src/output.rs` 改修

- 8 formatter (`harvest` / `search` / `get` / `action_result` / `embed` / `dry_run` / `model_download` / `status`) が `json: bool` 引数を廃止、`CommandOutput` を返却
- `search` formatter に `embedder_load_failed: bool` 引数を追加 — `--no-embed` (意図的 FTS) と loader 失敗 (degraded fallback) を区別し、後者のみ `degraded=true` + `notes=["semantic search unavailable, falling back to FTS"]` を populate
- `dry_run` は `--json` 関係なく常に envelope-wrap (markdown は pretty-printed JSON)
- 新 unit test 2 本 (`T-260` / `T-261`)

### `src/commands/*.rs` 改修

- `run_get` / `run_create` / `run_update` / `run_archive` / `run_ship` / `run_search` / `run_status` を `CommandOutput` 返却に migrate
- `run_search` で `embedder_load_failed` を `try_load_embedder()` の `Err` 起源で計算し output に thread

### `src/main.rs` 改修

- `json_mode_from_argv` — `env::args_os()` を pre-scan して `--json` を検出。clap parse 失敗を超えて生き残る
- `emit_success` / `emit_error` / `handle_parse_error` helper
- `--help` / `--version` (`use_stderr() == false`) は `--json` を無視して exit `SUCCESS`。exit code と payload が矛盾しないよう gate
- `T-300` / `T-301` で `json_mode_from_argv` の正常 / 不在ケースを pin

### `src/lib.rs` 改修

- `pub render_success` / `render_error` / `render_parse_error` — `main.rs` から呼ぶ薄い lib-level API
- JSON 化される clap error は **1 行目のみ** を `error.message` に入れる (full clap blurb はノイズ)

### `tests/cli_integration.rs` (新規)

- `T-CI001`: `sae --json` (subcommand 欠落) → stderr に `USAGE_ERROR` envelope
- `T-CI002`: `sae --json status` (empty config) → stdout に `SuccessEnvelope`
- `T-CI003`: default mode は markdown を出力
- `T-CI004`: `sae --json --help` → stdout に help text、exit 0 (help / `--json` collision の regression net)
- 実機 `sae` バイナリを `std::process::Command` で spawn

### `CHANGELOG.md` (新規)

- Keep a Changelog 1.1.0 + SemVer 2.0.0 準拠
- 0.2.0 として Phase 1 + 2.1 + 2.2 を統合記載

### `Cargo.toml` / `Cargo.lock`

- `0.1.0` → `0.2.0` (`Sae::*` 戻り値型変更は SemVer 0.x で breaking)
- `Cargo.lock` を `cargo update -p sae` で再生成 (`cargo check --locked` 用)

## 検証

- `cargo test`: 298 pass (256 lib + 35 bin + 4 cli_integration + 3 sync_state)
- `cargo clippy --all-targets -- -D warnings`: green
- `cargo check --locked`: green
- 実機 manual:
  - `sae --json status` → `{"data":[],"degraded":false,"notes":[]}`
  - `sae --json` → `{"error":{"code":"USAGE_ERROR","message":"error: 'sae' requires a subcommand but one was not provided","retryable":false}}`
  - `sae --json --help` → help text + exit 0

## Phase 計画 (#100)

- ✅ Phase 1: BrokenPipe handling (#110)
- ✅ Phase 2.1: envelope types + `SaeError` 拡張 (#111)
- ✅ Phase 2.2: `--json` 配線 + `degraded` / `notes` (本 PR)
- ⬜ Phase 3 (将来): sae / yomu / recall 3 ツール揃った時点で envelope / `write_output` ヘルパーの amici 昇格を別 issue で起票

## 設計判断メモ

- **`--json` pre-scan**: `parse_cli_args` 内で完結させると clap parse 失敗時に flag を失う。argv の `env::args_os()` を main 階層で直接スキャンし、clap parse 前に `json_mode` を確定
- **`embedder_load_failed` を別フラグで thread**: `!semantic` だけでは `--no-embed` (ユーザー意図) と loader 失敗 (degraded) を区別できない。`record_degraded` 呼び出し位置で立てた bool を `output::search` に渡し、後者のみ `degraded=true`
- **`dry_run` 常時 envelope-wrap**: 同コマンドで `--json` 有無により 2 shape を持つのは不整合。0.2.0 break のタイミングで統一
- **`CommandOutput` field 名 `markdown`**: Phase 3 で amici 昇格時の cross-crate rename を避けるため。doc コメントで "default-mode rendering" と明記
- **`--help` / `--version` の `--json` 無視**: `use_stderr() == false` の clap Err を USAGE_ERROR envelope 化すると exit code (`SUCCESS`) と payload (`USAGE_ERROR`) が矛盾し agent が混乱。`!use_stderr()` 分岐を先頭に置く
- **clap message 1 行目のみ**: `error.message` に full clap blurb (usage line + subcommand list + "try --help") は noisy。1 行目だけ抽出
- **`SaeError::to_error_envelope` を `tools` 側に**: `envelope` が `SaeError` を import すると `tools` ↔ `envelope` が cyclic。`tools::SaeError::to_error_envelope` で `ErrorEnvelope` を組み立てて `envelope::render_json_error` に渡す形に分離
- **`pub(crate)` → `pub`**: `CommandOutput` のみ `pub` (`Sae::*` 戻り値型のため不可避)。`SuccessEnvelope` / `ErrorEnvelope` / `ErrorCode` 等は `pub(crate)` を維持し lib-level helper (`render_success` / `render_error` / `render_parse_error`) 経由でのみ公開

Refs: #100, ADR-0060