### PR TITLE
refactor(cli)!: harvest を index + rebuild に分割 (yomu/recall 整列)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `sae harvest <team>` および `sae harvest <team> --full` を廃止し、
+  `sae index <team>`（増分）と `sae rebuild <team>`（全件再構築）の 2 サブコマンドに
+  分割。yomu / recall と命名を揃えるため。`--full` の発見性問題も解消する。
+  - 移行: `sae harvest myteam` → `sae index myteam`、
+    `sae harvest myteam --full` → `sae rebuild myteam`。
+  - エラーメッセージの誘導文言（`Run \`sae harvest <team>\` first.`）も
+    `Run \`sae index <team>\` first.` に更新。
+
 ## [0.2.0] - 2026-05-12
 
 ADR-0060 agent-friendly CLI envelope (Phase 1 + 2.1 + 2.2).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,7 +2480,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sae"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "amici",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sae"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95"
 description = "esa semantic search CLI"

--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ export ESA_ACCESS_TOKEN="your-token"
 ### 投稿の取得・検索
 
 ```bash
-# チームの投稿をインデックス
-sae harvest myteam
+# チームの投稿をインデックス（増分）
+sae index myteam
+
+# 全件再構築（差分追従が破綻したときなど）
+sae rebuild myteam
 
 # 検索（shorthand）
 sae "認証"
@@ -118,7 +121,7 @@ sae --json status
 | Code | 名前       | 意味             | 例                                                       | 推奨 retry  |
 | ---- | ---------- | ---------------- | -------------------------------------------------------- | ----------- |
 | 0    | SUCCESS    | 正常終了         |                                                          |             |
-| 64   | USAGE      | 入力エラー       | 不明なチーム、トークン未設定、未 harvest                 | しない      |
+| 64   | USAGE      | 入力エラー       | 不明なチーム、トークン未設定、未 index 実行              | しない      |
 | 70   | SOFTWARE   | 内部エラー       | JSON parse 失敗、想定外の例外、model 検証失敗            | しない      |
 | 73   | CANT_CREAT | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
 | 74   | IO_ERR     | I/O エラー       | ファイル読み書き失敗                                     | 状況による  |

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -55,19 +55,19 @@ where
     Ok((result.processed, result.budget_exhausted))
 }
 
-fn spawn_background_harvest(team: &str) {
+fn spawn_background_index(team: &str) {
     let Ok(exe) = env::current_exe() else {
-        tracing::warn!("background harvest skipped: current_exe() failed");
+        tracing::warn!("background index skipped: current_exe() failed");
         return;
     };
     if let Err(e) = Command::new(exe)
-        .args(["harvest", team])
+        .args(["index", team])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
     {
-        tracing::warn!(error = %e, "background harvest spawn failed");
+        tracing::warn!(error = %e, "background index spawn failed");
     }
 }
 
@@ -165,7 +165,7 @@ pub(crate) fn run_search(
     )?;
     const PREFETCH_TTL_SECS: u64 = 5 * 60;
     if !storage::sync_harvested_within(db.conn(), PREFETCH_TTL_SECS) {
-        spawn_background_harvest(team);
+        spawn_background_index(team);
     }
     Ok(output)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,9 +163,12 @@ enum ModelCommand {
     Download,
 }
 
+// Includes the deprecated `harvest` (split into `index`/`rebuild` in v0.3.0)
+// so `sae harvest` reaches clap as an unrecognized subcommand instead of being
+// silently rewritten to `sae search harvest` by the shorthand expander.
 const KNOWN_SUBCOMMANDS: &[&str] = &[
     "index", "rebuild", "search", "get", "create", "update", "archive", "ship", "embed", "status",
-    "model",
+    "model", "harvest",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
@@ -432,6 +435,18 @@ mod tests {
     fn rebuild_missing_arg_is_clap_error() {
         let result = parse_cli_args(["sae", "rebuild"]);
         assert!(result.is_err(), "rebuild without team should be clap error");
+    }
+
+    // T-034c: `sae harvest` (deprecated in v0.3.0) must surface as a clap
+    // error so users see a migration hint, not a silent rewrite to
+    // `sae search harvest`. Guarded by KNOWN_SUBCOMMANDS keeping `harvest`.
+    #[test]
+    fn deprecated_harvest_not_rewritten_as_search() {
+        let result = parse_cli_args(["sae", "harvest"]);
+        assert!(
+            result.is_err(),
+            "deprecated `harvest` must produce a clap error, not be rewritten as search"
+        );
     }
 
     // T-049: parse_cli_args(["sae", "query"]) → Command::Search (json=false) - regression

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,17 +29,21 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Fetch and index esa posts
+    /// Fetch new esa posts incrementally and index them
     #[command(after_help = "\
 Examples:
-  sae harvest myteam
-  sae harvest myteam --full")]
-    Harvest {
+  sae index myteam")]
+    Index {
         /// Team name
         team: String,
-        /// Re-fetch all posts (ignore sync state)
-        #[arg(long)]
-        full: bool,
+    },
+    /// Re-fetch all esa posts and rebuild the index from scratch
+    #[command(after_help = "\
+Examples:
+  sae rebuild myteam")]
+    Rebuild {
+        /// Team name
+        team: String,
     },
     /// Semantic search over indexed posts
     #[command(after_help = "\
@@ -160,7 +164,8 @@ enum ModelCommand {
 }
 
 const KNOWN_SUBCOMMANDS: &[&str] = &[
-    "harvest", "search", "get", "create", "update", "archive", "ship", "embed", "status", "model",
+    "index", "rebuild", "search", "get", "create", "update", "archive", "ship", "embed", "status",
+    "model",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
@@ -201,7 +206,8 @@ async fn run(cli: Cli, config: Config) -> Result<CommandOutput, SaeError> {
     }
     let sae = Sae::new(config);
     match cli.command {
-        Command::Harvest { team, full } => sae.harvest(&team, full).await,
+        Command::Index { team } => sae.index(&team).await,
+        Command::Rebuild { team } => sae.rebuild(&team).await,
         Command::Search { args } => sae.search(args),
         Command::Get {
             number,
@@ -321,7 +327,7 @@ mod tests {
     fn known_subcommand_not_expanded() {
         assert!(
             try_expand_shorthand(
-                &os(&["sae", "harvest", "myteam"]),
+                &os(&["sae", "index", "myteam"]),
                 KNOWN_SUBCOMMANDS,
                 GLOBAL_FLAGS
             )
@@ -414,11 +420,18 @@ mod tests {
         }
     }
 
-    // T-034: `sae harvest` (missing required arg) → clap error via helper
+    // T-034: `sae index` (missing required arg) → clap error via helper
     #[test]
-    fn harvest_missing_arg_is_clap_error() {
-        let result = parse_cli_args(["sae", "harvest"]);
-        assert!(result.is_err(), "harvest without team should be clap error");
+    fn index_missing_arg_is_clap_error() {
+        let result = parse_cli_args(["sae", "index"]);
+        assert!(result.is_err(), "index without team should be clap error");
+    }
+
+    // T-034b: `sae rebuild` (missing required arg) → clap error via helper
+    #[test]
+    fn rebuild_missing_arg_is_clap_error() {
+        let result = parse_cli_args(["sae", "rebuild"]);
+        assert!(result.is_err(), "rebuild without team should be clap error");
     }
 
     // T-049: parse_cli_args(["sae", "query"]) → Command::Search (json=false) - regression
@@ -721,7 +734,7 @@ mod tests {
     #[test]
     fn all_subcommands_not_shorthand() {
         for cmd in [
-            "harvest", "get", "update", "ship", "archive", "embed", "status", "model",
+            "index", "rebuild", "get", "update", "ship", "archive", "embed", "status", "model",
         ] {
             let result = parse_cli_args(["sae", cmd]);
             assert!(

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -174,7 +174,7 @@ pub async fn harvest(
 
     if gap_detected {
         progress_step(&[&format!(
-            "warning: gap detected — {} missing posts (run with --full to re-sync)",
+            "warning: gap detected — {} missing posts (run `sae rebuild {team}` to re-sync)",
             api_total - local_count
         )]);
         info!(

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -119,7 +119,15 @@ impl Sae {
         &self.config
     }
 
-    pub async fn harvest(&self, team: &str, full: bool) -> Result<CommandOutput, SaeError> {
+    pub async fn index(&self, team: &str) -> Result<CommandOutput, SaeError> {
+        self.fetch_and_index(team, false).await
+    }
+
+    pub async fn rebuild(&self, team: &str) -> Result<CommandOutput, SaeError> {
+        self.fetch_and_index(team, true).await
+    }
+
+    async fn fetch_and_index(&self, team: &str, full: bool) -> Result<CommandOutput, SaeError> {
         let (team, client) = resolve_client(&self.config, Some(team))?;
         let db_path = self.config.team_db_path(team)?;
         let db = Db::open(&db_path)?;
@@ -293,7 +301,7 @@ pub enum SaeError {
     /// chain so [`Self::error_code`] can classify per-variant (ADR-0066 Group 2).
     #[error(transparent)]
     Probe(#[from] ProbeError),
-    /// User action required (e.g., run harvest or model download first)
+    /// User action required (e.g., run `sae index` or `sae model download` first)
     #[error("{0}")]
     Input(String),
     /// Operational failure (e.g., model load, embedding, download)
@@ -306,7 +314,7 @@ impl SaeError {
     /// so the canonical prefix `next_step()` keys off stays in sync.
     pub(crate) fn input_no_data_for_team(team: &str) -> Self {
         Self::Input(format!(
-            "No data for team '{team}'. Run `sae harvest {team}` first."
+            "No data for team '{team}'. Run `sae index {team}` first."
         ))
     }
 
@@ -352,13 +360,13 @@ impl SaeError {
         }
     }
 
-    /// Returns template strings (`Run \`sae harvest <team>\``).
-    /// Concrete values (`Run \`sae harvest gaji\``) would require parsing the
+    /// Returns template strings (`Run \`sae index <team>\``).
+    /// Concrete values (`Run \`sae index gaji\``) would require parsing the
     /// message back, which is fragile; the agent-facing template is unambiguous.
     pub(crate) fn next_step(&self) -> Option<&'static str> {
         match self {
             Self::Input(s) if s.starts_with("No data for team ") => {
-                Some("Run `sae harvest <team>` to fetch posts.")
+                Some("Run `sae index <team>` to fetch posts.")
             }
             Self::Input(s) if s.starts_with("Model not found") => {
                 Some("Run `sae model download` to fetch the embedding model.")
@@ -371,8 +379,8 @@ impl SaeError {
                 Some("Set `ESA_ACCESS_TOKEN=<token>` and retry.")
             }
             // Direct API commands (get/create/update/archive/ship) bubble
-            // ClientError::MaxRetries as Self::Client(_); harvest wraps it
-            // under Sync. Both share the same retry guidance.
+            // ClientError::MaxRetries as Self::Client(_); the index/rebuild
+            // path wraps it under Sync. Both share the same retry guidance.
             Self::Client(ClientError::MaxRetries(_))
             | Self::Sync(SyncError::Client(ClientError::MaxRetries(_))) => {
                 Some("Retry after the rate-limit window resets.")
@@ -442,9 +450,9 @@ pub(crate) fn require_db(config: &Config, team: &str) -> Result<Db, SaeError> {
 }
 
 /// Best-effort DB open for mutation commands. Returns `None` when the team
-/// cannot be resolved, the DB file does not yet exist (no prior harvest), or
-/// the DB fails to open — letting the API call proceed regardless. Only the
-/// open failure logs a warning; the other paths are silent.
+/// cannot be resolved, the DB file does not yet exist (no prior `sae index`
+/// run), or the DB fails to open — letting the API call proceed regardless.
+/// Only the open failure logs a warning; the other paths are silent.
 pub(crate) fn try_open_team_db(config: &Config, team: Option<&str>) -> Option<Db> {
     let team = config.resolve_team(team).ok()?;
     let db_path = config.team_db_path(team).ok()?;
@@ -671,13 +679,13 @@ mod tests {
         }
     }
 
-    // T-310: input_no_data_for_team_pins_next_step_harvest_hint
+    // T-310: input_no_data_for_team_pins_next_step_index_hint
     #[test]
-    fn input_no_data_for_team_pins_next_step_harvest_hint() {
+    fn input_no_data_for_team_pins_next_step_index_hint() {
         let err = SaeError::input_no_data_for_team("gaji");
         assert_eq!(
             err.next_step(),
-            Some("Run `sae harvest <team>` to fetch posts."),
+            Some("Run `sae index <team>` to fetch posts."),
             "constructor and next_step must stay in sync"
         );
     }
@@ -735,7 +743,8 @@ mod tests {
 
     // T-325: next_step_client_max_retries_matches_sync_variant
     // Direct API commands (get/create/update/archive/ship) surface MaxRetries
-    // as Self::Client; harvest wraps it under Sync. Both must give the same hint.
+    // as Self::Client; the index/rebuild path wraps it under Sync. Both must
+    // give the same hint.
     #[test]
     fn next_step_client_max_retries_matches_sync_variant() {
         let err = SaeError::Client(ClientError::MaxRetries(5));

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -309,19 +309,23 @@ pub enum SaeError {
     Other(String),
 }
 
+/// Prefixes shared by the constructors below and [`SaeError::next_step`]
+/// lookup. Centralising them removes the implicit contract that constructor
+/// and lookup strings stay in sync by convention.
+const NO_DATA_PREFIX: &str = "No data for team ";
+const MODEL_NOT_FOUND_PREFIX: &str = "Model not found";
+
 impl SaeError {
-    /// Production sites MUST use this constructor (not `SaeError::Input(format!(...))`)
-    /// so the canonical prefix `next_step()` keys off stays in sync.
     pub(crate) fn input_no_data_for_team(team: &str) -> Self {
         Self::Input(format!(
-            "No data for team '{team}'. Run `sae index {team}` first."
+            "{NO_DATA_PREFIX}'{team}'. Run `sae index {team}` first."
         ))
     }
 
-    /// Production sites MUST use this constructor (not `SaeError::Input(...)`)
-    /// so the canonical prefix `next_step()` keys off stays in sync.
     pub(crate) fn input_model_not_found() -> Self {
-        Self::Input("Model not found. Run 'sae model download' first.".to_owned())
+        Self::Input(format!(
+            "{MODEL_NOT_FOUND_PREFIX}. Run 'sae model download' first."
+        ))
     }
 
     /// [`CliError::exit_code`] delegates here so the sysexits mapping is single-sourced.
@@ -365,10 +369,10 @@ impl SaeError {
     /// message back, which is fragile; the agent-facing template is unambiguous.
     pub(crate) fn next_step(&self) -> Option<&'static str> {
         match self {
-            Self::Input(s) if s.starts_with("No data for team ") => {
+            Self::Input(s) if s.starts_with(NO_DATA_PREFIX) => {
                 Some("Run `sae index <team>` to fetch posts.")
             }
-            Self::Input(s) if s.starts_with("Model not found") => {
+            Self::Input(s) if s.starts_with(MODEL_NOT_FOUND_PREFIX) => {
                 Some("Run `sae model download` to fetch the embedding model.")
             }
             Self::Config(ConfigError::NoTeamSpecified) => {


### PR DESCRIPTION
## 概要

- `sae harvest <team>` を `sae index <team>` (増分) と `sae rebuild <team>` (全件再構築) の 2 サブコマンドに分割し、yomu / recall と命名を揃える
- 旧 `--full` フラグを廃止し、`rebuild` サブコマンドに昇格 (発見性向上)
- 削除した `harvest` を `KNOWN_SUBCOMMANDS` 予約に残し、shorthand expander が `sae search harvest` に silent 書き換えするのを防止

Closes #114

## 移行

| Before | After |
| --- | --- |
| `sae harvest myteam` | `sae index myteam` |
| `sae harvest myteam --full` | `sae rebuild myteam` |

`sae harvest` を実行すると clap が `unrecognized subcommand` を返し、suggestion で `index` を提示する。

## 変更内容

### CLI 入口 (src/main.rs)

- `Command::Harvest { team, full }` → `Command::Index { team }` + `Command::Rebuild { team }` に分割
- `KNOWN_SUBCOMMANDS` 配列を 2 箇所 (`parse_cli_args` 用 + `T-078` テスト用) 更新
- `harvest` を deprecated 予約として残す (silent shorthand 防止、コメント明示)
- regression test 3 件追加: T-034 (`index` missing arg) / T-034b (`rebuild` missing arg) / T-034c (`harvest` deprecated → clap error)

### Sae 層 (src/tools.rs)

- `Sae::harvest(team, full)` → `Sae::index(team)` + `Sae::rebuild(team)`
- 共通実装は private `fetch_and_index(team, full)` helper に集約 (既存 `sync::harvest(full)` 内部 API は変更なしで再利用)
- ユーザー文言更新:
  - `Run \`sae index <team>\` first.` (`input_no_data_for_team`)
  - `Run \`sae index <team>\` to fetch posts.` (`next_step`)
- `NO_DATA_PREFIX` / `MODEL_NOT_FOUND_PREFIX` を const 抽出 (constructor の format string と `next_step` の `starts_with` lookup が同一 prefix を二重定義していた箇所を一本化)

### バックグラウンド sync (src/commands/search.rs)

- `spawn_background_harvest` → `spawn_background_index` リネーム
- サブプロセス引数 `[\"harvest\", team]` → `[\"index\", team]` に追従 (これがないと検索後の自動再同期が silently 失敗する)

### gap 警告 (src/sync.rs)

- gap 検出時の文言から `--full` 言及を排除し `sae rebuild <team>` を案内

### ドキュメント

- README: 使い方セクションに `sae index` + `sae rebuild` の 2 行構成、exit code 表の例を `未 index 実行` に
- CHANGELOG: `[Unreleased]` に breaking 内容と移行手順を記載

### バージョン

- 0.2.0 → 0.3.0 (semver pre-1.0 breaking convention)

## 内部 API の方針

`sync::harvest` / `HarvestResult` / `output::harvest` / `sync_harvested_within` は概念名として保持。「esa からの取得」という内部動作を表す動詞として残す方が、ユーザー意図 (`index` / `rebuild`) と内部動作 (取得) を区別できる。

## 受け入れ条件

- [x] `cargo nextest run` — 315/315 PASS (新規 regression test 3 件含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `sae --help` で `index` / `rebuild` が表示される
- [x] `sae index --help` / `sae rebuild --help` で Examples 行が新名で出る
- [x] `sae harvest` (deprecated) が clap unrecognized subcommand error を返す
- [x] エラーメッセージ (`No data for team ...`) のヒントが `sae index` を案内する

## /polish 結果

- simplify: 4 findings → CQ-003 (NO_DATA_PREFIX 抽出) 適用 / 3 件は bool→enum 系で agent 自身が「現状で問題なし」評価のため見送り
- Codex: P2 finding 1 件適用 (`harvest` を `KNOWN_SUBCOMMANDS` 予約 + regression test)
- CodeRabbit: skip (6 分超 stuck で kill)
- Gemini: critical/major 0
- Phase 2 enhancer-code: code is clean (substantive cleanup は Phase 1 で完了)

## 破壊的変更

`sae harvest <team>` および `sae harvest <team> --full` を廃止。スクリプトは `sae index <team>` / `sae rebuild <team>` に書き換え。