### PR TITLE
amici / rurico の rev を最新 main に追従

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=2ffe963#2ffe963b13047635f407ea396991c0d3b98b5a74"
+source = "git+https://github.com/thkt/amici?rev=584afdd#584afdd21e5976428c0ef7aa5ae17aae5551bbf8"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -716,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1352,7 +1352,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1727,7 +1727,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
+source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
+source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2386,7 +2386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2445,7 +2445,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2672,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2826,7 +2826,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3499,7 +3499,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "2ffe963" }
+amici = { git = "https://github.com/thkt/amici", rev = "584afdd" }
 bytemuck = "1"
 clap = { version = "4.6", features = ["derive"] }
 jiff = "0.2"
 reqwest = { version = "0.13", features = ["json"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "bd637c2" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "087dc4a" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "bd637c2", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "087dc4a", features = ["test-support"] }
 tempfile = "3"
 wiremock = "0.6"
 


### PR DESCRIPTION
## What & Why

amici と rurico の rev を最新 main に追従。両者の Dependabot cooldown 追加 / install-action SHA pin 同期 / zizmor-action bump など CI supply-chain 整備を sae に取り込む。

## Changes

- `amici`: `2ffe963` → `584afdd` (10 commits, CI/Dependabot 整備のみ)
- `rurico`: `bd637c2` → `087dc4a` (11 commits, CI/Dependabot 整備のみ)
- `Cargo.lock` を `cargo update -p amici -p rurico` で再生成

## Design Decisions

- amici #107 が rurico `087dc4a` を追従済みのため、依存グラフ衝突 (`project_sae_121_122_migration_playbook` 記載の amici/rurico rev 不整合) は発生せず。`[patch]` を導入せず通常の `rev` 更新で完結

## How to Test

1. `cargo check --all-targets` でビルド成功
2. `cargo nextest run --profile ci` で 326 tests PASS
3. `cargo clippy --all-targets --all-features -- -D warnings` で warning ゼロ
4. `cargo fmt -- --check` で差分なし

## Related

- amici #107 (rurico 087dc4a 追従の merge)
- rurico #182 (install-action SHA pin v2.78.2)
