### PR TITLE
feat(local-db): mutation コマンドに local DB write-through を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -1,7 +1,9 @@
-use crate::client::UpdatePostParams;
+use crate::client::{EsaClient, UpdatePostParams};
 use crate::config::Config;
 use crate::envelope::CommandOutput;
 use crate::output;
+use crate::storage::Db;
+use crate::sync;
 use crate::tools::{SaeError, resolve_client};
 
 pub(crate) fn archive_category(current: Option<&str>) -> Option<String> {
@@ -18,11 +20,22 @@ pub(crate) fn archive_category(current: Option<&str>) -> Option<String> {
 
 pub(crate) async fn run_archive(
     config: &Config,
+    db: Option<&Db>,
     number: u32,
     team: Option<&str>,
     dry_run: bool,
 ) -> Result<CommandOutput, SaeError> {
     let (team, client) = resolve_client(config, team)?;
+    archive_via_client(team, &client, db, number, dry_run).await
+}
+
+pub(crate) async fn archive_via_client(
+    team: &str,
+    client: &EsaClient,
+    db: Option<&Db>,
+    number: u32,
+    dry_run: bool,
+) -> Result<CommandOutput, SaeError> {
     let post = client.get_post(team, number).await?;
     let new_category = match archive_category(post.category.as_deref()) {
         Some(c) => c,
@@ -49,11 +62,13 @@ pub(crate) async fn run_archive(
         ..Default::default()
     };
     let post = client.update_post(team, number, &params).await?;
+    sync::try_upsert_post_locally(db, &post);
     output::action_result("Archived", &post)
 }
 
 pub(crate) async fn run_ship(
     config: &Config,
+    db: Option<&Db>,
     number: u32,
     team: Option<&str>,
     dry_run: bool,
@@ -65,11 +80,21 @@ pub(crate) async fn run_ship(
         }));
     }
     let (team, client) = resolve_client(config, team)?;
+    ship_via_client(team, &client, db, number).await
+}
+
+pub(crate) async fn ship_via_client(
+    team: &str,
+    client: &EsaClient,
+    db: Option<&Db>,
+    number: u32,
+) -> Result<CommandOutput, SaeError> {
     let params = UpdatePostParams {
         wip: Some(false),
         ..Default::default()
     };
     let post = client.update_post(team, number, &params).await?;
+    sync::try_upsert_post_locally(db, &post);
     output::action_result("Shipped", &post)
 }
 
@@ -107,5 +132,92 @@ mod tests {
             archive_category(Some("ArchivedData")),
             Some("Archived/ArchivedData".into())
         );
+    }
+
+    use crate::sync::tests::esa_post_fixture;
+
+    fn esa_post_json(
+        number: u32,
+        category: Option<&str>,
+        wip: bool,
+        updated_at: &str,
+    ) -> serde_json::Value {
+        esa_post_fixture(number, "Post", "# x", category, wip, updated_at)
+    }
+
+    // T-313: archive_via_client moves category and writes through to local DB
+    #[tokio::test]
+    async fn archive_via_client_writes_through_to_local_db() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/myteam/posts/5"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(esa_post_json(
+                5,
+                Some("dev/guide"),
+                false,
+                "2025-01-01T00:00:00+09:00",
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path("/teams/myteam/posts/5"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(esa_post_json(
+                5,
+                Some("Archived/dev/guide"),
+                false,
+                "2025-06-01T00:00:00+09:00",
+            )))
+            .mount(&server)
+            .await;
+
+        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let db = Db::open_memory().unwrap();
+
+        archive_via_client("myteam", &client, Some(&db), 5, false)
+            .await
+            .expect("archive should succeed");
+
+        let category: String = db
+            .conn()
+            .query_row("SELECT category FROM posts WHERE number = 5", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(category, "Archived/dev/guide");
+    }
+
+    // T-314: ship_via_client unsets wip and reflects to local DB
+    #[tokio::test]
+    async fn ship_via_client_writes_through_to_local_db() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/teams/myteam/posts/9"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(esa_post_json(
+                9,
+                Some("dev"),
+                false,
+                "2025-06-01T00:00:00+09:00",
+            )))
+            .mount(&server)
+            .await;
+
+        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let db = Db::open_memory().unwrap();
+
+        ship_via_client("myteam", &client, Some(&db), 9)
+            .await
+            .expect("ship should succeed");
+
+        let wip: bool = db
+            .conn()
+            .query_row("SELECT wip FROM posts WHERE number = 9", [], |r| r.get(0))
+            .unwrap();
+        assert!(!wip, "wip should be false after ship");
     }
 }

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -1,11 +1,12 @@
 use std::fs;
 use std::io::{self, Read};
 
