### PR TITLE
feat(error): ProbeError を variant ごとに ADR-0066 Group 2 で routing する

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -13,20 +13,31 @@
 use amici::cli::exit_code::codes;
 use serde::Serialize;
 
-/// JSON-serializable error classification per ADR-0060.
+/// JSON-serializable error classification per ADR-0060 / ADR-0066 Group 2.
 ///
-/// Covers every sysexits code `SaeError` currently produces. `DATA_ERROR (65)`
-/// and `NOT_FOUND (66)` are absent because no sae operation maps to them today;
-/// they will be reconsidered when this type lifts into amici alongside yomu /
-/// recall (ADR-0060 Phase 3).
+/// `Internal` serializes as `"INTERNAL"` (numerically `EX_SOFTWARE` 70) per
+/// ADR-0066's Group 2 classification table — agent-facing JSON uses the
+/// concept name, not the sysexits label. `Unknown` (`104`) is the project
+/// extension reserved for catch-all paths; sae has no anyhow path today, so
+/// no `SaeError` variant routes here, but the slot is wired so future
+/// unclassified variants pin against ADR-0066. `DATA_ERROR (65)` and
+/// `NOT_FOUND (66)` are absent — `DATA_ERROR` will arrive with #115's full
+/// Group 2 alignment (FTS5 sanitize, query encoding); `NOT_FOUND` stays
+/// Group 1 (external fetch) territory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
     UsageError,
-    Software,
+    Internal,
     CantCreat,
     IoError,
     TempFailure,
