### PR TITLE
zizmor アラート解消 (dependabot cooldown + version-pin コメント)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - ci
@@ -15,6 +17,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: cargo check
 
       - name: Install nextest
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Parse bug.yml
         id: parse-bug
-        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3.2.5
         with:
           template-path: .github/ISSUE_TEMPLATE/bug.yml
         continue-on-error: true
@@ -37,7 +37,7 @@ jobs:
 
       - name: Parse feature.yml
         id: parse-feature
-        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3.2.5
         with:
           template-path: .github/ISSUE_TEMPLATE/feature.yml
         continue-on-error: true


### PR DESCRIPTION
## 概要と背景

main 上で zizmor が報告していた 3 件の Code scanning アラート (#1 / #2 / #3) を解消する。いずれも `warning` レベルで、対症療法 (`ignore` 設定) ではなく根本対応（cooldown 追加 + 正しい version-pin コメント）で対処。

## 変更点

- **`zizmor/dependabot-cooldown` (#1, #2)** — `.github/dependabot.yml` の `github-actions` / `cargo` 両 ecosystem に `cooldown: { default-days: 7 }` を追加。Dependabot は新リリースを取り込むまで 7 日間待機する
- **`zizmor/ref-version-mismatch` (#3)** — `.github/workflows/ci.yml:38` の `taiki-e/install-action` SHA は v2.78.1 を指すため、bare-major `# v2` を `# v2.78.1` に修正
- **予防修正** — `.github/workflows/label-from-issue.yml` の `stefanbuck/github-issue-parser # v3` × 2 (SHA は v3.2.5) も同類の bare-major パターン。現在の zizmor 1.24.1 は flag していないが将来の rule 更新で再発する可能性が高いため `# v3.2.5` に修正

## 設計判断

- **cooldown 値は両 ecosystem 同値 (`default-days: 7`)**: semver 階層 (major/minor/patch) で差をつけることも検討したが、(a) 25 リポへの横展開で同じ rationale を繰り返すコストの方が、非対称値の限界的安全性より大きい (b) CI に `cargo audit` / `cargo deny` が既にあり cooldown による脆弱性パッチ遅延の懸念は緩和される (c) cargo 側の `groups: patch-and-minor` で週次バッチ化されているため 7 日 cooldown による cadence 影響は最小
- **対症療法ではなく根本対応**: `zizmor.yml` に `ignore` 設定を追加する選択肢もあったが、playbook の方針「ignore はリポ固有の正当化があるときだけ追加」に沿って根本対応を選択

## 範囲

- **含めない**: 他リポ (yomu / recall / scout / guardrails / rurico / amici) への同様の cooldown 追加と version-pin 修正。同じ問題を抱えているが横展開は別 PR とする
- **含めない**: zizmor が現在 flag していない `auditor` persona 観点の 11 件 (suppressed) の対処。playbook 通り default persona のみで完了条件を満たす

## 動作確認手順

1. ローカル `zizmor .github/workflows/ .github/dependabot.yml` で `No findings to report` を確認 (zizmor 1.25.2)
2. PR の zizmor CI ジョブが green になること
3. main マージ後、Code scanning アラート #1 / #2 / #3 が auto-close されること (zizmor は次回スキャンで自動的に fixed に遷移)

## 関連

- Code scanning alerts: #1 / #2 / #3
- Playbook: `project_zizmor_baseline_playbook.md` (本 PR の知見を反映予定)