### PR TITLE
chore(deps): openssl の transitive bump (0.10.79 → 0.10.80 / openssl-sys 0.9.115 → 0.9.116)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1853,9 +1853,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## 概要
- openssl: `0.10.79` → `0.10.80`
- openssl-sys: `0.9.115` → `0.9.116`
- API 変更なし、純粋な transitive dependency bump (`Cargo.lock` のみ)

## 動作確認
- [x] `cargo nextest run --profile ci` — 330 tests passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — 差分なし