+    /// Reserved per ADR-0066 Group 2 for catch-all paths. sae currently has
+    /// no anyhow-style fallback (all SaeError variants classify explicitly),
+    /// so no production site emits this. Kept in the enum to keep the JSON
+    /// contract stable when a future unclassifiable variant arrives.
+    #[allow(dead_code)]
+    Unknown,
 }
 
 impl ErrorCode {
@@ -35,10 +46,11 @@ impl ErrorCode {
     pub(crate) fn exit_code(self) -> u8 {
         match self {
             Self::UsageError => codes::USAGE,
-            Self::Software => codes::SOFTWARE,
+            Self::Internal => codes::INTERNAL,
             Self::CantCreat => codes::CANT_CREAT,
             Self::IoError => codes::IO_ERR,
             Self::TempFailure => codes::TEMP_FAIL,
+            Self::Unknown => codes::UNKNOWN,
         }
     }
 }
@@ -138,10 +150,11 @@ mod tests {
     fn error_code_serializes_screaming_snake_case() {
         let pairs = [
             (ErrorCode::UsageError, r#""USAGE_ERROR""#),
-            (ErrorCode::Software, r#""SOFTWARE""#),
+            (ErrorCode::Internal, r#""INTERNAL""#),
             (ErrorCode::CantCreat, r#""CANT_CREAT""#),
             (ErrorCode::IoError, r#""IO_ERROR""#),
             (ErrorCode::TempFailure, r#""TEMP_FAILURE""#),
+            (ErrorCode::Unknown, r#""UNKNOWN""#),
         ];
         for (code, expected) in pairs {
             let actual = serde_json::to_string(&code).unwrap();
@@ -156,10 +169,14 @@ mod tests {
     #[test]
     fn error_code_exit_code_matches_sysexits() {
         assert_eq!(ErrorCode::UsageError.exit_code(), 64);
-        assert_eq!(ErrorCode::Software.exit_code(), 70);
+        // Internal numerically aliases SOFTWARE (70) per ADR-0066; the rename
+        // is a JSON-contract change, not a numeric one.
+        assert_eq!(ErrorCode::Internal.exit_code(), 70);
         assert_eq!(ErrorCode::CantCreat.exit_code(), 73);
         assert_eq!(ErrorCode::IoError.exit_code(), 74);
         assert_eq!(ErrorCode::TempFailure.exit_code(), 75);
+        // Unknown is the ADR-0066 project-extension catch-all (104).
+        assert_eq!(ErrorCode::Unknown.exit_code(), 104);
     }
 
     // T-EN003: error_payload_omits_optional_next_step_when_none

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -15,15 +15,9 @@ use serde::Serialize;
 
 /// JSON-serializable error classification per ADR-0060 / ADR-0066 Group 2.
 ///
-/// `Internal` serializes as `"INTERNAL"` (numerically `EX_SOFTWARE` 70) per
-/// ADR-0066's Group 2 classification table — agent-facing JSON uses the
-/// concept name, not the sysexits label. `Unknown` (`104`) is the project
-/// extension reserved for catch-all paths; sae has no anyhow path today, so
-/// no `SaeError` variant routes here, but the slot is wired so future
-/// unclassified variants pin against ADR-0066. `DATA_ERROR (65)` and
-/// `NOT_FOUND (66)` are absent — `DATA_ERROR` will arrive with #115's full
-/// Group 2 alignment (FTS5 sanitize, query encoding); `NOT_FOUND` stays
-/// Group 1 (external fetch) territory.
+/// `Internal` serializes as `"INTERNAL"` (numerically `EX_SOFTWARE` 70) so
+/// agent-facing JSON uses the concept name, not the sysexits label.
+/// `Unknown` (`104`) is the project extension reserved for catch-all paths.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
@@ -32,10 +26,6 @@ pub(crate) enum ErrorCode {
     CantCreat,
     IoError,
     TempFailure,
-    /// Reserved per ADR-0066 Group 2 for catch-all paths. sae currently has
-    /// no anyhow-style fallback (all SaeError variants classify explicitly),
-    /// so no production site emits this. Kept in the enum to keep the JSON
-    /// contract stable when a future unclassifiable variant arrives.
     #[allow(dead_code)]
     Unknown,
 }
@@ -169,13 +159,10 @@ mod tests {
     #[test]
     fn error_code_exit_code_matches_sysexits() {
         assert_eq!(ErrorCode::UsageError.exit_code(), 64);
-        // Internal numerically aliases SOFTWARE (70) per ADR-0066; the rename
-        // is a JSON-contract change, not a numeric one.
         assert_eq!(ErrorCode::Internal.exit_code(), 70);
         assert_eq!(ErrorCode::CantCreat.exit_code(), 73);
         assert_eq!(ErrorCode::IoError.exit_code(), 74);
         assert_eq!(ErrorCode::TempFailure.exit_code(), 75);
-        // Unknown is the ADR-0066 project-extension catch-all (104).
         assert_eq!(ErrorCode::Unknown.exit_code(), 104);
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -136,34 +136,27 @@ impl Sae {
         let result = embed_with_spinners(
             pending,
             |_| {
-                let mut probe_err: Option<ProbeError> = None;
-                let mut probe_detail: Option<String> = None;
+                // Ok = typed probe variant; Err = fallback Display for the
+                // non-ProbeError path; None = callback never fired.
+                let mut captured: Option<Result<ProbeError, String>> = None;
                 match try_load_embedder_with(
                     || Ok::<_, Infallible>(Some(paths)),
                     |e| tracing::warn!(error = %e, "failed to delete corrupt model files"),
                     |e| {
-                        // Capture Display before move so the non-ProbeError
-                        // path (e.g. MLX kernel failures inside Embedder::new)
-                        // still surfaces the underlying detail to the user.
                         let display = e.to_string();
-                        probe_err = extract_probe_error(e);
-                        if probe_err.is_none() {
-                            probe_detail = Some(display);
-                        }
+                        captured = Some(extract_probe_error(e).ok_or(display));
                     },
                 ) {
                     Ok(e) => Ok(e),
                     Err(DegradedReason::BackendUnavailable) => {
                         Err(SaeError::Other("MLX backend is unavailable".to_owned()))
                     }
-                    Err(reason) => match probe_err {
-                        Some(probe) => Err(SaeError::Probe(probe)),
-                        None => {
-                            let detail = probe_detail.map(|d| format!(": {d}")).unwrap_or_default();
-                            Err(SaeError::Other(format!(
-                                "Model probe failed: {reason:?}{detail}"
-                            )))
-                        }
+                    Err(reason) => match captured {
+                        Some(Ok(probe)) => Err(SaeError::Probe(probe)),
+                        Some(Err(detail)) => Err(SaeError::Other(format!(
+                            "Model probe failed: {reason:?}: {detail}"
+                        ))),
+                        None => Err(SaeError::Other(format!("Model probe failed: {reason:?}"))),
                     },
                 }
             },
@@ -296,10 +289,8 @@ pub enum SaeError {
     Io(#[from] io::Error),
     #[error(transparent)]
     ModelDownload(#[from] ModelDownloadError),
-    /// Probe subprocess failure surfaced through `try_load_embedder_with`'s
-    /// `ModelInitError` source chain. Carries the original `rurico::ProbeError`
-    /// so `error_code()` can classify per-variant (ADR-0066 Group 2: 3 variants
-    /// route to INTERNAL, `SubprocessFailed` routes to IO_ERROR).
+    /// Carries the typed `ProbeError` recovered from `ModelInitError`'s source
+    /// chain so [`Self::error_code`] can classify per-variant (ADR-0066 Group 2).
     #[error(transparent)]
     Probe(#[from] ProbeError),
     /// User action required (e.g., run harvest or model download first)
@@ -347,13 +338,13 @@ impl SaeError {
             Self::ModelDownload(
                 ModelDownloadError::BackendUnavailable | ModelDownloadError::ProbeFailed(_),
             ) => ErrorCode::Internal,
-            // ProbeError per-variant routing per ADR-0066 Group 2. The raw
-            // PROBE_EXIT_* (3–8) wire codes from rurico stay sealed inside
-            // ProbeError; only the classified sysexits value reaches the
-            // process exit code.
-            Self::Probe(ProbeError::HandlerNotInstalled)
-            | Self::Probe(ProbeError::ModelLoadFailed { .. })
-            | Self::Probe(ProbeError::SetupRejected { .. }) => ErrorCode::Internal,
+            // PROBE_EXIT_* (3–8) wire codes stay sealed inside ProbeError;
+            // only the sysexits classification reaches the process exit code.
+            Self::Probe(
+                ProbeError::HandlerNotInstalled
+                | ProbeError::ModelLoadFailed { .. }
+                | ProbeError::SetupRejected { .. },
+            ) => ErrorCode::Internal,
             Self::Probe(ProbeError::SubprocessFailed(_)) => ErrorCode::IoError,
             // Remaining Client/Sync (Network connect/timeout, MaxRetries) are retry-eligible.
             // Explicit arms (no wildcard) so future amici variants force a compile-time review.
@@ -390,10 +381,7 @@ impl SaeError {
                 Some("Retry `sae model download`; the failure is transient.")
             }
             // Explicit catch-all arms per variant. Adding a new SaeError variant
-            // must force a compile-time review (no wildcard). Probe failures
-            // are unactionable from the agent's side (the host binary needs a
-            // fix or the model artifacts need re-download), so no hint is
-            // emitted — the error message itself carries the diagnosis.
+            // must force a compile-time review (no wildcard).
             Self::Input(_)
             | Self::Config(_)
             | Self::Client(_)
@@ -490,22 +478,11 @@ fn require_embed_model() -> Result<Artifacts, SaeError> {
     }
 }
 
-/// Recover the originating [`ProbeError`] from a [`ModelInitError`].
-///
-/// `try_load_embedder_with` collapses every probe failure into one of two
-/// `ModelInitError` variants but preserves the typed source on the chain via
-/// [`rurico::model_init::ModelInitError::backend`]. This walker reverses the
-/// collapse so `SaeError::error_code` can route per ADR-0066 Group 2.
-///
-/// | `ModelInitError`        | Source            | Returned `ProbeError`              |
-/// | ----------------------- | ----------------- | ---------------------------------- |
-/// | `ModelCorrupt { reason }` | (none)          | `ModelLoadFailed { reason }`       |
-/// | `Backend { source: Some }` | downcastable  | `HandlerNotInstalled` / `SetupRejected` |
-/// | `Backend { source: None }` | (none)         | `SubprocessFailed(message)`        |
-///
-/// Returns `None` only when `Backend { source: Some }` carries a non-`ProbeError`
-/// payload — a path that does not exist today in rurico but is left open so a
-/// future amici/rurico change does not silently misclassify.
+/// Reverse [`From<ProbeError> for ModelInitError`] so per-variant `ProbeError`
+/// routing in [`SaeError::error_code`] survives amici's collapse boundary.
+/// Returns `None` only when `Backend.source` carries a non-`ProbeError`
+/// payload — left open so a future amici/rurico change does not silently
+/// misclassify.
 fn extract_probe_error(init_err: ModelInitError) -> Option<ProbeError> {
     match init_err {
         ModelInitError::ModelCorrupt { reason } => Some(ProbeError::ModelLoadFailed { reason }),
@@ -560,17 +537,14 @@ mod tests {
         );
     }
 
-    // T-241: Json variant maps to INTERNAL (sysexits 70, ADR-0066 Group 2)
+    // T-241: Json variant maps to INTERNAL (sysexits 70)
     #[test]
     fn exit_code_json_is_internal() {
         let err: serde_json::Error = serde_json::from_str::<i32>("not json").unwrap_err();
         assert_code(&SaeError::Json(err), codes::INTERNAL);
     }
 
-    // T-242: Other variant maps to INTERNAL (sysexits 70, ADR-0066 Group 2).
-    // Other carries model-related operational failures (MLX backend, probe,
-    // batch embedding, model-cache lookup) — all classified as "model
-    // artifact 不整合" per ADR-0066.
+    // T-242: Other variant maps to INTERNAL (sysexits 70)
     #[test]
     fn exit_code_other_is_internal() {
         assert_code(&SaeError::Other("unexpected".into()), codes::INTERNAL);
@@ -848,53 +822,31 @@ mod tests {
         }
     }
 
-    // T-326: Probe(HandlerNotInstalled) → INTERNAL (70).
-    // Host bin forgot to call `rurico::handle_probe_if_needed()` — an invariant
-    // violation in the sae binary itself, not retryable by the agent.
+    // T-326: every ProbeError variant routes per ADR-0066 Group 2
     #[test]
-    fn exit_code_probe_handler_not_installed_is_internal() {
-        assert_code(
-            &SaeError::Probe(ProbeError::HandlerNotInstalled),
-            codes::INTERNAL,
-        );
-    }
-
-    // T-327: Probe(ModelLoadFailed) → INTERNAL (70).
-    // Model artifact 不整合 (ADR-0066 Group 2).
-    #[test]
-    fn exit_code_probe_model_load_failed_is_internal() {
-        assert_code(
-            &SaeError::Probe(ProbeError::ModelLoadFailed {
-                reason: "weight tensor missing".into(),
-            }),
-            codes::INTERNAL,
-        );
-    }
-
-    // T-328: Probe(SetupRejected) → INTERNAL (70).
-    // env / path invariant violation in the probe child setup phase.
-    #[test]
-    fn exit_code_probe_setup_rejected_is_internal() {
+    fn exit_code_probe_variants_route_per_adr_0066() {
         use rurico::model_probe::SetupReason;
-        for reason in [
-            SetupReason::EnvIncomplete,
-            SetupReason::CanonicalizeFailed,
-            SetupReason::PathOutsideCache,
-            SetupReason::CacheRootInvalid,
-        ] {
-            assert_code(
-                &SaeError::Probe(ProbeError::SetupRejected { reason }),
-                codes::INTERNAL,
-            );
+        let internal_cases = [
+            ProbeError::HandlerNotInstalled,
+            ProbeError::ModelLoadFailed {
+                reason: "weight tensor missing".into(),
+            },
+            ProbeError::SetupRejected {
+                reason: SetupReason::EnvIncomplete,
+            },
+            ProbeError::SetupRejected {
+                reason: SetupReason::CanonicalizeFailed,
+            },
+            ProbeError::SetupRejected {
+                reason: SetupReason::PathOutsideCache,
+            },
+            ProbeError::SetupRejected {
+                reason: SetupReason::CacheRootInvalid,
+            },
+        ];
+        for probe in internal_cases {
+            assert_code(&SaeError::Probe(probe), codes::INTERNAL);
         }
-    }
-
-    // T-329: Probe(SubprocessFailed) → IO_ERR (74).
-    // Subprocess spawn / wait / pipe IO failure — distinct from
-    // ModelLoadFailed because the load itself never ran. Sysexits classifies
-    // this as IO_ERROR.
-    #[test]
-    fn exit_code_probe_subprocess_failed_is_io_err() {
         assert_code(
             &SaeError::Probe(ProbeError::SubprocessFailed(
                 "probe spawn failed: ENOENT".into(),
@@ -904,11 +856,8 @@ mod tests {
     }
 
     // T-330: PROBE_EXIT_* wire format (3-8) cannot leak through SaeError::exit_code.
-    // The raw probe-child exit codes encode rurico's internal IPC contract;
-    // a parent that exits with those numbers would confuse downstream agents
-    // expecting sysexits classifications. This test pins that even when the
-    // ProbeError carries a SetupReason whose `code()` is 5, the wrapping
-    // SaeError emits 70 (INTERNAL), not 5.
+    // Wire codes encode rurico's internal IPC contract; surfacing them as the
+    // process exit code would confuse agents expecting sysexits classifications.
     #[test]
     fn exit_code_probe_setup_rejected_does_not_leak_wire_code() {
         use rurico::model_probe::SetupReason;
@@ -944,8 +893,7 @@ mod tests {
         }
     }
 
-    // T-332: extract_probe_error walks the source chain to recover the
-    // original ProbeError variant from ModelInitError::Backend.
+    // T-332: extract_probe_error recovers the typed variant from Backend.source
     #[test]
     fn extract_probe_error_backend_with_source_recovers_typed_variant() {
         let init: ModelInitError = ProbeError::HandlerNotInstalled.into();
@@ -956,10 +904,8 @@ mod tests {
         );
     }
 
-    // T-333: extract_probe_error maps source-less Backend to SubprocessFailed.
-    // From<ProbeError>::From routes SubprocessFailed → Backend { source: None }
-    // (the only variant whose payload is a bare String); the walker must
-    // round-trip that back to SubprocessFailed using the Backend.message.
+    // T-333: extract_probe_error maps source-less Backend to SubprocessFailed
+    // (round-trips From<ProbeError> for ModelInitError on SubprocessFailed).
     #[test]
     fn extract_probe_error_backend_without_source_maps_to_subprocess_failed() {
         let init: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
@@ -970,11 +916,8 @@ mod tests {
         }
     }
 
-    // T-334: extract_probe_error returns None for non-ProbeError sources.
-    // Backend can carry MLX-layer errors from Embedder::new that are not
-    // ProbeError instances. The walker must fall through so the Sae::embed
-    // fallback emits SaeError::Other with the underlying detail preserved
-    // (rather than misclassifying the error as a probe failure).
+    // T-334: extract_probe_error returns None for non-ProbeError sources so
+    // the Sae::embed Other fallback runs instead of misclassifying as probe.
     #[test]
     fn extract_probe_error_backend_with_non_probe_source_returns_none() {
         let init = ModelInitError::Backend {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -8,6 +8,8 @@ use amici::cli::exit_code::CliError;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use amici::model::{ModelDownloadError, download_and_verify_model};
 use rurico::embed::{Artifacts, ModelId, cached_artifacts};
+use rurico::model_init::ModelInitError;
+use rurico::model_probe::ProbeError;
 
 use crate::client::{ClientError, EsaClient};
 use crate::commands;
@@ -134,24 +136,35 @@ impl Sae {
         let result = embed_with_spinners(
             pending,
             |_| {
-                let mut embed_err: Option<String> = None;
+                let mut probe_err: Option<ProbeError> = None;
+                let mut probe_detail: Option<String> = None;
                 match try_load_embedder_with(
                     || Ok::<_, Infallible>(Some(paths)),
                     |e| tracing::warn!(error = %e, "failed to delete corrupt model files"),
                     |e| {
-                        embed_err = Some(e.to_string());
+                        // Capture Display before move so the non-ProbeError
+                        // path (e.g. MLX kernel failures inside Embedder::new)
+                        // still surfaces the underlying detail to the user.
+                        let display = e.to_string();
+                        probe_err = extract_probe_error(e);
+                        if probe_err.is_none() {
+                            probe_detail = Some(display);
+                        }
                     },
                 ) {
                     Ok(e) => Ok(e),
                     Err(DegradedReason::BackendUnavailable) => {
                         Err(SaeError::Other("MLX backend is unavailable".to_owned()))
                     }
-                    Err(reason) => {
-                        let detail = embed_err.map(|e| format!(": {e}")).unwrap_or_default();
-                        Err(SaeError::Other(format!(
-                            "Model probe failed: {reason:?}{detail}"
-                        )))
-                    }
+                    Err(reason) => match probe_err {
+                        Some(probe) => Err(SaeError::Probe(probe)),
+                        None => {
+                            let detail = probe_detail.map(|d| format!(": {d}")).unwrap_or_default();
+                            Err(SaeError::Other(format!(
+                                "Model probe failed: {reason:?}{detail}"
+                            )))
+                        }
+                    },
                 }
             },
             |r: &commands::embed_batch::EmbedAllResult| {
@@ -283,6 +296,12 @@ pub enum SaeError {
     Io(#[from] io::Error),
     #[error(transparent)]
     ModelDownload(#[from] ModelDownloadError),
+    /// Probe subprocess failure surfaced through `try_load_embedder_with`'s
+    /// `ModelInitError` source chain. Carries the original `rurico::ProbeError`
+    /// so `error_code()` can classify per-variant (ADR-0066 Group 2: 3 variants
+    /// route to INTERNAL, `SubprocessFailed` routes to IO_ERROR).
+    #[error(transparent)]
+    Probe(#[from] ProbeError),
     /// User action required (e.g., run harvest or model download first)
     #[error("{0}")]
     Input(String),
@@ -316,18 +335,26 @@ impl SaeError {
             Self::Json(_)
             | Self::Other(_)
             | Self::Client(ClientError::Api(_))
-            | Self::Sync(SyncError::Client(ClientError::Api(_))) => ErrorCode::Software,
+            | Self::Sync(SyncError::Client(ClientError::Api(_))) => ErrorCode::Internal,
             Self::Client(ClientError::Network(e))
             | Self::Sync(SyncError::Client(ClientError::Network(e)))
                 if e.is_decode() =>
             {
-                ErrorCode::Software
+                ErrorCode::Internal
             }
             Self::Io(_) => ErrorCode::IoError,
             Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => ErrorCode::TempFailure,
             Self::ModelDownload(
                 ModelDownloadError::BackendUnavailable | ModelDownloadError::ProbeFailed(_),
-            ) => ErrorCode::Software,
+            ) => ErrorCode::Internal,
+            // ProbeError per-variant routing per ADR-0066 Group 2. The raw
+            // PROBE_EXIT_* (3–8) wire codes from rurico stay sealed inside
+            // ProbeError; only the classified sysexits value reaches the
+            // process exit code.
+            Self::Probe(ProbeError::HandlerNotInstalled)
+            | Self::Probe(ProbeError::ModelLoadFailed { .. })
+            | Self::Probe(ProbeError::SetupRejected { .. }) => ErrorCode::Internal,
+            Self::Probe(ProbeError::SubprocessFailed(_)) => ErrorCode::IoError,
             // Remaining Client/Sync (Network connect/timeout, MaxRetries) are retry-eligible.
             // Explicit arms (no wildcard) so future amici variants force a compile-time review.
             Self::Client(_) | Self::Sync(_) => ErrorCode::TempFailure,
@@ -363,7 +390,10 @@ impl SaeError {
                 Some("Retry `sae model download`; the failure is transient.")
             }
             // Explicit catch-all arms per variant. Adding a new SaeError variant
-            // must force a compile-time review (no wildcard).
+            // must force a compile-time review (no wildcard). Probe failures
+            // are unactionable from the agent's side (the host binary needs a
+            // fix or the model artifacts need re-download), so no hint is
+            // emitted — the error message itself carries the diagnosis.
             Self::Input(_)
             | Self::Config(_)
             | Self::Client(_)
@@ -372,6 +402,7 @@ impl SaeError {
             | Self::Json(_)
             | Self::Io(_)
             | Self::ModelDownload(_)
+            | Self::Probe(_)
             | Self::Other(_) => None,
         }
     }
@@ -459,6 +490,36 @@ fn require_embed_model() -> Result<Artifacts, SaeError> {
     }
 }
 
+/// Recover the originating [`ProbeError`] from a [`ModelInitError`].
+///
+/// `try_load_embedder_with` collapses every probe failure into one of two
+/// `ModelInitError` variants but preserves the typed source on the chain via
+/// [`rurico::model_init::ModelInitError::backend`]. This walker reverses the
+/// collapse so `SaeError::error_code` can route per ADR-0066 Group 2.
+///
+/// | `ModelInitError`        | Source            | Returned `ProbeError`              |
+/// | ----------------------- | ----------------- | ---------------------------------- |
+/// | `ModelCorrupt { reason }` | (none)          | `ModelLoadFailed { reason }`       |
+/// | `Backend { source: Some }` | downcastable  | `HandlerNotInstalled` / `SetupRejected` |
+/// | `Backend { source: None }` | (none)         | `SubprocessFailed(message)`        |
+///
+/// Returns `None` only when `Backend { source: Some }` carries a non-`ProbeError`
+/// payload — a path that does not exist today in rurico but is left open so a
+/// future amici/rurico change does not silently misclassify.
+fn extract_probe_error(init_err: ModelInitError) -> Option<ProbeError> {
+    match init_err {
+        ModelInitError::ModelCorrupt { reason } => Some(ProbeError::ModelLoadFailed { reason }),
+        ModelInitError::Backend {
+            source: Some(boxed),
+            ..
+        } => boxed.downcast::<ProbeError>().ok().map(|b| *b),
+        ModelInitError::Backend {
+            source: None,
+            message,
+        } => Some(ProbeError::SubprocessFailed(message)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use amici::cli::exit_code::codes;
@@ -499,17 +560,20 @@ mod tests {
         );
     }
 
-    // T-241: Json variant maps to SOFTWARE (sysexits 70)
+    // T-241: Json variant maps to INTERNAL (sysexits 70, ADR-0066 Group 2)
     #[test]
-    fn exit_code_json_is_software() {
+    fn exit_code_json_is_internal() {
         let err: serde_json::Error = serde_json::from_str::<i32>("not json").unwrap_err();
-        assert_code(&SaeError::Json(err), codes::SOFTWARE);
+        assert_code(&SaeError::Json(err), codes::INTERNAL);
     }
 
-    // T-242: Other variant maps to SOFTWARE (sysexits 70)
+    // T-242: Other variant maps to INTERNAL (sysexits 70, ADR-0066 Group 2).
+    // Other carries model-related operational failures (MLX backend, probe,
+    // batch embedding, model-cache lookup) — all classified as "model
+    // artifact 不整合" per ADR-0066.
     #[test]
-    fn exit_code_other_is_software() {
-        assert_code(&SaeError::Other("unexpected".into()), codes::SOFTWARE);
+    fn exit_code_other_is_internal() {
+        assert_code(&SaeError::Other("unexpected".into()), codes::INTERNAL);
     }
 
     // T-243: Io variant maps to IO_ERR (sysexits 74)
@@ -527,12 +591,12 @@ mod tests {
         );
     }
 
-    // T-245: Client(Api) maps to SOFTWARE (sysexits 70) — non-retryable HTTP 4xx
+    // T-245: Client(Api) maps to INTERNAL (sysexits 70) — non-retryable HTTP 4xx
     #[test]
-    fn exit_code_client_api_is_software() {
+    fn exit_code_client_api_is_internal() {
         assert_code(
             &SaeError::Client(ClientError::Api("404 Not Found".into())),
-            codes::SOFTWARE,
+            codes::INTERNAL,
         );
     }
 
@@ -547,21 +611,21 @@ mod tests {
         );
     }
 
-    // T-304: ModelDownload(BackendUnavailable) maps to SOFTWARE (sysexits 70) — non-retryable hardware mismatch
+    // T-304: ModelDownload(BackendUnavailable) maps to INTERNAL (sysexits 70) — non-retryable hardware mismatch
     #[test]
-    fn exit_code_model_download_backend_unavailable_is_software() {
+    fn exit_code_model_download_backend_unavailable_is_internal() {
         assert_code(
             &SaeError::ModelDownload(ModelDownloadError::BackendUnavailable),
-            codes::SOFTWARE,
+            codes::INTERNAL,
         );
     }
 
-    // T-305: ModelDownload(ProbeFailed) maps to SOFTWARE (sysexits 70) — verification failure, retry won't help
+    // T-305: ModelDownload(ProbeFailed) maps to INTERNAL (sysexits 70) — verification failure, retry won't help
     #[test]
-    fn exit_code_model_download_probe_failed_is_software() {
+    fn exit_code_model_download_probe_failed_is_internal() {
         assert_code(
             &SaeError::ModelDownload(ModelDownloadError::ProbeFailed("hash mismatch".into())),
-            codes::SOFTWARE,
+            codes::INTERNAL,
         );
     }
 
@@ -583,12 +647,12 @@ mod tests {
         );
     }
 
-    // T-248: Sync(Client(Api)) maps to SOFTWARE (sysexits 70) — non-retryable HTTP 4xx
+    // T-248: Sync(Client(Api)) maps to INTERNAL (sysexits 70) — non-retryable HTTP 4xx
     #[test]
-    fn exit_code_sync_client_api_is_software() {
+    fn exit_code_sync_client_api_is_internal() {
         assert_code(
             &SaeError::Sync(SyncError::Client(ClientError::Api("404 Not Found".into()))),
-            codes::SOFTWARE,
+            codes::INTERNAL,
         );
     }
 
@@ -782,5 +846,144 @@ mod tests {
                 "Phase 2.1 returns empty Vec for {err:?}"
             );
         }
+    }
+
+    // T-326: Probe(HandlerNotInstalled) → INTERNAL (70).
+    // Host bin forgot to call `rurico::handle_probe_if_needed()` — an invariant
+    // violation in the sae binary itself, not retryable by the agent.
+    #[test]
+    fn exit_code_probe_handler_not_installed_is_internal() {
+        assert_code(
+            &SaeError::Probe(ProbeError::HandlerNotInstalled),
+            codes::INTERNAL,
+        );
+    }
+
+    // T-327: Probe(ModelLoadFailed) → INTERNAL (70).
+    // Model artifact 不整合 (ADR-0066 Group 2).
+    #[test]
+    fn exit_code_probe_model_load_failed_is_internal() {
+        assert_code(
+            &SaeError::Probe(ProbeError::ModelLoadFailed {
+                reason: "weight tensor missing".into(),
+            }),
+            codes::INTERNAL,
+        );
+    }
+
+    // T-328: Probe(SetupRejected) → INTERNAL (70).
+    // env / path invariant violation in the probe child setup phase.
+    #[test]
+    fn exit_code_probe_setup_rejected_is_internal() {
+        use rurico::model_probe::SetupReason;
+        for reason in [
+            SetupReason::EnvIncomplete,
+            SetupReason::CanonicalizeFailed,
+            SetupReason::PathOutsideCache,
+            SetupReason::CacheRootInvalid,
+        ] {
+            assert_code(
+                &SaeError::Probe(ProbeError::SetupRejected { reason }),
+                codes::INTERNAL,
+            );
+        }
+    }
+
+    // T-329: Probe(SubprocessFailed) → IO_ERR (74).
+    // Subprocess spawn / wait / pipe IO failure — distinct from
+    // ModelLoadFailed because the load itself never ran. Sysexits classifies
+    // this as IO_ERROR.
+    #[test]
+    fn exit_code_probe_subprocess_failed_is_io_err() {
+        assert_code(
+            &SaeError::Probe(ProbeError::SubprocessFailed(
+                "probe spawn failed: ENOENT".into(),
+            )),
+            codes::IO_ERR,
+        );
+    }
+
+    // T-330: PROBE_EXIT_* wire format (3-8) cannot leak through SaeError::exit_code.
+    // The raw probe-child exit codes encode rurico's internal IPC contract;
+    // a parent that exits with those numbers would confuse downstream agents
+    // expecting sysexits classifications. This test pins that even when the
+    // ProbeError carries a SetupReason whose `code()` is 5, the wrapping
+    // SaeError emits 70 (INTERNAL), not 5.
+    #[test]
+    fn exit_code_probe_setup_rejected_does_not_leak_wire_code() {
+        use rurico::model_probe::SetupReason;
+        let reason = SetupReason::PathOutsideCache;
+        assert_eq!(
+            reason.code(),
+            5,
+            "test premise: PathOutsideCache wire code is 5"
+        );
+        let err = SaeError::Probe(ProbeError::SetupRejected { reason });
+        assert_eq!(
+            err.exit_code(),
+            ExitCode::from(codes::INTERNAL),
+            "wire code 5 must be sealed; exit must be INTERNAL (70)"
+        );
+        assert_ne!(
+            err.exit_code(),
+            ExitCode::from(5),
+            "PROBE_EXIT_PATH_OUTSIDE_CACHE (5) must not leak as the process exit code"
+        );
+    }
+
+    // T-331: extract_probe_error recovers ModelLoadFailed from ModelCorrupt.
+    #[test]
+    fn extract_probe_error_model_corrupt_maps_to_model_load_failed() {
+        let init = ModelInitError::ModelCorrupt {
+            reason: "checksum mismatch".into(),
+        };
+        let probe = extract_probe_error(init).expect("ModelCorrupt yields ProbeError");
+        match probe {
+            ProbeError::ModelLoadFailed { reason } => assert_eq!(reason, "checksum mismatch"),
+            other => panic!("expected ModelLoadFailed, got {other:?}"),
+        }
+    }
+
+    // T-332: extract_probe_error walks the source chain to recover the
+    // original ProbeError variant from ModelInitError::Backend.
+    #[test]
+    fn extract_probe_error_backend_with_source_recovers_typed_variant() {
+        let init: ModelInitError = ProbeError::HandlerNotInstalled.into();
+        let probe = extract_probe_error(init).expect("Backend with source yields ProbeError");
+        assert!(
+            matches!(probe, ProbeError::HandlerNotInstalled),
+            "expected HandlerNotInstalled, got {probe:?}"
+        );
+    }
+
+    // T-333: extract_probe_error maps source-less Backend to SubprocessFailed.
+    // From<ProbeError>::From routes SubprocessFailed → Backend { source: None }
+    // (the only variant whose payload is a bare String); the walker must
+    // round-trip that back to SubprocessFailed using the Backend.message.
+    #[test]
+    fn extract_probe_error_backend_without_source_maps_to_subprocess_failed() {
+        let init: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
+        let probe = extract_probe_error(init).expect("Backend message yields ProbeError");
+        match probe {
+            ProbeError::SubprocessFailed(msg) => assert_eq!(msg, "spawn failed"),
+            other => panic!("expected SubprocessFailed, got {other:?}"),
+        }
+    }
+
+    // T-334: extract_probe_error returns None for non-ProbeError sources.
+    // Backend can carry MLX-layer errors from Embedder::new that are not
+    // ProbeError instances. The walker must fall through so the Sae::embed
+    // fallback emits SaeError::Other with the underlying detail preserved
+    // (rather than misclassifying the error as a probe failure).
+    #[test]
+    fn extract_probe_error_backend_with_non_probe_source_returns_none() {
+        let init = ModelInitError::Backend {
+            message: "MLX kernel launch failed".into(),
+            source: Some(Box::new(io::Error::other("MLX kernel launch failed"))),
+        };
+        assert!(
+            extract_probe_error(init).is_none(),
+            "non-ProbeError source must fall through to None so the Other fallback runs"
+        );
     }
 }


### PR DESCRIPTION
## 概要

`rurico::ProbeError` の各 variant を `SaeError::exit_code` で per-variant 分類できるよう、`ModelInitError` の source chain walk で typed error を復元する経路を sae 内に追加した。あわせて ADR-0066 Group 2 の JSON contract (`"SOFTWARE"` → `"INTERNAL"`) に整列し、catch-all 用の `Unknown` (104) を defensively に予約。`PROBE_EXIT_*` (3-8) の wire format は `SaeError` 内に封じ込めて process exit code に漏れない。

## ProbeError exit code mapping (ADR-0066 Group 2)

| ProbeError variant | exit code | 理由 |
| --- | --- | --- |
| `HandlerNotInstalled` | INTERNAL (70) | host bin の bug、invariant violation |
| `ModelLoadFailed` | INTERNAL (70) | model artifact 不整合 |
| `SetupRejected` (4 sub-reasons) | INTERNAL (70) | env / path invariant violation |
| `SubprocessFailed` | IO_ERR (74) | subprocess spawn / wait / pipe IO 失敗 |

## 設計判断

- **sae 単独で per-variant fidelity (C 案)**: yomu/recall は `DegradedReason` レイヤで止めており `ProbeError` variant 個別アクセス不要のため、amici 拡張 (`on_probe_err: FnOnce(ProbeError)` 化) は yomu/recall を巻き込めない → over-engineering。`ModelInitError::Backend.source` の `Box::downcast::<ProbeError>()` で typed error を復元する経路を sae 内に閉じた。
- **JSON contract 変更を本 PR に同梱**: ADR-0066 Group 2 の table が `"INTERNAL"` を canonical 名としており、`"SOFTWARE"` を吐いてるのは ADR drift。constants 差し替えと JSON enum 切り替えを別タイミングにすると envelope と error code の意味がズレる期間が発生するため同時整列。
- **`Unknown` は defensive 追加**: sae は `anyhow` 不使用、`error_code()` は wildcard なし explicit per-variant。production firing site なし。ADR-0066 の "UNKNOWN 増加 = 設計見直し signal" の意図を守るため、catch-all 経路ができた時点で初めて発火させる方針。`#[allow(dead_code)]` で warn 抑制。
- **`SubprocessFailed` だけ IO_ERR (74)**: subprocess spawn / pipe / wait 失敗は infrastructure-level IO であり、model artifact 不整合 (INTERNAL カテゴリ) とは別レイヤ。

## 範囲外 (#117 で扱わない)

- `DATA_ERROR (65)` 追加 — #115 territory (FTS5 sanitize, query encoding)
- `NOT_FOUND (66)` — Group 1 (外部 fetch) territory
- amici 拡張で `on_probe_err: FnOnce(ProbeError)` 化 — yomu/recall に動機なく over-engineering

## 既知の制限

- **`ModelInitError::ModelCorrupt` 経路は unreachable**: amici の `try_load_embedder_with` は `ModelCorrupt` を捕捉した時 `on_probe_err` を呼ばずに artifacts 削除 + `DegradedReason::ProbeFailed` を返すため、sae の callback で `ProbeError::ModelLoadFailed` を捕捉できない。`extract_probe_error` の `ModelCorrupt` mapping (T-331) は test では valid だが実 loader path では `Other` fallback に流れる。fix には amici 側で `try_load_embedder_with` の callback semantics 拡張が必要、本 PR スコープ外。

## テスト計画

- [x] `cargo test --lib` → 271 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean
- [x] T-326: ProbeError 全 variant の exit_code mapping (parameterized)
- [x] T-330: `PROBE_EXIT_PATH_OUTSIDE_CACHE` (5) が `SaeError::exit_code` に漏れず 70 (INTERNAL) を返すこと
- [x] T-331-334: `extract_probe_error` 4 経路 (ModelCorrupt / Backend with source / Backend without source / non-ProbeError source → None)
- [x] T-EN001 / T-EN002: `ErrorCode` の serialize 名と sysexits 数値 pin

Closes #117