### PR TITLE
chore: nextest 化 + chrono→jiff 移行 + deps bump

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "120s", terminate-after = 2 }
+final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,13 @@ jobs:
       - name: Check
         run: cargo check
 
+      - name: Install nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
-        run: cargo test
+        run: cargo nextest run --profile ci
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=6d1df67#6d1df6726a50a45a4a667f9b38672fe3c93a6e2f"
+source = "git+https://github.com/thkt/amici?rev=9be815a#9be815a693b71dc9a1993b2c2a510244334ec905"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -46,15 +46,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -93,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -104,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -276,17 +267,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
 ]
 
 [[package]]
@@ -667,7 +647,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -736,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1185,30 +1165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1339,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1730,7 +1727,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1933,6 +1930,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2309,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=d757670#d757670f2018cc8850171072a181c2e29e44f866"
+source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2327,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=d757670#d757670f2018cc8850171072a181c2e29e44f866"
+source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2380,7 +2386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2439,7 +2445,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2478,14 +2484,13 @@ version = "0.2.0"
 dependencies = [
  "amici",
  "bytemuck",
- "chrono",
  "clap",
+ "jiff",
  "reqwest 0.13.3",
  "rurico",
  "rusqlite",
  "serde",
  "serde_json",
- "serial_test",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2503,15 +2508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,12 +2521,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -2617,32 +2607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2862,7 +2826,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3535,7 +3499,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3543,41 +3507,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "6d1df67" }
+amici = { git = "https://github.com/thkt/amici", rev = "9be815a" }
 bytemuck = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.6", features = ["derive"] }
+jiff = "0.2"
 reqwest = { version = "0.13", features = ["json"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "d757670" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bd637c2" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,8 +24,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "d757670", features = ["test-support"] }
-serial_test = "3"
+rurico = { git = "https://github.com/thkt/rurico", rev = "bd637c2", features = ["test-support"] }
 tempfile = "3"
 wiremock = "0.6"
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -6,6 +6,9 @@ use crate::config::Config;
 use crate::envelope::CommandOutput;
 use crate::storage;
 use amici::model::{ModelLoad, record_degraded};
+use jiff::Timestamp;
+use jiff::civil::Date;
+use jiff::tz::TimeZone;
 use rurico::embed::ChunkedEmbedding;
 use rurico::reranker::Rerank;
 
@@ -16,20 +19,19 @@ use crate::tools::{SaeError, require_db};
 
 const SEARCH_EMBED_BUDGET: u32 = 128;
 
-fn parse_date_arg(
-    s: Option<&str>,
-    flag: &str,
-) -> Result<Option<chrono::DateTime<chrono::Utc>>, SaeError> {
+fn parse_date_arg(s: Option<&str>, flag: &str) -> Result<Option<Timestamp>, SaeError> {
     let Some(s) = s else {
         return Ok(None);
     };
-    chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
-        .map_err(|_| {
-            SaeError::Input(format!(
-                "Invalid date '--{flag} {s}': expected YYYY-MM-DD (e.g. 2025-01-01)"
-            ))
-        })
-        .map(|d| Some(d.and_time(chrono::NaiveTime::MIN).and_utc()))
+    let date = Date::strptime("%Y-%m-%d", s).map_err(|_| {
+        SaeError::Input(format!(
+            "Invalid date '--{flag} {s}': expected YYYY-MM-DD (e.g. 2025-01-01)"
+        ))
+    })?;
+    let zoned = date
+        .to_zoned(TimeZone::UTC)
+        .map_err(|e| SaeError::Other(format!("failed to zone date to UTC: {e}")))?;
+    Ok(Some(zoned.timestamp()))
 }
 
 /// Embeds up to `budget` pending chunks in one batch.
@@ -146,7 +148,7 @@ pub(crate) fn run_search(
         query,
         query_embedding.as_deref(),
         limit,
-        chrono::Utc::now(),
+        Timestamp::now(),
         &filter,
         reranker_ref,
     )?;
@@ -425,7 +427,7 @@ mod tests {
         let dt = parse_date_arg(Some("2025-06-30"), "after")
             .unwrap()
             .unwrap();
-        assert_eq!(dt.format("%Y-%m-%d").to_string(), "2025-06-30");
+        assert_eq!(dt.strftime("%Y-%m-%d").to_string(), "2025-06-30");
     }
 
     // T-072: parse_date_arg returns Input error for non-ISO8601 date

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -6,7 +6,7 @@ use amici::storage::{
     filter::{append_eq_filter, append_in_filter, append_timestamp_day_cutoff_filter},
     fts::clean_for_trigram,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rurico::reranker::Rerank;
 use rurico::storage::{normalize_for_fts, prepare_match_query};
 use rusqlite::Connection;
@@ -44,8 +44,8 @@ pub struct SearchFilter<'a> {
     pub tags: Option<&'a [&'a str]>,
     pub category: Option<&'a str>,
     pub created_by: Option<&'a str>,
-    pub updated_after: Option<DateTime<Utc>>,
-    pub updated_before: Option<DateTime<Utc>>,
+    pub updated_after: Option<Timestamp>,
+    pub updated_before: Option<Timestamp>,
 }
 
 #[derive(Debug, Clone)]
@@ -118,10 +118,10 @@ fn append_search_filters(
     append_eq_filter(sql, params, "p.created_by", filter.created_by);
     let after = filter
         .updated_after
-        .map(|dt| dt.format("%Y-%m-%d").to_string());
+        .map(|ts| ts.strftime("%Y-%m-%d").to_string());
     let before = filter
         .updated_before
-        .map(|dt| dt.format("%Y-%m-%d").to_string());
+        .map(|ts| ts.strftime("%Y-%m-%d").to_string());
     append_timestamp_day_cutoff_filter(sql, params, "p.updated_at", false, after.as_deref());
     append_timestamp_day_cutoff_filter(sql, params, "p.updated_at", true, before.as_deref());
 }
@@ -192,7 +192,7 @@ fn recency_decay(age_days: f64, half_life_days: f64) -> f64 {
 fn apply_recency_boost(
     merged: Vec<(u32, f64)>,
     post_meta: &HashMap<u32, PostMeta>,
-    now: DateTime<Utc>,
+    now: Timestamp,
 ) -> Vec<(u32, f64)> {
     let mut scored: Vec<(u32, f64)> = merged
         .into_iter()
@@ -201,13 +201,13 @@ fn apply_recency_boost(
                 .get(&post_number)
                 .and_then(|meta| {
                     let updated_at = &meta.updated_at;
-                    DateTime::parse_from_rfc3339(updated_at)
+                    updated_at
+                        .parse::<Timestamp>()
                         .map_err(|e| warn!(%e, %updated_at, "unparseable updated_at, decay=0.0"))
                         .ok()
                 })
                 .map(|updated| {
-                    let age_days =
-                        (now - updated.with_timezone(&Utc)).num_seconds() as f64 / SECS_PER_DAY;
+                    let age_days = now.duration_since(updated).as_secs_f64() / SECS_PER_DAY;
                     recency_decay(age_days, RECENCY_HALF_LIFE)
                 })
                 .unwrap_or(0.0);
@@ -355,7 +355,7 @@ pub fn hybrid_search(
     query: &str,
     query_embedding: Option<&[f32]>,
     limit: u32,
-    now: DateTime<Utc>,
+    now: Timestamp,
     filter: &SearchFilter<'_>,
     reranker: Option<&dyn Rerank>,
 ) -> Result<SearchOutput, StorageError> {
@@ -478,7 +478,8 @@ pub fn hybrid_search(
 mod tests {
     use super::*;
     use crate::storage::{self, Db};
-    use chrono::{NaiveDate, NaiveTime};
+    use jiff::civil::Date;
+    use jiff::tz::TimeZone;
     use std::collections::HashSet;
 
     fn test_post(number: u32, name: &str, body_md: &str) -> storage::EsaPostRow {
@@ -566,7 +567,7 @@ mod tests {
             "認証の仕組み",
             None,
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter::default(),
             None,
         )
@@ -589,7 +590,7 @@ mod tests {
             "",
             None,
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter::default(),
             None,
         )
@@ -762,9 +763,7 @@ mod tests {
             storage::rechunk_post(db.conn(), *num, shared_body).unwrap();
         }
 
-        let now = DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
-            .unwrap()
-            .with_timezone(&Utc);
+        let now: Timestamp = "2025-02-01T00:00:00+00:00".parse().unwrap();
         let results = hybrid_search(
             db.conn(),
             "認証の仕組み",
@@ -798,9 +797,7 @@ mod tests {
         storage::upsert_post(db.conn(), &post).unwrap();
         storage::rechunk_post(db.conn(), 1, body).unwrap();
 
-        let now = DateTime::parse_from_rfc3339("2025-02-01T00:00:00+00:00")
-            .unwrap()
-            .with_timezone(&Utc);
+        let now: Timestamp = "2025-02-01T00:00:00+00:00".parse().unwrap();
         let results = hybrid_search(
             db.conn(),
             "認証の仕組み",
@@ -982,7 +979,7 @@ mod tests {
             "認証",
             Some(&query_emb),
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter::default(),
             None,
         )
@@ -1029,7 +1026,7 @@ mod tests {
             "認証",
             Some(&query_emb),
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter::default(),
             None,
         )
@@ -1087,7 +1084,7 @@ mod tests {
             "認証",
             Some(&query_emb),
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter::default(),
             None,
         )
@@ -1317,7 +1314,7 @@ mod tests {
             "認証の仕組み",
             None,
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter {
                 category: Some("backend"),
                 ..Default::default()
@@ -1355,11 +1352,12 @@ mod tests {
         }
     }
 
-    fn date_utc(s: &str) -> DateTime<Utc> {
-        NaiveDate::parse_from_str(s, "%Y-%m-%d")
+    fn date_utc(s: &str) -> Timestamp {
+        Date::strptime("%Y-%m-%d", s)
             .unwrap()
-            .and_time(NaiveTime::MIN)
-            .and_utc()
+            .to_zoned(TimeZone::UTC)
+            .unwrap()
+            .timestamp()
     }
 
     // T-108: updated_after filters out posts with updated_at before threshold
@@ -1372,9 +1370,17 @@ mod tests {
             updated_after: Some(date_utc("2025-03-01")),
             ..Default::default()
         };
-        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
-            .unwrap()
-            .results;
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            Timestamp::now(),
+            &filter,
+            None,
+        )
+        .unwrap()
+        .results;
 
         assert_eq!(results.len(), 1, "only the newer post should be returned");
         assert_eq!(results[0].post_number, 2);
@@ -1390,9 +1396,17 @@ mod tests {
             updated_before: Some(date_utc("2025-03-01")),
             ..Default::default()
         };
-        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
-            .unwrap()
-            .results;
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            Timestamp::now(),
+            &filter,
+            None,
+        )
+        .unwrap()
+        .results;
 
         assert_eq!(results.len(), 1, "only the older post should be returned");
         assert_eq!(results[0].post_number, 1);
@@ -1410,9 +1424,17 @@ mod tests {
             updated_before: Some(date_utc("2025-03-01")),
             ..Default::default()
         };
-        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
-            .unwrap()
-            .results;
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            Timestamp::now(),
+            &filter,
+            None,
+        )
+        .unwrap()
+        .results;
 
         assert_eq!(
             results.len(),
@@ -1434,9 +1456,17 @@ mod tests {
             updated_before: Some(date_utc("2025-03-01")),
             ..Default::default()
         };
-        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
-            .unwrap()
-            .results;
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            Timestamp::now(),
+            &filter,
+            None,
+        )
+        .unwrap()
+        .results;
         assert_eq!(
             results.len(),
             1,
@@ -1456,9 +1486,17 @@ mod tests {
             updated_after: Some(date_utc("2025-03-01")),
             ..Default::default()
         };
-        let results = hybrid_search(db.conn(), "ガイド", None, 10, Utc::now(), &filter, None)
-            .unwrap()
-            .results;
+        let results = hybrid_search(
+            db.conn(),
+            "ガイド",
+            None,
+            10,
+            Timestamp::now(),
+            &filter,
+            None,
+        )
+        .unwrap()
+        .results;
         assert_eq!(
             results.len(),
             1,
@@ -1480,7 +1518,7 @@ mod tests {
             "認証の仕組み",
             None,
             10,
-            Utc::now(),
+            Timestamp::now(),
             &SearchFilter::default(),
             Some(&reranker),
         )


### PR DESCRIPTION
## 概要

- #121 (cargo test → cargo nextest 移行 + serial_test 撤去) と #122 (chrono → jiff 移行) を 1 PR にまとめて対応
- あわせて amici (`6d1df67` → `9be815a`) と rurico (`d757670` → `bd637c2`) の rev を最新に bump
- dependency graph の都合上 amici が rurico を rev 固定するため、amici を nextest 追従済みコミット (rurico bd637c2 参照) まで上げて graph を単線化

## 変更内容

### #121: nextest 化

- `.config/nextest.toml` 新規作成 (profile.default / profile.ci、amici/rurico と同形)
- `.github/workflows/ci.yml` の Test step を `cargo nextest run --profile ci` に置換
- `serial_test = "3"` 撤去 (`#[serial]` 利用箇所 0 件のため `[test-groups]` 設定も不要)
- doctest step は追加せず (src 配下に doctest 0 件)

### #122: chrono → jiff 移行

| chrono | jiff |
|--------|------|
| `DateTime<Utc>` | `jiff::Timestamp` |
| `NaiveDate::parse_from_str` | `jiff::civil::Date::strptime` |
| `dt.format("%Y-%m-%d")` | `ts.strftime("%Y-%m-%d")` |
| `chrono::Utc::now()` | `jiff::Timestamp::now()` |
| `DateTime::parse_from_rfc3339` | `str.parse::<Timestamp>()` (FromStr) |
| `(a - b).num_seconds() as f64` | `a.duration_since(b).as_secs_f64()` (SignedDuration) |

`SearchFilter.updated_after / updated_before` は `Option<Timestamp>` に変更 (public 型 breaking change だが crate 外利用なし)。

### deps bump

- amici: `6d1df67` → `9be815a` (nextest 化 + rurico bd637c2 追従済み)
- rurico: `d757670` → `bd637c2` (nextest 化済み rev)

## 受け入れ条件

### #121
- [x] `cargo nextest run --profile ci` がローカルで green (313 tests passed)
- [x] `serial_test` crate が `Cargo.toml` から消えている
- [x] `cargo tree | grep serial_test` が空

### #122
- [x] `chrono` crate が `Cargo.toml` から消えている
- [x] `cargo tree | grep chrono` が空
- [x] 既存テスト全部 green (313 tests passed)
- [x] 既存の出力 format が変わらない (`strftime("%Y-%m-%d")` は chrono `format` と同 format 出力)

## テスト計画

- [ ] CI で `cargo nextest run --profile ci` が green
- [ ] CI で `cargo clippy --all-targets --all-features -- -D warnings` が green
- [ ] CI で `cargo fmt -- --check` が green
- [ ] CI で `cargo deny check` / `cargo audit` が green

Closes #121
Closes #122