### PR TITLE
SaeError を ADR-0066 Group 2 baseline に整列 (DATA_ERROR/UNKNOWN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `sae harvest myteam --full` → `sae rebuild myteam`。
   - エラーメッセージの誘導文言（`Run \`sae harvest <team>\` first.`）も
     `Run \`sae index <team>\` first.` に更新。
+- **BREAKING**: ADR-0066 Group 2 baseline に整列。`--json` の `error.code` と
+  プロセス exit code が以下のように変化する（amici #102 で `DATA_ERROR` (65)
+  baseline 追加を受けて、sae 側 routing を整理）。
+  - `--after` / `--before` の日付形式不正 (`YYYY-MM-DD` ではない、または
+    UTC 変換失敗): `code: "USAGE_ERROR"` (exit 64) → `code: "DATA_ERROR"`
+    (exit 65)。
+  - 分類不能な内部失敗 (`SaeError::Other`、分類されない catch-all):
+    `code: "INTERNAL"` (exit 70) → `code: "UNKNOWN"` (exit 104)。
+    分類済み `INTERNAL` (70) と区別する ADR-0066 L136 の意図に合わせる。
+  - 公開 API: `SaeError::Input` を `SaeError::InputUsage` / `SaeError::InputData`
+    に分割 (USAGE_ERROR と DATA_ERROR の責務分離)。`SaeError` は `lib.rs` から
+    `pub use` されており、`Input` variant を pattern match で参照していた
+    downstream crate はコンパイルエラーになる (現状 0 件)。同時に
+    `#[non_exhaustive]` を付与し、以後の variant 追加は非破壊変更となる。
 
 ## [0.2.0] - 2026-05-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=9be815a#9be815a693b71dc9a1993b2c2a510244334ec905"
+source = "git+https://github.com/thkt/amici?rev=2ffe963#2ffe963b13047635f407ea396991c0d3b98b5a74"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "9be815a" }
+amici = { git = "https://github.com/thkt/amici", rev = "2ffe963" }
 bytemuck = "1"
 clap = { version = "4.6", features = ["derive"] }
 jiff = "0.2"

