### PR TITLE
chore(deps): amici と rurico の rev を更新 (584afdd→2b54c72 / 087dc4a→bb25a06)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=584afdd#584afdd21e5976428c0ef7aa5ae17aae5551bbf8"
+source = "git+https://github.com/thkt/amici?rev=2b54c72#2b54c728f745a88794a7b9084b06d4b7723158af"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -716,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1352,7 +1352,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1727,7 +1727,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
+source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
+source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2386,7 +2386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2445,7 +2445,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2672,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2826,7 +2826,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3499,7 +3499,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ license = "MIT"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "584afdd" }
+amici = { git = "https://github.com/thkt/amici", rev = "2b54c72" }
 bytemuck = "1"
 clap = { version = "4.6", features = ["derive"] }
 jiff = "0.2"
 reqwest = { version = "0.13", features = ["json"] }
-rurico = { git = "https://github.com/thkt/rurico", rev = "087dc4a" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "087dc4a", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06", features = ["test-support"] }
 tempfile = "3"
 wiremock = "0.6"
 


### PR DESCRIPTION
## 概要
- amici: `584afdd` → `2b54c72` — openssl 0.10.80 への transitive bump と rurico bump の取り込み
- rurico: `087dc4a` → `bb25a06` — openssl 0.10.79 → 0.10.80 / openssl-sys 0.9.115 → 0.9.116
- API 変更なし、純粋な transitive dependency bump

## 動作確認
- [x] `cargo nextest run --all-features` — 333 tests passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean