### PR TITLE
READMEを実コード (--help / config / envelope) に整列

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,30 @@ export ESA_ACCESS_TOKEN="your-token"
 ### 投稿の取得・検索
 
 ```bash
-# チームの投稿をインデックス（増分）
+# チームの投稿をインデックス（増分。旧 `sae harvest myteam` は v0.3.0 で廃止）
 sae index myteam
 
-# 全件再構築（差分追従が破綻したときなど）
+# 全件再構築（差分追従が破綻したときなど。旧 `sae harvest myteam --full` 相当）
 sae rebuild myteam
 
-# 検索（shorthand）
+# 検索（shorthand: 既知サブコマンド以外の単一 positional は `sae search` に展開され、stderr に `→ sae search ...` のヒントが出る）
 sae "認証"
 
 # オプション付き検索
 sae search "認証" --team myteam --limit 5
 
+# 期間フィルタ（YYYY-MM-DD、updated 基準）
+sae search "認証" --after 2025-01-01 --before 2025-06-30
+
+# stdin から query を読む（pipe / 明示 `-`）
+echo "認証" | sae search
+sae search - < query.txt
+
 # 投稿を取得
 sae get 42
 ```
+
+`--team` を省略した場合は `default_team` → 設定済みチームが1つだけならそれ → どちらでもなければ `USAGE_ERROR` (64) の順で解決される。`index` / `rebuild` / `embed` だけは team が必須 positional。
 
 ### 投稿の作成・更新
 
@@ -62,7 +71,11 @@ sae create --name "タイトル" --body-file draft.md
 # stdin から読み込み
 cat body.md | sae create --name "タイトル" --body-file -
 
-# 更新
+# カテゴリ / タグ / WIP（`--tag` は繰り返し指定で複数）
+sae create --name "タイトル" --body "本文" \
+  --category "design/notes" --tag rfc --tag draft --wip
+
+# 更新（create と同じ content flag が使える。`--tag` は既存タグを置き換え）
 sae update 42 --name "新タイトル"
 
 # アーカイブ / Ship
@@ -73,18 +86,20 @@ sae ship 42
 ### エージェント向け機能
 
 ```bash
-# JSON 出力（全コマンド共通）
+# JSON 出力（global flag、位置自由）
 sae --json search "認証"
 sae --json get 42
 sae --json status
 
-# get の JSON は body_md を省略（--with-body で含める）
+# get の JSON は body_md を省略（--with-body で含める。`--json` 無しでは無視）
 sae --json get 42 --with-body
 
 # dry-run（API を呼ばずにプレビュー）
 sae create --name "タイトル" --body "本文" --dry-run
 sae archive 42 --dry-run
 ```
+
+`--json` 成功 envelope は `{"data": ..., "degraded": bool, "notes": [...]}`。embedder のロード失敗で FTS にフォールバックした場合は `degraded=true` + `notes=["semantic search unavailable, falling back to FTS"]` を返す。意図的な `--no-embed` は `degraded=false` のまま。
 
 ### セマンティック検索
 
@@ -100,12 +115,16 @@ sae search "認証フローの設計方針"
 
 # embedder のロードコストを避けて FTS のみで検索（CI / スクリプト用途）
 sae search "認証" --no-embed
+
+# reranker を有効化（モデル別途キャッシュ必要）
+SAE_RERANK=1 sae search "認証フローの設計方針"
 ```
 
 ### 同期状態の確認
 
 ```bash
-sae status
+sae status                    # 全チーム
+sae status --team myteam      # 単独
 sae --json status
 ```
 


### PR DESCRIPTION
## 概要と背景

`sae` の README を実コード (`--help` / `config.rs` / `envelope.rs` / `CHANGELOG`) に整列させ、既存 Exit code テーブルが `--after` / `--before` を例示しているのに usage に登場していない等の不整合を解消する。

`--help` 出力は確認の結果、過不足なく正確だったため変更しない（README のみ更新）。

## 変更点

- `sae search --after` / `--before` の使い方を追加（既存 Exit code テーブルで言及されていたのに usage が無かった正確性 fix）
- `sae search` の stdin 入力 (pipe / `-`)、shorthand `sae "認証"` 展開時の `→ sae search ...` stderr hint を明記
- `--team` 省略時の解決順序 (`default_team` → 単一 team → `USAGE_ERROR` 64) と必須 positional 例外 (`index` / `rebuild` / `embed`) を追記
- `create` / `update` に `--category` / `--tag` (繰り返し指定) / `--wip` を追加。update は「create と同じ content flag が使え、`--tag` は既存タグを置換」と注記
- `--with-body` の「`--json` 無しでは無視」を明示
- `--json` 成功 envelope の `degraded` / `notes` フォールバック (embedder ロード失敗時の FTS フォールバック) を追記
- `SAE_RERANK=1` 環境変数 (reranker トグル) を追加
- 旧 `sae harvest` の v0.3.0 廃止注記 (CHANGELOG `Unreleased` と整合)
- `sae status` の単独 / 全チーム表示の使い分け

## 範囲

- **含めない**: `embed_budget` config キー (実コードでパースされるだけで未使用、書くと罠になるため意図的に除外)
- **含めない**: `--help` テキスト本体の変更 (既に正確と確認)

## 設計判断

- README を `--help` のクローンにしない方針: `--help` で見える挙動は簡潔に触れ、shorthand 展開・`--team` 解決順序・envelope `degraded` / `notes` 等の `--help` から見えない cross-cutting な挙動を README 側に集約
- `embed_budget` は未使用だが書かない: dead config key の罠を避ける

## 動作確認手順

1. `sae --help` および各サブコマンド `--help` を見て、README に登場する全フラグ (`--after` / `--before` / `--no-embed` / `--with-body` / `--category` / `--tag` / `--wip` / `--dry-run` / `--team` / `--limit` / `--name` / `--body` / `--body-file` / `--json`) が見つかること
2. `sae "認証"` を実行し、stderr に `→ sae search 認証` のヒントが出ること
3. `sae search "認証" --after 2025-01-01 --before 2025-06-30` が日付フィルタ付きで動作すること
4. `SAE_RERANK=1 sae search "..."` で reranker が有効化されること (モデルキャッシュがある環境)