-use crate::client::{CreatePostParams, UpdatePostParams};
+use crate::client::{CreatePostParams, EsaClient, UpdatePostParams};
 use crate::config::Config;
 use crate::envelope::CommandOutput;
-
 use crate::output;
+use crate::storage::Db;
+use crate::sync;
 use crate::tools::{CreateArgs, SaeError, UpdateArgs, resolve_client};
 
 pub(crate) async fn run_get(
@@ -21,6 +22,7 @@ pub(crate) async fn run_get(
 
 pub(crate) async fn run_create(
     config: &Config,
+    db: Option<&Db>,
     args: CreateArgs,
 ) -> Result<CommandOutput, SaeError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
@@ -34,26 +36,38 @@ pub(crate) async fn run_create(
         }));
     }
     let (team, client) = resolve_client(config, args.team.as_deref())?;
+    create_via_client(team, &client, db, &args, resolved_body.as_deref()).await
+}
+
+pub(crate) async fn create_via_client(
+    team: &str,
+    client: &EsaClient,
+    db: Option<&Db>,
+    args: &CreateArgs,
+    body_md: Option<&str>,
+) -> Result<CommandOutput, SaeError> {
     let params = CreatePostParams {
         name: &args.name,
-        body_md: resolved_body.as_deref(),
+        body_md,
         category: args.category.as_deref(),
-        tags: args.tag,
+        tags: args.tag.clone(),
         wip: args.wip,
     };
     let post = client.create_post(team, &params).await?;
+    sync::try_upsert_post_locally(db, &post);
     output::action_result("Created", &post)
 }
 
 pub(crate) async fn run_update(
     config: &Config,
+    db: Option<&Db>,
     args: UpdateArgs,
 ) -> Result<CommandOutput, SaeError> {
     let resolved_body = resolve_body(args.body.as_deref(), args.body_file.as_deref())?;
     let tags: Option<Vec<String>> = if args.tag.is_empty() {
         None
     } else {
-        Some(args.tag)
+        Some(args.tag.clone())
     };
     if args.dry_run {
         return output::dry_run(&serde_json::json!({
@@ -65,14 +79,26 @@ pub(crate) async fn run_update(
         }));
     }
     let (team, client) = resolve_client(config, args.team.as_deref())?;
+    update_via_client(team, &client, db, &args, resolved_body.as_deref(), tags).await
+}
+
+pub(crate) async fn update_via_client(
+    team: &str,
+    client: &EsaClient,
+    db: Option<&Db>,
+    args: &UpdateArgs,
+    body_md: Option<&str>,
+    tags: Option<Vec<String>>,
+) -> Result<CommandOutput, SaeError> {
     let params = UpdatePostParams {
         name: args.name.as_deref(),
-        body_md: resolved_body.as_deref(),
+        body_md,
         category: args.category.as_deref(),
         tags,
         ..Default::default()
     };
     let post = client.update_post(team, args.number, &params).await?;
+    sync::try_upsert_post_locally(db, &post);
     output::action_result("Updated", &post)
 }
 
@@ -179,5 +205,141 @@ mod tests {
             Some("# Hello\nBody from stdin\n"),
             "body should contain stdin contents as-is"
         );
+    }
+
+    use crate::sync::tests::esa_post_fixture;
+
+    fn esa_post_json(
+        number: u32,
+        name: &str,
+        body_md: &str,
+        updated_at: &str,
+    ) -> serde_json::Value {
+        esa_post_fixture(number, name, body_md, Some("dev"), false, updated_at)
+    }
+
+    fn create_args(name: &str) -> CreateArgs {
+        CreateArgs {
+            name: name.into(),
+            body: None,
+            body_file: None,
+            category: None,
+            tag: vec![],
+            wip: false,
+            team: None,
+            dry_run: false,
+        }
+    }
+
+    fn update_args(number: u32) -> UpdateArgs {
+        UpdateArgs {
+            number,
+            name: None,
+            body: None,
+            body_file: None,
+            category: None,
+            tag: vec![],
+            team: None,
+            dry_run: false,
+        }
+    }
+
+    // T-310: create_via_client reflects API response into local DB
+    #[tokio::test]
+    async fn create_via_client_writes_through_to_local_db() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/teams/myteam/posts"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(esa_post_json(
+                42,
+                "Created Post",
+                "# Hello",
+                "2025-06-01T00:00:00+09:00",
+            )))
+            .mount(&server)
+            .await;
+
+        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let db = Db::open_memory().unwrap();
+        let args = create_args("Created Post");
+
+        let out = create_via_client("myteam", &client, Some(&db), &args, Some("# Hello"))
+            .await
+            .expect("create should succeed");
+        assert!(out.markdown.contains("Created"));
+
+        let name: String = db
+            .conn()
+            .query_row("SELECT name FROM posts WHERE number = 42", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(name, "Created Post", "post should be persisted locally");
+    }
+
+    // T-311: update_via_client overwrites local row with the API response
+    #[tokio::test]
+    async fn update_via_client_overwrites_local_post() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/teams/myteam/posts/7"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(esa_post_json(
+                7,
+                "Renamed",
+                "# Updated body",
+                "2025-07-01T00:00:00+09:00",
+            )))
+            .mount(&server)
+            .await;
+
+        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let db = Db::open_memory().unwrap();
+        let args = update_args(7);
+
+        update_via_client(
+            "myteam",
+            &client,
+            Some(&db),
+            &args,
+            Some("# Updated body"),
+            None,
+        )
+        .await
+        .expect("update should succeed");
+
+        let name: String = db
+            .conn()
+            .query_row("SELECT name FROM posts WHERE number = 7", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(name, "Renamed");
+    }
+
+    // T-312: create_via_client succeeds even when db=None (write-through skipped)
+    #[tokio::test]
+    async fn create_via_client_works_without_db() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/teams/myteam/posts"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(esa_post_json(
+                1,
+                "No DB",
+                "",
+                "2025-06-01T00:00:00+09:00",
+            )))
+            .mount(&server)
+            .await;
+
+        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let args = create_args("No DB");
+        create_via_client("myteam", &client, None, &args, None)
+            .await
+            .expect("create should still succeed without a DB");
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -222,6 +222,41 @@ fn resolve_start(full: bool, state: &Option<storage::SyncState>) -> (u32, Option
     (page, q)
 }
 