--- a/README.md
+++ b/README.md
@@ -118,16 +118,23 @@ sae --json status
 
 [sysexits.h](https://man.openbsd.org/sysexits.3) 慣例に準拠（amici #34 で全 CLI 共通化）。LLM / shell script はこの数値で retry policy を判別できる。
 
-| Code | 名前       | 意味             | 例                                                       | 推奨 retry  |
-| ---- | ---------- | ---------------- | -------------------------------------------------------- | ----------- |
-| 0    | SUCCESS    | 正常終了         |                                                          |             |
-| 64   | USAGE      | 入力エラー       | 不明なチーム、トークン未設定、未 index 実行              | しない      |
-| 70   | SOFTWARE   | 内部エラー       | JSON parse 失敗、想定外の例外、model 検証失敗            | しない      |
-| 73   | CANT_CREAT | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
-| 74   | IO_ERR     | I/O エラー       | ファイル読み書き失敗                                     | 状況による  |
-| 75   | TEMP_FAIL  | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout) | する  |
+名前列は `--json` の `error.code` 文字列 (sysexits 数値と分離した、agent 向けの安定名)。
+sysexits.h の symbolic name (`EX_USAGE`, `EX_SOFTWARE` 等) は数値の出典であって `error.code` 値とは別。
+
+| Code | error.code     | 意味             | 例                                                       | 推奨 retry  |
+| ---- | -------------- | ---------------- | -------------------------------------------------------- | ----------- |
+| 0    | (none)         | 正常終了         |                                                          |             |
+| 64   | USAGE_ERROR    | 入力エラー       | 不明なチーム、トークン未設定、未 index 実行              | しない      |
+| 65   | DATA_ERROR     | データ形式不正   | `--after` / `--before` の日付形式不正 (`YYYY-MM-DD` 以外) | しない      |
+| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、HTTP 4xx (API)、model download 検証失敗 (`ModelDownloadError::BackendUnavailable` / `ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected) | しない      |
+| 73   | CANT_CREAT     | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
+| 74   | IO_ERROR       | I/O エラー       | ファイル読み書き失敗、`ProbeError::SubprocessFailed`     | 状況による  |
+| 75   | TEMP_FAILURE   | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout) | する  |
+| 104  | UNKNOWN        | 分類不能         | embedding 失敗、`sae embed` 中の MLX backend 不在、想定外の例外。分類済み 70 と区別する ADR-0066 L136 の意図に対応 | しない |
 
 > ⚠️ 破壊的変更（issue #91 / amici #34 migration）: 旧 schema (`1` / `2` / `4`) からの切り替え。スクリプト / CI で specific number に branch している場合は更新が必要。
+
+> ⚠️ 破壊的変更（issue #126 / ADR-0066 Group 2 baseline）: 日付形式不正が 64 → 65、catch-all (`SaeError::Other`) が 70 → 104 に変化。`--json` の `error.code` も同様に `USAGE_ERROR` → `DATA_ERROR`、`INTERNAL` → `UNKNOWN`。
 
 ## ログ
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -24,13 +24,13 @@ fn parse_date_arg(s: Option<&str>, flag: &str) -> Result<Option<Timestamp>, SaeE
         return Ok(None);
     };
     let date = Date::strptime("%Y-%m-%d", s).map_err(|_| {
-        SaeError::Input(format!(
+        SaeError::InputData(format!(
             "Invalid date '--{flag} {s}': expected YYYY-MM-DD (e.g. 2025-01-01)"
         ))
     })?;
     let zoned = date
         .to_zoned(TimeZone::UTC)
-        .map_err(|e| SaeError::Other(format!("failed to zone date to UTC: {e}")))?;
+        .map_err(|e| SaeError::InputData(format!("failed to zone date to UTC: {e}")))?;
     Ok(Some(zoned.timestamp()))
 }
 
@@ -180,7 +180,7 @@ fn read_stdin_value(
 
     let value = buf.trim();
     if value.is_empty() {
-        return Err(SaeError::Input(format!(
+        return Err(SaeError::InputUsage(format!(
             "No {label} provided. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
         )));
     }
@@ -198,7 +198,7 @@ pub(crate) fn resolve_value_with_reader(
     match value {
         Some(value) if value != "-" => Ok(value),
         Some(_) => read_stdin_value(&mut stdin, label, placeholder),
-        None if stdin_is_terminal => Err(SaeError::Input(format!(
+        None if stdin_is_terminal => Err(SaeError::InputUsage(format!(
             "Missing {label}. Pass {placeholder}, pipe it via stdin, or use `-` to read stdin interactively"
         ))),
         None => read_stdin_value(&mut stdin, label, placeholder),

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -17,16 +17,18 @@ use serde::Serialize;
 ///
 /// `Internal` serializes as `"INTERNAL"` (numerically `EX_SOFTWARE` 70) so
 /// agent-facing JSON uses the concept name, not the sysexits label.
-/// `Unknown` (`104`) is the project extension reserved for catch-all paths.
+/// `Unknown` (`104`) is the project extension reserved for catch-all paths
+/// (`SaeError::Other`) so the `anyhow`-style swallowing surfaces as a
+/// distinct code per ADR-0066 L136.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
     UsageError,
+    DataError,
     Internal,
     CantCreat,
     IoError,
     TempFailure,
-    #[allow(dead_code)]
     Unknown,
 }
 
@@ -36,6 +38,7 @@ impl ErrorCode {
     pub(crate) fn exit_code(self) -> u8 {
         match self {
             Self::UsageError => codes::USAGE,
+            Self::DataError => codes::DATA_ERROR,
             Self::Internal => codes::INTERNAL,
             Self::CantCreat => codes::CANT_CREAT,
             Self::IoError => codes::IO_ERR,
@@ -140,6 +143,7 @@ mod tests {
     fn error_code_serializes_screaming_snake_case() {
         let pairs = [
             (ErrorCode::UsageError, r#""USAGE_ERROR""#),
+            (ErrorCode::DataError, r#""DATA_ERROR""#),
             (ErrorCode::Internal, r#""INTERNAL""#),
             (ErrorCode::CantCreat, r#""CANT_CREAT""#),
             (ErrorCode::IoError, r#""IO_ERROR""#),
@@ -159,6 +163,7 @@ mod tests {
     #[test]
     fn error_code_exit_code_matches_sysexits() {
         assert_eq!(ErrorCode::UsageError.exit_code(), 64);
+        assert_eq!(ErrorCode::DataError.exit_code(), 65);
         assert_eq!(ErrorCode::Internal.exit_code(), 70);
         assert_eq!(ErrorCode::CantCreat.exit_code(), 73);
         assert_eq!(ErrorCode::IoError.exit_code(), 74);

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -282,6 +282,7 @@ impl Sae {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SaeError {
     #[error(transparent)]
     Config(#[from] ConfigError),
@@ -301,10 +302,17 @@ pub enum SaeError {
     /// chain so [`Self::error_code`] can classify per-variant (ADR-0066 Group 2).
     #[error(transparent)]
     Probe(#[from] ProbeError),
-    /// User action required (e.g., run `sae index` or `sae model download` first)
+    /// User action required (e.g., run `sae index` or `sae model download` first,
+    /// or pass a missing flag). Maps to `USAGE_ERROR` (sysexits 64).
     #[error("{0}")]
-    Input(String),
-    /// Operational failure (e.g., model load, embedding, download)
+    InputUsage(String),
+    /// User-supplied data malformed (e.g., date string not `YYYY-MM-DD`).
+    /// Maps to `DATA_ERROR` (sysexits 65) per ADR-0066 Group 2.
+    #[error("{0}")]
+    InputData(String),
+    /// Operational failure with no classified variant. Maps to `UNKNOWN`
+    /// (104) so the `anyhow`-style catch-all is distinguishable from genuine
+    /// `INTERNAL` (70) classifications per ADR-0066 L136.
     #[error("{0}")]
     Other(String),
 }
@@ -317,13 +325,13 @@ const MODEL_NOT_FOUND_PREFIX: &str = "Model not found";
 
 impl SaeError {
     pub(crate) fn input_no_data_for_team(team: &str) -> Self {
-        Self::Input(format!(
+        Self::InputUsage(format!(
             "{NO_DATA_PREFIX}'{team}'. Run `sae index {team}` first."
         ))
     }
 
     pub(crate) fn input_model_not_found() -> Self {
-        Self::Input(format!(
+        Self::InputUsage(format!(
             "{MODEL_NOT_FOUND_PREFIX}. Run 'sae model download' first."
         ))
     }
@@ -331,12 +339,12 @@ impl SaeError {
     /// [`CliError::exit_code`] delegates here so the sysexits mapping is single-sourced.
     pub(crate) fn error_code(&self) -> ErrorCode {
         match self {
-            Self::Input(_) | Self::Config(_) => ErrorCode::UsageError,
+            Self::InputUsage(_) | Self::Config(_) => ErrorCode::UsageError,
+            Self::InputData(_) => ErrorCode::DataError,
             Self::Client(ClientError::TokenNotSet)
             | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => ErrorCode::UsageError,
             Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => ErrorCode::CantCreat,
             Self::Json(_)
-            | Self::Other(_)
             | Self::Client(ClientError::Api(_))
             | Self::Sync(SyncError::Client(ClientError::Api(_))) => ErrorCode::Internal,
             Self::Client(ClientError::Network(e))
@@ -361,6 +369,9 @@ impl SaeError {
             // Remaining Client/Sync (Network connect/timeout, MaxRetries) are retry-eligible.
             // Explicit arms (no wildcard) so future amici variants force a compile-time review.
             Self::Client(_) | Self::Sync(_) => ErrorCode::TempFailure,
+            // Catch-all: anyhow-style swallowing surfaces as UNKNOWN (104) to
+            // distinguish it from classified INTERNAL (70) per ADR-0066 L136.
+            Self::Other(_) => ErrorCode::Unknown,
         }
     }
 
@@ -369,10 +380,10 @@ impl SaeError {
     /// message back, which is fragile; the agent-facing template is unambiguous.
     pub(crate) fn next_step(&self) -> Option<&'static str> {
         match self {
-            Self::Input(s) if s.starts_with(NO_DATA_PREFIX) => {
+            Self::InputUsage(s) if s.starts_with(NO_DATA_PREFIX) => {
                 Some("Run `sae index <team>` to fetch posts.")
             }
-            Self::Input(s) if s.starts_with(MODEL_NOT_FOUND_PREFIX) => {
+            Self::InputUsage(s) if s.starts_with(MODEL_NOT_FOUND_PREFIX) => {
                 Some("Run `sae model download` to fetch the embedding model.")
             }
             Self::Config(ConfigError::NoTeamSpecified) => {
@@ -394,7 +405,8 @@ impl SaeError {
             }
             // Explicit catch-all arms per variant. Adding a new SaeError variant
             // must force a compile-time review (no wildcard).
-            Self::Input(_)
+            Self::InputUsage(_)
+            | Self::InputData(_)
             | Self::Config(_)
             | Self::Client(_)
             | Self::Storage(_)
@@ -519,10 +531,19 @@ mod tests {
         assert_eq!(err.exit_code(), ExitCode::from(expected));
     }
 
-    // T-237: Input variant maps to USAGE (sysexits 64)
+    // T-237: InputUsage variant maps to USAGE (sysexits 64)
     #[test]
-    fn exit_code_input_is_usage() {
-        assert_code(&SaeError::Input("bad".into()), codes::USAGE);
+    fn exit_code_input_usage_is_usage() {
+        assert_code(&SaeError::InputUsage("bad".into()), codes::USAGE);
+    }
+
+    // T-335: InputData variant maps to DATA_ERROR (sysexits 65) per ADR-0066 Group 2
+    #[test]
+    fn exit_code_input_data_is_data_error() {
+        assert_code(
+            &SaeError::InputData("Invalid date".into()),
+            codes::DATA_ERROR,
+        );
     }
 
     // T-238: Config variant maps to USAGE (sysexits 64)
@@ -556,10 +577,11 @@ mod tests {
         assert_code(&SaeError::Json(err), codes::INTERNAL);
     }
 
-    // T-242: Other variant maps to INTERNAL (sysexits 70)
+    // T-242: Other variant maps to UNKNOWN (104) — anyhow-style catch-all is
+    // distinguished from classified INTERNAL (70) per ADR-0066 L136.
     #[test]
-    fn exit_code_other_is_internal() {
-        assert_code(&SaeError::Other("unexpected".into()), codes::INTERNAL);
+    fn exit_code_other_is_unknown() {
+        assert_code(&SaeError::Other("unexpected".into()), codes::UNKNOWN);
     }
 
     // T-243: Io variant maps to IO_ERR (sysexits 74)
@@ -768,13 +790,39 @@ mod tests {
         );
     }
 
-    // T-317: next_step_input_without_recognized_prefix_returns_none
+    // T-317: next_step_input_data_returns_none
+    // InputData carries malformed user input (date parse, etc.) — no
+    // structured hint is appropriate because the fix is "correct the value".
     #[test]
-    fn next_step_input_without_recognized_prefix_returns_none() {
-        let err = SaeError::Input(
+    fn next_step_input_data_returns_none() {
+        let err = SaeError::InputData(
             "Invalid date '--from 2025-xx-xx': expected YYYY-MM-DD (e.g. 2025-01-01)".into(),
         );
         assert_eq!(err.next_step(), None);
+    }
+
+    // T-336: next_step_input_usage_without_recognized_prefix_returns_none
+    // InputUsage messages with a recognized prefix get a hint; arbitrary
+    // strings (e.g. clap-side messages) fall through to None.
+    #[test]
+    fn next_step_input_usage_without_recognized_prefix_returns_none() {
+        let err = SaeError::InputUsage("Missing search query.".into());
+        assert_eq!(err.next_step(), None);
+    }
+
+    // T-337: to_error_envelope(InputData) composes the ADR-0060 wire payload.
+    // Pins the integration of error_code / next_step / retryable / candidates
+    // for the new variant — each method has its own test (T-335, T-317,
+    // T-323, T-324) but only their composition is the agent-facing contract.
+    #[test]
+    fn to_error_envelope_input_data_composes_data_error_payload() {
+        let err = SaeError::InputData("Invalid date '--after 2025-xx-xx'".into());
+        let env = err.to_error_envelope();
+        assert_eq!(env.error.code, ErrorCode::DataError);
+        assert!(!env.error.retryable);
+        assert!(env.error.next_step.is_none());
+        assert!(env.error.candidates.is_empty());
+        assert_eq!(env.error.message, "Invalid date '--after 2025-xx-xx'");
     }
 
     // T-318: next_step_other_returns_none
@@ -815,15 +863,20 @@ mod tests {
     // T-323: retryable_false_for_input
     #[test]
     fn retryable_false_for_input() {
-        let err = SaeError::Input("bad".into());
-        assert!(!err.retryable(), "Input must not be retryable");
+        for err in [
+            SaeError::InputUsage("bad".into()),
+            SaeError::InputData("bad".into()),
+        ] {
+            assert!(!err.retryable(), "{err:?} must not be retryable");
+        }
     }
 
     // T-324: candidates_returns_empty_in_phase_2_1
     #[test]
     fn candidates_returns_empty_in_phase_2_1() {
         for err in [
-            SaeError::Input("anything".into()),
+            SaeError::InputUsage("anything".into()),
+            SaeError::InputData("anything".into()),
             SaeError::Config(ConfigError::NoTeamSpecified),
             SaeError::Other("internal".into()),
         ] {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -118,3 +118,37 @@ fn help_with_json_exits_success_with_help_text() {
         "help text should land on stdout; got: {stdout}"
     );
 }
+
+// T-CI005: malformed `--after` value exits 65 (DATA_ERROR) with
+// `error.code = "DATA_ERROR"` per ADR-0066 Group 2 baseline.
+// Pins the binary-side contract: process-boundary exit code and JSON
+// envelope code both reach the consumer for the new DATA_ERROR path.
+#[test]
+fn malformed_date_with_json_emits_data_error_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "search", "test", "--after", "2025-xx-xx"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(65),
+        "exit code must be 65 (DATA_ERROR); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env: serde_json::Value = stderr
+        .lines()
+        .find_map(|line| serde_json::from_str(line).ok())
+        .unwrap_or_else(|| panic!("no JSON line on stderr; got: {stderr}"));
+    assert_eq!(env["error"]["code"], "DATA_ERROR");
+    assert_eq!(env["error"]["retryable"], false);
+    let message = env["error"]["message"]
+        .as_str()
+        .expect("error.message must be a string");
+    assert!(
+        message.contains("Invalid date"),
+        "message must describe the date parse failure; got: {message}"
+    );
+}


### PR DESCRIPTION
## What & Why

ADR-0066 Group 2 baseline (sae / yomu / recall / rurico) に sae の error
classification を完全準拠させる。`SaeError` routing 整理と amici の
`codes::DATA_ERROR` (65) baseline 追加 (amici #102) を受けて、agent が
`--json` の `error.code` と exit code だけで retry policy を判別できる
状態を完成させる。

## Changes

- `ErrorCode::DataError` (65) 追加、`SaeError::Input` を `InputUsage` /
  `InputData` に rename-split (USAGE_ERROR / DATA_ERROR の責務分離)
- `SaeError::Other` を `Internal` (70) → `Unknown` (104) に再分類
  (anyhow-style 握り潰しを分類済み `Internal` と区別、ADR-0066 L136)
- `parse_date_arg` の `to_zoned(UTC)` 失敗も `InputData` に揃える
  (同一の日付引数が strptime / to_zoned で違う exit code に分裂する
  inconsistency を解消、/audit DP-03)
- `SaeError` に `#[non_exhaustive]` 追加 (以後の variant 追加を非破壊化)
- amici `9be815a` → `2ffe963` (`codes::DATA_ERROR` baseline 取り込み)
- README exit-code table の名前列を JSON `error.code` 軸に統一
  (旧 `SOFTWARE` / `IO_ERR` / `TEMP_FAIL` は sysexits 由来名で `--json`
  出力と不一致だった、/audit DOC-001)
- 新 T-CI005 integration test で binary boundary の DATA_ERROR (65)
  契約を pin

## Scope

- **Not included**:
  - UNKNOWN (104) の integration test (MLX backend / batch embedding
    依存パスでしか trigger できないため、follow-up #127 で扱う)
  - MLX `BackendUnavailable` の embed (104) vs model download (70)
    routing 統一 (設計判断要、follow-up #127)
  - `SaeError::Other` 8 構築サイトの大規模再分類 (今 PR は routing
    boundary 確定のみ)

## Design Decisions

- **rename-split (B 案)** を選択。`SaeError::Input` のテスト名
  `exit_code_input_is_usage` が既に USAGE / DATA 混在を示唆していた。
  新 variant `Query(QueryError)` (A) は 1 サイトのみで YAGNI、FTS5
  専用 variant (C) は実発生サイト無し (`clean_for_trigram` は silent
  `None` 返却)。
- **`Other → Unknown` 再分類** は ADR-0066 L136 の意図。`Internal`
  (70) を「分類済みの内部失敗」、`Unknown` (104) を「分類されない
  catch-all」に分けることで、agent が `code == "INTERNAL"` を見て真の
  typed internal を判別できる。
- **README 列を JSON 軸に統一** したのは、`--json` consumer が
  `error.code` 文字列と表の名前列を直接照合するため。sysexits 名
  (`SOFTWARE` / `IO_ERR` / `TEMP_FAIL`) は数値の出典で、`error.code`
  出力 (`INTERNAL` / `IO_ERROR` / `TEMP_FAILURE`) と乖離していた。
- **`#[non_exhaustive]`** を `InputData` 追加と同時に付与。`SaeError`
  は `pub use` で公開されているため、以後の variant 追加が
  semver-breaking にならないようにする。内部 no-wildcard match の
  compile-time review 規律はインライン comment で維持。

## How to Test

1. `cargo nextest run` → 319 tests pass (T-337 + T-CI005 含む)
2. `cargo clippy --all-targets --all-features -- -D warnings` → clean
3. `cargo run -- --json search test --after 2025-xx-xx; echo "exit=$?"`
   → stderr に `{"error":{"code":"DATA_ERROR",...}}` + exit 65
4. `cargo run -- --json status` → 既存 success envelope
   (`degraded:false`) が変化していないこと
5. README の exit code table が JSON `error.code` 軸で一貫しているか
   目視確認

## Related

- Closes #126
- Follow-up: #127 (`SaeError::Other` routing 監査 + UNKNOWN integration test)
- Depends on: thkt/amici#102 (`codes::DATA_ERROR` baseline、amici `2ffe963` 取り込み)
- ADR-0066 (Group 2 exit code baseline)
- ADR-0060 (agent-friendly CLI envelope)
