### PR TITLE
feat(error): SaeError::Other routing 監査 + UNKNOWN integration test (#126 audit follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Test
         run: cargo nextest run --profile ci
 
+      - name: Test (test-support feature)
+        run: cargo nextest run --profile ci --features test-support
+        # Runs T-CI006..T-CI008 hidden-seam integration tests that pin the
+        # UNKNOWN (104) and INTERNAL (70) envelopes at the process boundary
+        # (#127 OPS-005 / CHX-001). The default `cargo nextest` invocation
+        # builds without `--features test-support`, so these tests are
+        # skipped there.
+
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `pub use` されており、`Input` variant を pattern match で参照していた
     downstream crate はコンパイルエラーになる (現状 0 件)。同時に
     `#[non_exhaustive]` を付与し、以後の variant 追加は非破壊変更となる。
+- **BREAKING**: `sae embed` で MLX backend が利用不能な場合の exit code が
+  `104` (UNKNOWN) から `70` (INTERNAL) に変化 (#127 CHX-001)。
+  `--json` の `error.code` も `"UNKNOWN"` → `"INTERNAL"`。
+  `sae model download` 側 (`ModelDownloadError::BackendUnavailable` → 70) と
+  routing を一致させ、agent が「ハードウェア / 環境セットアップ問題」シグナル
+  として一貫して検知できるようにする。同様に `sae embed` / `sae search` の
+  embedder バッチ件数不整合 (programmer-detectable invariant 違反) も `104`
+  → `70` に変化。
+  - **net 状態** (#126 catch-all 70 → 104 化との関係): #126 は分類不能な
+    `SaeError::Other` を 70 → 104 に動かし、本変更 #127 は MLX backend 不在と
+    embedder invariant 違反を **104 に流さず 70 のまま固定** する例外を作る。
+    agent retry policy は `error.code` (= `INTERNAL` か `UNKNOWN`) で分岐すれば
+    両変更を吸収できる。
+  - 移行: backend missing / embedder invariant 違反で `UNKNOWN` を branch して
+    いたスクリプト・agent retry policy は `INTERNAL` を見るように更新する。
+
+### Added
+
+- 新 `SaeError::BackendUnavailable` variant (MLX backend 不在) と
+  `SaeError::Internal(String)` variant (programmer-detectable invariant
+  違反 — 例: embedder batch count mismatch)。両方とも `INTERNAL` (70) に
+  routing し、anyhow-swallow `Other` (=UNKNOWN 104) と区別する (#127 CHX-001)。
+
+### Internal
+
+- 残存 `SaeError::Other` 構築サイト 5 箇所 (`tools.rs` の model probe
+  fallback × 2、batch embedding error × 1、model cache check × 1、および
+  `search.rs` の batch embedding error × 1) にインライン文書化を追加。
+  「なぜ Other のままか」「上流の typed surface が必要」を明記し、将来の
+  typed 化候補を可視化 (#127)。
+- `[features] test-support` 下に hidden `__test_force_unknown` subcommand
+  を追加 (`#[command(hide = true)]`)。`tests/cli_integration.rs::T-CI006`
+  で UNKNOWN (104) envelope を hermetic に pin する (#127 OPS-005)。
+  `cargo install` で配布される production binary には含まれない。
 
 ## [0.2.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -126,15 +126,17 @@ sysexits.h の symbolic name (`EX_USAGE`, `EX_SOFTWARE` 等) は数値の出典�
 | 0    | (none)         | 正常終了         |                                                          |             |
 | 64   | USAGE_ERROR    | 入力エラー       | 不明なチーム、トークン未設定、未 index 実行              | しない      |
 | 65   | DATA_ERROR     | データ形式不正   | `--after` / `--before` の日付形式不正 (`YYYY-MM-DD` 以外) | しない      |
-| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、HTTP 4xx (API)、model download 検証失敗 (`ModelDownloadError::BackendUnavailable` / `ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected) | しない      |
+| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、HTTP 4xx (API)、MLX backend 不在 (`sae embed` / `sae model download` 共通)、model download 検証失敗 (`ModelDownloadError::ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected)、embedder invariant 違反 (例: batch count mismatch) | しない      |
 | 73   | CANT_CREAT     | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
 | 74   | IO_ERROR       | I/O エラー       | ファイル読み書き失敗、`ProbeError::SubprocessFailed`     | 状況による  |
 | 75   | TEMP_FAILURE   | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout) | する  |
-| 104  | UNKNOWN        | 分類不能         | embedding 失敗、`sae embed` 中の MLX backend 不在、想定外の例外。分類済み 70 と区別する ADR-0066 L136 の意図に対応 | しない |
+| 104  | UNKNOWN        | 分類不能         | model probe fallback、未型化の embedder ランタイムエラー (`anyhow::Error` 経由)、その他の想定外例外。分類済み 70 と区別する ADR-0066 L136 の意図に対応 | しない |
 
 > ⚠️ 破壊的変更（issue #91 / amici #34 migration）: 旧 schema (`1` / `2` / `4`) からの切り替え。スクリプト / CI で specific number に branch している場合は更新が必要。
 
 > ⚠️ 破壊的変更（issue #126 / ADR-0066 Group 2 baseline）: 日付形式不正が 64 → 65、catch-all (`SaeError::Other`) が 70 → 104 に変化。`--json` の `error.code` も同様に `USAGE_ERROR` → `DATA_ERROR`、`INTERNAL` → `UNKNOWN`。
+
+> ⚠️ 破壊的変更（issue #127 / `SaeError::Other` routing audit）: #126 で catch-all が 70 → 104 に動いた一方、以下の 2 種の失敗は **70 (INTERNAL) に分類される** — `sae embed` / `sae search` での MLX backend 不在 (`SaeError::BackendUnavailable`)、`sae embed` / `sae search` での embedder invariant 違反 (`SaeError::Internal`、例: batch count mismatch)。`sae model download` 側 (既に 70) と routing を揃え、agent が「ハードウェア / 環境不一致 or プログラム不変条件違反」シグナルとして検知できるようにする。**net 状態**: agent retry policy は `error.code` (= `"INTERNAL"` か `"UNKNOWN"`) で分岐すれば #126 / #127 双方の変更を吸収できる。
 
 ## ログ
 

--- a/src/commands/embed_batch.rs
+++ b/src/commands/embed_batch.rs
@@ -64,7 +64,11 @@ where
     let batch_len = u32::try_from(batch.len()).expect("batch size exceeds u32::MAX");
     let embs = embed_fn(&texts)?;
     if embs.len() != batch.len() {
-        return Err(SaeError::Other(format!(
+        // Programmer-detectable invariant violation: embedder returned a
+        // vector count that does not match the requested batch. Surfaces as
+        // `INTERNAL` so agents can distinguish bug signals from the
+        // `anyhow`-swallow `Other` (=UNKNOWN) path (#127 CHX-001).
+        return Err(SaeError::Internal(format!(
             "Embedding count mismatch: expected {}, got {}",
             batch.len(),
             embs.len()

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -101,6 +101,10 @@ pub(crate) fn run_search(
     let embed_info = if let Some(emb) = embedder {
         match auto_embed_pending_with(&db, SEARCH_EMBED_BUDGET, |texts| {
             emb.embed_documents_batch(texts)
+                // Other (UNKNOWN): embedder's runtime error is an opaque
+                // `anyhow::Error` (no typed variant from amici/rurico).
+                // Mirrors `tools::Sae::embed`; promoting requires upstream
+                // typed surface first.
                 .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
         }) {
             Ok((processed, budget_exhausted)) => Some(output::EmbedInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,29 @@ Examples:
         #[command(subcommand)]
         command: ModelCommand,
     },
+    /// Hidden test seam: force a `SaeError::Other` so
+    /// `tests/cli_integration.rs` can pin the UNKNOWN (104) envelope on a
+    /// hermetic process spawn (#127 OPS-005). Compiled only with
+    /// `--features test-support`; the production binary built with
+    /// `cargo install` never carries this variant.
+    #[cfg(feature = "test-support")]
+    #[command(name = "__test_force_unknown", hide = true)]
+    TestForceUnknown,
+    /// Hidden test seam: force `SaeError::BackendUnavailable` so
+    /// `tests/cli_integration.rs` can pin the INTERNAL (70) envelope for the
+    /// MLX backend missing path on a hermetic spawn (#127 CHX-001).
+    /// `test-support` feature only.
+    #[cfg(feature = "test-support")]
+    #[command(name = "__test_force_backend_unavailable", hide = true)]
+    TestForceBackendUnavailable,
+    /// Hidden test seam: force `SaeError::Internal` so
+    /// `tests/cli_integration.rs` can pin the INTERNAL (70) envelope for the
+    /// programmer-detectable invariant-violation path (e.g., embedder count
+    /// mismatch at `embed_batch.rs::embed_one_batch`) on a hermetic spawn
+    /// (#127 CHX-001 audit follow-up). `test-support` feature only.
+    #[cfg(feature = "test-support")]
+    #[command(name = "__test_force_internal", hide = true)]
+    TestForceInternal,
 }
 
 #[derive(Debug, Subcommand)]
@@ -166,9 +189,25 @@ enum ModelCommand {
 // Includes the deprecated `harvest` (split into `index`/`rebuild` in v0.3.0)
 // so `sae harvest` reaches clap as an unrecognized subcommand instead of being
 // silently rewritten to `sae search harvest` by the shorthand expander.
+// `__test_force_unknown` is the hidden test seam (#127 OPS-005); listing it
+// here keeps the production binary from rewriting it to `sae search
+// __test_force_unknown` so users see clap's "unrecognized subcommand" error.
 const KNOWN_SUBCOMMANDS: &[&str] = &[
-    "index", "rebuild", "search", "get", "create", "update", "archive", "ship", "embed", "status",
-    "model", "harvest",
+    "index",
+    "rebuild",
+    "search",
+    "get",
+    "create",
+    "update",
+    "archive",
+    "ship",
+    "embed",
+    "status",
+    "model",
+    "harvest",
+    "__test_force_unknown",
+    "__test_force_backend_unavailable",
+    "__test_force_internal",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
@@ -231,6 +270,16 @@ async fn run(cli: Cli, config: Config) -> Result<CommandOutput, SaeError> {
             dry_run,
         } => sae.ship(number, team.as_deref(), dry_run).await,
         Command::Status { team } => sae.status(team.as_deref()),
+        #[cfg(feature = "test-support")]
+        Command::TestForceUnknown => Err(SaeError::Other(
+            "synthetic UNKNOWN for cli_integration test (test-support feature)".to_owned(),
+        )),
+        #[cfg(feature = "test-support")]
+        Command::TestForceBackendUnavailable => Err(SaeError::BackendUnavailable),
+        #[cfg(feature = "test-support")]
+        Command::TestForceInternal => Err(SaeError::Internal(
+            "synthetic INTERNAL for cli_integration test (test-support feature)".to_owned(),
+        )),
         Command::Model { .. } => unreachable!("handled before Sae::new()"),
     }
 }
@@ -529,6 +578,12 @@ mod tests {
     fn help_output_contains_examples() {
         let cmd = Cli::command();
         for sub in cmd.get_subcommands() {
+            // Hidden subcommands (e.g. `__test_force_unknown` under
+            // `test-support`) intentionally have no Examples — they are not
+            // user-facing.
+            if sub.is_hide_set() {
+                continue;
+            }
             let after_help = subcommand_after_help(sub.get_name());
             assert!(
                 after_help.contains("Examples"),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -156,14 +156,22 @@ impl Sae {
                     },
                 ) {
                     Ok(e) => Ok(e),
-                    Err(DegradedReason::BackendUnavailable) => {
-                        Err(SaeError::Other("MLX backend is unavailable".to_owned()))
-                    }
+                    // Mirrors `ModelDownload(BackendUnavailable)` routing via
+                    // `SaeError::BackendUnavailable` so embed and model download
+                    // surface the same INTERNAL signal for hardware mismatch
+                    // (#127 CHX-001; was `Other` → UNKNOWN before).
+                    Err(DegradedReason::BackendUnavailable) => Err(SaeError::BackendUnavailable),
                     Err(reason) => match captured {
                         Some(Ok(probe)) => Err(SaeError::Probe(probe)),
+                        // Other (UNKNOWN): `extract_probe_error` returned a non-`ProbeError`
+                        // payload that we surfaced via `Display`. No typed variant exists
+                        // yet for the remaining `DegradedReason` shapes coming from amici.
                         Some(Err(detail)) => Err(SaeError::Other(format!(
                             "Model probe failed: {reason:?}: {detail}"
                         ))),
+                        // Other (UNKNOWN): probe callback never fired — amici returned a
+                        // `DegradedReason` without invoking the per-error hook. Genuine
+                        // unclassified path.
                         None => Err(SaeError::Other(format!("Model probe failed: {reason:?}"))),
                     },
                 }
@@ -177,6 +185,9 @@ impl Sae {
                     |texts| {
                         embedder
                             .embed_documents_batch(texts)
+                            // Other (UNKNOWN): embedder's runtime error is an opaque
+                            // `anyhow::Error` (no typed variant from amici/rurico).
+                            // Promoting requires upstream type surface first.
                             .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
                     },
                     |n| update(&format!("Embedding... {n}/{pending} chunks")),
@@ -310,6 +321,18 @@ pub enum SaeError {
     /// Maps to `DATA_ERROR` (sysexits 65) per ADR-0066 Group 2.
     #[error("{0}")]
     InputData(String),
+    /// MLX backend missing in the runtime hardware (e.g., running on a host
+    /// without Apple Silicon). Maps to `INTERNAL` (sysexits 70) so `sae embed`
+    /// and `sae model download` surface the same hardware-mismatch signal
+    /// (was split between 104 and 70 before #127 CHX-001).
+    #[error("MLX backend is unavailable")]
+    BackendUnavailable,
+    /// Programmer-detectable invariant violation (e.g., embedder returned a
+    /// vector count that does not match the requested batch). Maps to
+    /// `INTERNAL` (sysexits 70) so agents distinguish bug signals from the
+    /// `anyhow`-swallow `UNKNOWN` (104) path per ADR-0066 L136 (#127 CHX-001).
+    #[error("{0}")]
+    Internal(String),
     /// Operational failure with no classified variant. Maps to `UNKNOWN`
     /// (104) so the `anyhow`-style catch-all is distinguishable from genuine
     /// `INTERNAL` (70) classifications per ADR-0066 L136.
@@ -322,6 +345,13 @@ pub enum SaeError {
 /// and lookup strings stay in sync by convention.
 const NO_DATA_PREFIX: &str = "No data for team ";
 const MODEL_NOT_FOUND_PREFIX: &str = "Model not found";
+
+/// Shared `next_step` hint for both `SaeError::BackendUnavailable` (embed
+/// path) and `SaeError::ModelDownload(ModelDownloadError::BackendUnavailable)`
+/// (model download path). Lives as a single const so the unit tests, the
+/// integration test, and the production arm cannot drift.
+const BACKEND_UNAVAILABLE_HINT: &str =
+    "Install the MLX backend (Apple Silicon required), or pass `--no-embed` for FTS-only search.";
 
 impl SaeError {
     pub(crate) fn input_no_data_for_team(team: &str) -> Self {
@@ -358,6 +388,13 @@ impl SaeError {
             Self::ModelDownload(
                 ModelDownloadError::BackendUnavailable | ModelDownloadError::ProbeFailed(_),
             ) => ErrorCode::Internal,
+            // Mirrors `ModelDownload(BackendUnavailable)` so the embed path and
+            // model-download path agree on hardware-mismatch routing (#127 CHX-001).
+            Self::BackendUnavailable => ErrorCode::Internal,
+            // Programmer-detectable invariant violation (embedder bug, etc.).
+            // Routed to `INTERNAL` so it stays distinguishable from anyhow-swallow
+            // `Other(=UNKNOWN)` per ADR-0066 L136 (#127).
+            Self::Internal(_) => ErrorCode::Internal,
             // PROBE_EXIT_* (3–8) wire codes stay sealed inside ProbeError;
             // only the sysexits classification reaches the process exit code.
             Self::Probe(
@@ -403,6 +440,13 @@ impl SaeError {
             Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => {
                 Some("Retry `sae model download`; the failure is transient.")
             }
+            // Mirrors `BackendUnavailable` below so both `sae embed` and
+            // `sae model download` surface the same actionable hint on
+            // hardware mismatch (#127 OPS-007).
+            Self::ModelDownload(ModelDownloadError::BackendUnavailable) => {
+                Some(BACKEND_UNAVAILABLE_HINT)
+            }
+            Self::BackendUnavailable => Some(BACKEND_UNAVAILABLE_HINT),
             // Explicit catch-all arms per variant. Adding a new SaeError variant
             // must force a compile-time review (no wildcard).
             Self::InputUsage(_)
@@ -415,6 +459,7 @@ impl SaeError {
             | Self::Io(_)
             | Self::ModelDownload(_)
             | Self::Probe(_)
+            | Self::Internal(_)
             | Self::Other(_) => None,
         }
     }
@@ -498,6 +543,9 @@ fn require_embed_model() -> Result<Artifacts, SaeError> {
     match cached_artifacts(ModelId::default()) {
         Ok(Some(p)) => Ok(p),
         Ok(None) => Err(SaeError::input_model_not_found()),
+        // Other (UNKNOWN): `cached_artifacts` returns an opaque `anyhow::Error`
+        // covering filesystem / permission / cache-layout edge cases. Promoting
+        // requires typed surface from rurico first.
         Err(e) => Err(SaeError::Other(format!("Failed to check model cache: {e}"))),
     }
 }
@@ -993,6 +1041,86 @@ mod tests {
         assert!(
             extract_probe_error(init).is_none(),
             "non-ProbeError source must fall through to None so the Other fallback runs"
+        );
+    }
+
+    // T-338: BackendUnavailable variant maps to INTERNAL (70) — mirrors
+    // ModelDownload(BackendUnavailable) (T-304) so embed and model download
+    // share the same hardware-mismatch exit code (#127 CHX-001).
+    #[test]
+    fn exit_code_backend_unavailable_is_internal() {
+        assert_code(&SaeError::BackendUnavailable, codes::INTERNAL);
+    }
+
+    // T-339: Internal variant maps to INTERNAL (70) — distinguishes
+    // programmer-detectable invariant violations from anyhow-swallow
+    // Other (UNKNOWN, 104) per ADR-0066 L136 (#127 CHX-001).
+    #[test]
+    fn exit_code_internal_variant_is_internal() {
+        assert_code(
+            &SaeError::Internal("Embedding count mismatch: expected 5, got 4".into()),
+            codes::INTERNAL,
+        );
+    }
+
+    // T-340: BackendUnavailable's next_step points to install / --no-embed.
+    // Constructor and lookup must stay in sync (matches T-310 / T-311 pattern).
+    #[test]
+    fn next_step_backend_unavailable_returns_install_or_no_embed_hint() {
+        assert_eq!(
+            SaeError::BackendUnavailable.next_step(),
+            Some(BACKEND_UNAVAILABLE_HINT)
+        );
+    }
+
+    // T-344: ModelDownload(BackendUnavailable)'s next_step shares the same hint
+    // as the embed-path variant (#127 OPS-007). Constructor and lookup must
+    // stay in sync via the shared `BACKEND_UNAVAILABLE_HINT` const.
+    #[test]
+    fn next_step_model_download_backend_unavailable_returns_shared_hint() {
+        let err = SaeError::ModelDownload(ModelDownloadError::BackendUnavailable);
+        assert_eq!(err.next_step(), Some(BACKEND_UNAVAILABLE_HINT));
+    }
+
+    // T-341: Internal variant returns no structured hint — the message body
+    // already carries the invariant details; no canned next step applies.
+    #[test]
+    fn next_step_internal_variant_returns_none() {
+        assert_eq!(
+            SaeError::Internal("Embedding count mismatch".into()).next_step(),
+            None
+        );
+    }
+
+    // T-342: to_error_envelope(BackendUnavailable) composes the ADR-0060 wire
+    // payload — code=INTERNAL, next_step set, retryable=false. Pins the
+    // composition (T-337 pattern) for the new variant.
+    #[test]
+    fn to_error_envelope_backend_unavailable_composes_internal_payload() {
+        let env = SaeError::BackendUnavailable.to_error_envelope();
+        assert_eq!(env.error.code, ErrorCode::Internal);
+        assert!(!env.error.retryable);
+        assert_eq!(
+            env.error.next_step.as_deref(),
+            Some(BACKEND_UNAVAILABLE_HINT)
+        );
+        assert!(env.error.candidates.is_empty());
+        assert_eq!(env.error.message, "MLX backend is unavailable");
+    }
+
+    // T-343: to_error_envelope(Internal) composes code=INTERNAL with no hint.
+    // Mirrors T-342 so both new variants have their composition pinned.
+    #[test]
+    fn to_error_envelope_internal_variant_composes_internal_payload() {
+        let err = SaeError::Internal("Embedding count mismatch: expected 5, got 4".into());
+        let env = err.to_error_envelope();
+        assert_eq!(env.error.code, ErrorCode::Internal);
+        assert!(!env.error.retryable);
+        assert!(env.error.next_step.is_none());
+        assert!(env.error.candidates.is_empty());
+        assert_eq!(
+            env.error.message,
+            "Embedding count mismatch: expected 5, got 4"
         );
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -31,6 +31,16 @@ fn sae_command(home: &Path) -> Command {
     cmd
 }
 
+/// Extracts the first parseable JSON line from `stderr`. Mirror of the
+/// envelope-rendering contract: `--json` failures emit one JSON line on
+/// stderr. Panics on missing JSON to give a readable failure message.
+fn parse_stderr_envelope(stderr: &str) -> serde_json::Value {
+    stderr
+        .lines()
+        .find_map(|line| serde_json::from_str(line).ok())
+        .unwrap_or_else(|| panic!("no JSON line on stderr; got: {stderr}"))
+}
+
 // T-CI001: `sae --json` (missing subcommand) → JSON UsageError envelope on stderr
 #[test]
 fn missing_subcommand_with_json_emits_usage_envelope() {
@@ -42,10 +52,7 @@ fn missing_subcommand_with_json_emits_usage_envelope() {
 
     assert!(!output.status.success(), "should exit non-zero");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let env: serde_json::Value = stderr
-        .lines()
-        .find_map(|line| serde_json::from_str(line).ok())
-        .unwrap_or_else(|| panic!("no JSON line on stderr; got: {stderr}"));
+    let env = parse_stderr_envelope(&stderr);
     assert_eq!(env["error"]["code"], "USAGE_ERROR");
     assert!(
         env["error"]["message"].is_string(),
@@ -138,10 +145,7 @@ fn malformed_date_with_json_emits_data_error_envelope() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let env: serde_json::Value = stderr
-        .lines()
-        .find_map(|line| serde_json::from_str(line).ok())
-        .unwrap_or_else(|| panic!("no JSON line on stderr; got: {stderr}"));
+    let env = parse_stderr_envelope(&stderr);
     assert_eq!(env["error"]["code"], "DATA_ERROR");
     assert_eq!(env["error"]["retryable"], false);
     let message = env["error"]["message"]
@@ -150,5 +154,119 @@ fn malformed_date_with_json_emits_data_error_envelope() {
     assert!(
         message.contains("Invalid date"),
         "message must describe the date parse failure; got: {message}"
+    );
+}
+
+// T-CI006: synthetic UNKNOWN path exits 104 (UNKNOWN) with
+// `error.code = "UNKNOWN"`. Pins the process-boundary contract for
+// `SaeError::Other` per ADR-0066 L136 (#127 OPS-005). The hidden
+// `__test_force_unknown` subcommand is the only hermetic UNKNOWN trigger;
+// production sites (MLX backend, opaque embedder errors, model cache check)
+// require real hardware / network state we cannot stage in tests.
+#[cfg(feature = "test-support")]
+#[test]
+fn force_unknown_with_json_emits_unknown_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "__test_force_unknown"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(104),
+        "exit code must be 104 (UNKNOWN); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(env["error"]["code"], "UNKNOWN");
+    assert_eq!(env["error"]["retryable"], false);
+    assert!(
+        env["error"]["message"].is_string(),
+        "error.message must be present"
+    );
+}
+
+// T-CI007: synthetic BackendUnavailable path exits 70 (INTERNAL) with
+// `error.code = "INTERNAL"`. Pins the BREAKING `104 → 70` routing for the
+// MLX backend missing path (#127 CHX-001) at the process boundary, mirroring
+// T-CI005's role for DATA_ERROR. Without this pin, the contract only lives in
+// unit tests (T-338 / T-342) and could regress silently across the
+// `error_code()` → `exit_code()` → process exit translation layers.
+#[cfg(feature = "test-support")]
+#[test]
+fn force_backend_unavailable_with_json_emits_internal_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "__test_force_backend_unavailable"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(70),
+        "exit code must be 70 (INTERNAL); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(env["error"]["code"], "INTERNAL");
+    assert_eq!(env["error"]["retryable"], false);
+    assert_eq!(env["error"]["message"], "MLX backend is unavailable");
+    // Exact-equality assertion mirrors T-340 unit test so the wire-level hint
+    // and the in-process hint cannot drift independently. T-340 / T-344 pin
+    // the source-side const; this anchors the binary-boundary surface to the
+    // same literal.
+    assert_eq!(
+        env["error"]["next_step"],
+        "Install the MLX backend (Apple Silicon required), or pass `--no-embed` for FTS-only search."
+    );
+    // `candidates` must be present and empty in the envelope (matches the
+    // `to_error_envelope` composition pinned by T-342).
+    assert!(
+        env["error"].get("candidates").is_none()
+            || env["error"]["candidates"]
+                .as_array()
+                .is_some_and(Vec::is_empty),
+        "candidates must be absent or empty array; got: {}",
+        env["error"]["candidates"]
+    );
+}
+
+// T-CI008: synthetic Internal path exits 70 (INTERNAL) with
+// `error.code = "INTERNAL"`. Pins the `SaeError::Internal` routing at the
+// process boundary, parallel to T-CI007 for `BackendUnavailable` (#127
+// CHX-001 audit follow-up). Without this pin, the `Internal` ↔ `Other` split
+// (70 vs 104) only lives in unit tests (T-339 / T-343) and could regress
+// silently across the `error_code()` → `exit_code()` → process exit chain.
+#[cfg(feature = "test-support")]
+#[test]
+fn force_internal_with_json_emits_internal_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "__test_force_internal"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(70),
+        "exit code must be 70 (INTERNAL); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(env["error"]["code"], "INTERNAL");
+    assert_eq!(env["error"]["retryable"], false);
+    // Internal variant returns no canned next_step (T-341 pins this).
+    assert!(
+        env["error"].get("next_step").is_none() || env["error"]["next_step"].is_null(),
+        "next_step must be absent for Internal; got: {}",
+        env["error"]["next_step"]
+    );
+    assert!(
+        env["error"]["message"].is_string(),
+        "error.message must be present"
     );
 }


### PR DESCRIPTION
## 何を / なぜ

#126 で `SaeError::Other` (catch-all) を 70 → 104 に動かした際、分類済みの 2 種類の失敗（MLX backend 不在 / embedder invariant 違反）も巻き込まれて 104 に流れていた。これらは `sae model download` 側と routing を揃えて 70 (INTERNAL) に固定したい。agent retry policy が `error.code` (`INTERNAL` か `UNKNOWN`) で「環境問題」と「分類不能」を一貫して分岐できるようにする。

## 変更内容

- `SaeError::BackendUnavailable` / `SaeError::Internal(String)` を追加。両方とも `ErrorCode::Internal` (70) に routing
- `BACKEND_UNAVAILABLE_HINT` 定数を抽出し、`ModelDownload(BackendUnavailable)` と `BackendUnavailable` の両 arm で共有
- `test-support` feature 下に 3 つの hidden subcommand を追加: `__test_force_unknown` / `__test_force_backend_unavailable` / `__test_force_internal`
- `tests/cli_integration.rs` に `parse_stderr_envelope()` helper + T-CI006/007/008 を追加（binary-boundary で 104/70 envelope を pin）
- T-CI007 の assertion を substring → exact equality に強化（T-340 unit test と同精度）
- CI に `cargo nextest run --features test-support` step を追加（feature なしの default step では T-CI006/007/008 が skip されるため）
- 残存 5 箇所の `SaeError::Other` 構築サイトにインライン文書化（なぜ Other のままか / 上流の typed surface 候補）
- CHANGELOG / README に **net 状態** 節を追加: #126 と #127 の組み合わせで agent が `error.code` で分岐すれば両変更を吸収できる旨

## スコープ

- **含まれない**: 残存 5 箇所の `Other` 自体の typed 化（amici 側の `ProbeError` 拡張 / embedder error の上流 typed surface が必要、別 issue 候補）

## 設計判断

- **新 variant 追加 vs Other を分割**: `SaeError` は `#[non_exhaustive]` 化済みのため variant 追加は非破壊。downstream の pattern match 影響もゼロ
- **test seam を hidden subcommand に**: `test-support` feature gate で `cargo install` の production binary には含まれない。`#[command(hide = true)]` で `--help` にも出ない
- **`KNOWN_SUBCOMMANDS` には test seam を unconditional に列挙**: 列挙しないと shorthand expander が `sae __test_force_unknown` を `sae search __test_force_unknown` に rewrite する。production binary で test seam は実在しないが、shorthand 経路は塞いでおく
- **`BACKEND_UNAVAILABLE_HINT` を const 抽出**: 同じ hint 文字列が production arm + unit test 2 箇所に重複していたため

## 検証方法

1. `cargo nextest run` → 既存 329 テストが pass する
2. `cargo nextest run --features test-support` → T-CI006/007/008 (104/70/70 envelope pin) が pass する
3. `cargo clippy --all-targets --all-features -- -D warnings` → warning 0
4. `cargo fmt -- --check` → diff 0

## 関連

- Closes #127
- Follows #126 (ADR-0066 Group 2 baseline)
- Audit snapshot: `audit-2026-05-16-125136.json` (Ready / trust_score 88)