+/// Write-through: reflect a single `EsaPost` from a mutation API response
+/// into the local DB (posts table + chunks + FTS) atomically.
+///
+/// Does NOT touch `sync_state.latest_updated_at`. Advancing the harvest cursor
+/// from a single post would skip concurrent remote updates whose `updated_at`
+/// falls between the last harvest and this post — only a full paginated
+/// harvest can prove that range is fully covered.
+pub(crate) fn upsert_post_locally(db: &Db, post: &EsaPost) -> Result<(), SyncError> {
+    let row = post_to_row(post);
+    let tx = db
+        .conn()
+        .unchecked_transaction()
+        .map_err(StorageError::Db)?;
+    storage::upsert_post(&tx, &row)?;
+    let enriched_body = storage::enrich_body(&row);
+    storage::rechunk_post(&tx, row.number, &enriched_body)?;
+    tx.commit().map_err(StorageError::Db)?;
+    Ok(())
+}
+
+/// Best-effort wrapper for [`upsert_post_locally`]: when `db` is `None`,
+/// or when the write fails, log a warning and continue — never propagate.
+/// Used by mutation commands (create/update/archive/ship) to reflect their
+/// API response into the local DB without disrupting the user-visible result.
+pub(crate) fn try_upsert_post_locally(db: Option<&Db>, post: &EsaPost) {
+    let Some(db) = db else { return };
+    if let Err(e) = upsert_post_locally(db, post) {
+        tracing::warn!(
+            error = %e,
+            post = post.number,
+            "local DB write-through failed; next harvest will reconcile"
+        );
+    }
+}
+
 fn post_to_row(post: &EsaPost) -> EsaPostRow {
     EsaPostRow {
         number: post.number,
@@ -242,21 +277,51 @@ fn post_to_row(post: &EsaPost) -> EsaPostRow {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::client::EsaUser;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn api_post(number: u32, name: &str, updated_at: &str) -> serde_json::Value {
+    fn make_esa_post(number: u32, name: &str, body_md: &str, updated_at: &str) -> EsaPost {
+        EsaPost {
+            number,
+            name: name.into(),
+            full_name: format!("dev/{name}"),
+            body_md: Some(body_md.into()),
+            category: Some("dev".into()),
+            tags: vec!["rust".into()],
+            wip: false,
+            kind: "stock".into(),
+            url: format!("https://example.esa.io/posts/{number}"),
+            created_at: "2025-01-01T00:00:00+09:00".into(),
+            updated_at: updated_at.into(),
+            created_by: EsaUser {
+                screen_name: "alice".into(),
+            },
+            updated_by: EsaUser {
+                screen_name: "bob".into(),
+            },
+            revision_number: 1,
+        }
+    }
+
+    pub(crate) fn esa_post_fixture(
+        number: u32,
+        name: &str,
+        body_md: &str,
+        category: Option<&str>,
+        wip: bool,
+        updated_at: &str,
+    ) -> serde_json::Value {
         serde_json::json!({
             "number": number,
             "name": name,
             "full_name": format!("dev/{name}"),
-            "body_md": format!("# {name}"),
-            "category": "dev",
+            "body_md": body_md,
+            "category": category,
             "tags": ["test"],
-            "wip": false,
+            "wip": wip,
             "kind": "stock",
             "url": format!("https://example.esa.io/posts/{number}"),
             "created_at": "2025-01-01T00:00:00+09:00",
@@ -265,6 +330,17 @@ mod tests {
             "updated_by": {"screen_name": "bob"},
             "revision_number": 1
         })
+    }
+
+    fn api_post(number: u32, name: &str, updated_at: &str) -> serde_json::Value {
+        esa_post_fixture(
+            number,
+            name,
+            &format!("# {name}"),
+            Some("dev"),
+            false,
+            updated_at,
+        )
     }
 
     fn posts_response(
@@ -668,5 +744,96 @@ mod tests {
             "should fetch posts across window narrowing"
         );
         assert_eq!(storage::count_posts(db.conn()).unwrap(), 3);
+    }
+
+    // T-300: upsert_post_locally inserts a post into an empty DB
+    #[test]
+    fn upsert_post_locally_inserts_new_post() {
+        let db = Db::open_memory().unwrap();
+        let post = make_esa_post(42, "Hello", "# Body", "2025-06-01T00:00:00+09:00");
+        upsert_post_locally(&db, &post).unwrap();
+
+        let name: String = db
+            .conn()
+            .query_row("SELECT name FROM posts WHERE number = 42", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(name, "Hello");
+        let chunks = storage::count_chunks(db.conn()).unwrap();
+        assert!(chunks > 0, "expected at least one chunk to be created");
+    }
+
+    // T-301: upsert_post_locally replaces an existing post and re-chunks
+    #[test]
+    fn upsert_post_locally_replaces_existing() {
+        let db = Db::open_memory().unwrap();
+        upsert_post_locally(
+            &db,
+            &make_esa_post(7, "Original", "# Old", "2025-01-01T00:00:00+09:00"),
+        )
+        .unwrap();
+        upsert_post_locally(
+            &db,
+            &make_esa_post(7, "Renamed", "# New body", "2025-02-01T00:00:00+09:00"),
+        )
+        .unwrap();
+
+        let name: String = db
+            .conn()
+            .query_row("SELECT name FROM posts WHERE number = 7", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(name, "Renamed", "later upsert should win");
+        let total: u32 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM posts", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(total, 1, "no duplicate row should be created");
+    }
+
+    // T-302: upsert_post_locally must NOT touch sync_state so that the harvest
+    //        cursor only advances after a full paginated harvest proves the
+    //        intervening updated_at range was fully covered. Single-post
+    //        write-through would otherwise skip concurrent remote updates.
+    #[test]
+    fn upsert_post_locally_does_not_advance_sync_state() {
+        let db = Db::open_memory().unwrap();
+        storage::save_sync_state_at(
+            db.conn(),
+            &storage::SyncStateUpdate {
+                latest_updated_at: Some("2025-01-01T00:00:00+09:00"),
+                total_count: 5,
+                local_count: 5,
+                last_page: None,
+            },
+            1_700_000_000,
+        )
+        .unwrap();
+        let before = storage::get_sync_state(db.conn()).unwrap().unwrap();
+
+        let post = make_esa_post(1, "A", "# x", "2025-06-01T00:00:00+09:00");
+        upsert_post_locally(&db, &post).unwrap();
+
+        let after = storage::get_sync_state(db.conn()).unwrap().unwrap();
+        assert_eq!(after.latest_updated_at, before.latest_updated_at);
+        assert_eq!(after.total_count, before.total_count);
+        assert_eq!(after.local_count, before.local_count);
+        assert_eq!(after.updated_at, before.updated_at);
+    }
+
+    // T-304: upsert_post_locally without prior sync_state leaves it absent
+    #[test]
+    fn upsert_post_locally_skips_sync_state_when_absent() {
+        let db = Db::open_memory().unwrap();
+        let post = make_esa_post(1, "A", "# x", "2025-06-01T00:00:00+09:00");
+        upsert_post_locally(&db, &post).unwrap();
+
+        assert!(
+            storage::get_sync_state(db.conn()).unwrap().is_none(),
+            "sync_state should not be created when previously absent"
+        );
+        assert_eq!(storage::count_posts(db.conn()).unwrap(), 1);
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -203,11 +203,21 @@ impl Sae {
     }
 
     pub async fn create(&self, args: CreateArgs) -> Result<CommandOutput, SaeError> {
-        commands::post::run_create(&self.config, args).await
+        let db = if args.dry_run {
+            None
+        } else {
+            try_open_team_db(&self.config, args.team.as_deref())
+        };
+        commands::post::run_create(&self.config, db.as_ref(), args).await
     }
 
     pub async fn update(&self, args: UpdateArgs) -> Result<CommandOutput, SaeError> {
-        commands::post::run_update(&self.config, args).await
+        let db = if args.dry_run {
+            None
+        } else {
+            try_open_team_db(&self.config, args.team.as_deref())
+        };
+        commands::post::run_update(&self.config, db.as_ref(), args).await
     }
 
     pub async fn archive(
@@ -216,7 +226,12 @@ impl Sae {
         team: Option<&str>,
         dry_run: bool,
     ) -> Result<CommandOutput, SaeError> {
-        commands::archive::run_archive(&self.config, number, team, dry_run).await
+        let db = if dry_run {
+            None
+        } else {
+            try_open_team_db(&self.config, team)
+        };
+        commands::archive::run_archive(&self.config, db.as_ref(), number, team, dry_run).await
     }
 
     pub async fn ship(
@@ -225,7 +240,12 @@ impl Sae {
         team: Option<&str>,
         dry_run: bool,
     ) -> Result<CommandOutput, SaeError> {
-        commands::archive::run_ship(&self.config, number, team, dry_run).await
+        let db = if dry_run {
+            None
+        } else {
+            try_open_team_db(&self.config, team)
+        };
+        commands::archive::run_ship(&self.config, db.as_ref(), number, team, dry_run).await
     }
 
     pub fn search(&self, args: SearchArgs) -> Result<CommandOutput, SaeError> {
@@ -400,6 +420,29 @@ pub(crate) fn require_db(config: &Config, team: &str) -> Result<Db, SaeError> {
         return Err(SaeError::input_no_data_for_team(team));
     }
     Ok(Db::open(&db_path)?)
+}
+
+/// Best-effort DB open for mutation commands. Returns `None` when the team
+/// cannot be resolved, the DB file does not yet exist (no prior harvest), or
+/// the DB fails to open — letting the API call proceed regardless. Only the
+/// open failure logs a warning; the other paths are silent.
+pub(crate) fn try_open_team_db(config: &Config, team: Option<&str>) -> Option<Db> {
+    let team = config.resolve_team(team).ok()?;
+    let db_path = config.team_db_path(team).ok()?;
+    if !db_path.exists() {
+        return None;
+    }
+    match Db::open(&db_path) {
+        Ok(db) => Some(db),
+        Err(e) => {
+            tracing::warn!(
+                team,
+                error = %e,
+                "failed to open local DB; write-through skipped"
+            );
+            None
+        }
+    }
 }
 
 impl CliError for SaeError {


### PR DESCRIPTION
## 概要

- create / update / archive / ship の各 mutation で、API レスポンスを即座に local DB に書き込む（次の harvest を待たない）
- Best-effort 方式：storage 失敗時は warn ログのみで、API 呼び出しは失敗させない
- Sync state（`latest_updated_at`）は write-through で**進めない**（並行リモート更新の skip を防ぐ。Codex P1 対応）

## 実装メモ

- mutation の `run_*` を `run_*`（引数解析・dry-run）+ `*_via_client`（テスト可能な client 呼び出し + DB 書き込み）に分割
- `sync.rs` に `upsert_post_locally()` / `try_upsert_post_locally()` を追加
- 3 つに分散していたテストフィクスチャを `esa_post_fixture()` に統合
- `--dry-run` 時は DB open をスキップ（重い操作の回避）

## テスト計画

- [x] T-300..T-306: `upsert_post_locally` の new / replace / no-sync-state シナリオ
- [x] T-310: `create_via_client` が local DB に書き込む
- [x] T-311: `update_via_client` が local の post を上書きする
- [x] T-312: `create_via_client` が DB None でも動作する
- [x] T-313: `archive_via_client` がカテゴリ移動 + write-through する
- [x] T-314: `ship_via_client` が wip 解除 + write-through する
- [x] テスト 265 件すべて pass
- [x] clippy クリーン

Closes #113