### PR TITLE
fix(client): esa 404 を DATA_ERROR に振り分け

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     両変更を吸収できる。
   - 移行: backend missing / embedder invariant 違反で `UNKNOWN` を branch して
     いたスクリプト・agent retry policy は `INTERNAL` を見るように更新する。
+- **BREAKING**: esa API が 404 (post not found) を返した場合の exit code が
+  `70` (INTERNAL) から `65` (DATA_ERROR) に変化 (#136)。`--json` の
+  `error.code` も `"INTERNAL"` → `"DATA_ERROR"`、`next_step` に「Verify the
+  post number exists in esa, or run \`sae search <keyword>\` to find it.」
+  ヒントが追加される。`sae get` / `sae update` / `sae archive` / `sae ship`
+  に存在しない post 番号を渡したケースを、サーバ起因の 5xx と判別可能にする。
+  - **net 状態** (#126 / #127 routing との関係): 404 (入力データ起因) は
+    65 へ、404 以外の HTTP error (4xx 401/403/422 や 5xx) は引き続き 70。
+    agent retry policy は `error.code` で分岐すれば、入力ミスは「該当 post
+    の番号を確認」、5xx は「リトライ」と判別できる。
+  - 移行: 「post 番号間違い → INTERNAL (70)」を branch していたスクリプト
+    は `DATA_ERROR` (65) を見るように更新する。`error.code` で分岐していれば
+    変更は自動吸収される。
+- 公開 API: `ClientError::Api(String)` を `ClientError::Api { status: u16,
+  body: String }` に変更し、HTTP status を保持できるようにする。あわせて
+  URL parse / token format error 用の `ClientError::InvalidRequest(String)`
+  variant を追加。`ClientError` には `#[non_exhaustive]` を付与し、以後の
+  variant 追加は非破壊。`ClientError::Api` を pattern match で参照していた
+  downstream crate (sae crate 内 0 件) はコンパイルエラーになる。
 
 ### Added
 
@@ -79,6 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   を追加 (`#[command(hide = true)]`)。`tests/cli_integration.rs::T-CI006`
   で UNKNOWN (104) envelope を hermetic に pin する (#127 OPS-005)。
   `cargo install` で配布される production binary には含まれない。
+- `[features] test-support` 下に hidden `__test_force_client_api_404`
+  subcommand を追加。`tests/cli_integration.rs::T-CI009` で esa-404 →
+  DATA_ERROR (65) routing を binary-boundary で pin する (#136)。
 
 ## [0.2.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ sysexits.h の symbolic name (`EX_USAGE`, `EX_SOFTWARE` 等) は数値の出典�
 | ---- | -------------- | ---------------- | -------------------------------------------------------- | ----------- |
 | 0    | (none)         | 正常終了         |                                                          |             |
 | 64   | USAGE_ERROR    | 入力エラー       | 不明なチーム、トークン未設定、未 index 実行              | しない      |
-| 65   | DATA_ERROR     | データ形式不正   | `--after` / `--before` の日付形式不正 (`YYYY-MM-DD` 以外) | しない      |
-| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、HTTP 4xx (API)、MLX backend 不在 (`sae embed` / `sae model download` 共通)、model download 検証失敗 (`ModelDownloadError::ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected)、embedder invariant 違反 (例: batch count mismatch) | しない      |
+| 65   | DATA_ERROR     | データ形式不正   | `--after` / `--before` の日付形式不正 (`YYYY-MM-DD` 以外)、esa API 404 (指定 post 番号がチームに存在しない) | しない      |
+| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、esa API の 404 以外の HTTP エラー (5xx および 401/403/422 等の 4xx)、MLX backend 不在 (`sae embed` / `sae model download` 共通)、model download 検証失敗 (`ModelDownloadError::ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected)、embedder invariant 違反 (例: batch count mismatch) | しない      |
 | 73   | CANT_CREAT     | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
 | 74   | IO_ERROR       | I/O エラー       | ファイル読み書き失敗、`ProbeError::SubprocessFailed`     | 状況による  |
 | 75   | TEMP_FAILURE   | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout) | する  |
@@ -156,6 +156,8 @@ sysexits.h の symbolic name (`EX_USAGE`, `EX_SOFTWARE` 等) は数値の出典�
 > ⚠️ 破壊的変更（issue #126 / ADR-0066 Group 2 baseline）: 日付形式不正が 64 → 65、catch-all (`SaeError::Other`) が 70 → 104 に変化。`--json` の `error.code` も同様に `USAGE_ERROR` → `DATA_ERROR`、`INTERNAL` → `UNKNOWN`。
 
 > ⚠️ 破壊的変更（issue #127 / `SaeError::Other` routing audit）: #126 で catch-all が 70 → 104 に動いた一方、以下の 2 種の失敗は **70 (INTERNAL) に分類される** — `sae embed` / `sae search` での MLX backend 不在 (`SaeError::BackendUnavailable`)、`sae embed` / `sae search` での embedder invariant 違反 (`SaeError::Internal`、例: batch count mismatch)。`sae model download` 側 (既に 70) と routing を揃え、agent が「ハードウェア / 環境不一致 or プログラム不変条件違反」シグナルとして検知できるようにする。**net 状態**: agent retry policy は `error.code` (= `"INTERNAL"` か `"UNKNOWN"`) で分岐すれば #126 / #127 双方の変更を吸収できる。
+
+> ⚠️ 破壊的変更（issue #136 / esa API 404 reclassify）: esa API が 404 (post not found) を返したときの exit code が `70` → `65`、`--json` の `error.code` が `"INTERNAL"` → `"DATA_ERROR"` に変化。`next_step` に「Verify the post number exists in esa, or run `sae search <keyword>` to find it.」が付くため、agent が「入力 post 番号間違い」と「サーバ起因 5xx」を判別できる。**net 状態**: 404 (入力データ起因) は 65、404 以外の HTTP error (5xx および 401/403/422 等) は 70 のまま。`error.code` で分岐していれば変更は自動吸収される。
 
 ## ログ
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,12 +102,22 @@ struct UpdatePostBody {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ClientError {
     #[error("ESA_ACCESS_TOKEN not set")]
     TokenNotSet,
 
-    #[error("esa API error: {0}")]
-    Api(String),
+    /// HTTP non-success response from esa API. `status` is preserved so
+    /// downstream classification can split client-side (4xx, e.g. 404 →
+    /// DATA_ERROR) from server-side (5xx → INTERNAL) per #136.
+    #[error("esa API error: HTTP {status}: {body}")]
+    Api { status: u16, body: String },
+
+    /// Pre-call request construction failure (URL parse, malformed token
+    /// header). Distinct from `Api` because no HTTP exchange occurred —
+    /// these are program-detectable bugs and route to INTERNAL (70).
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
 
     #[error("Network error: {0}")]
     Network(#[from] reqwest::Error),
@@ -235,7 +245,8 @@ impl EsaClient {
 
     fn build_url(&self, path: &str) -> Result<reqwest::Url, ClientError> {
         let raw = format!("{}/{path}", self.base_url);
-        reqwest::Url::parse(&raw).map_err(|e| ClientError::Api(format!("invalid URL '{raw}': {e}")))
+        reqwest::Url::parse(&raw)
+            .map_err(|e| ClientError::InvalidRequest(format!("invalid URL '{raw}': {e}")))
     }
 
     async fn throttle(&self) {
@@ -255,7 +266,7 @@ impl EsaClient {
 
     fn auth_header(&self) -> Result<HeaderValue, ClientError> {
         let mut v = HeaderValue::from_str(&format!("Bearer {}", self.token))
-            .map_err(|_| ClientError::Api("invalid token format".into()))?;
+            .map_err(|_| ClientError::InvalidRequest("invalid token format".into()))?;
         v.set_sensitive(true);
         Ok(v)
     }
@@ -298,10 +309,10 @@ impl EsaClient {
                 None => {
                     let text = resp.text().await.unwrap_or_default();
                     let safe = redact_token(&text, &self.token);
-                    return Err(ClientError::Api(format!(
-                        "HTTP {status}: {}",
-                        truncate_str(&safe, 500)
-                    )));
+                    return Err(ClientError::Api {
+                        status,
+                        body: truncate_str(&safe, 500).to_owned(),
+                    });
                 }
             }
         }
@@ -464,6 +475,9 @@ mod tests {
         assert_eq!(post.name, "Getting Started");
     }
 
+    // T-345: get_post on 404 returns ClientError::Api with status=404 preserved
+    // so downstream routing (SaeError::error_code) can split 404 → DATA_ERROR
+    // from non-404 → INTERNAL per #136.
     #[tokio::test]
     async fn api_error_returns_client_error() {
         let server = MockServer::start().await;
@@ -481,7 +495,11 @@ mod tests {
             .get_post("myteam", 999)
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("404"));
+        assert!(
+            matches!(err, ClientError::Api { status: 404, .. }),
+            "expected Api {{ status: 404, .. }}, got: {err:?}"
+        );
+        assert!(err.to_string().contains("HTTP 404"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use amici::cli::exit_code::{CliError, codes};
 use amici::cli::{exit_error, hint_arrow, try_expand_shorthand};
 use amici::logging::init_subscriber;
 use clap::{Parser, Subcommand};
+#[cfg(feature = "test-support")]
+use sae::client::ClientError;
 use sae::config::Config;
 use sae::io::write_output;
 use sae::tools::{CreateArgs, Sae, SaeError, SearchArgs, UpdateArgs};
@@ -178,6 +180,14 @@ Examples:
     #[cfg(feature = "test-support")]
     #[command(name = "__test_force_internal", hide = true)]
     TestForceInternal,
+    /// Hidden test seam: force a `ClientError::Api { status: 404, .. }` so
+    /// `tests/cli_integration.rs` can pin the DATA_ERROR (65) envelope at the
+    /// process boundary for the esa-404 routing (#136). `test-support`
+    /// feature only — the production binary built with `cargo install` never
+    /// carries this variant.
+    #[cfg(feature = "test-support")]
+    #[command(name = "__test_force_client_api_404", hide = true)]
+    TestForceClientApi404,
 }
 
 #[derive(Debug, Subcommand)]
@@ -208,6 +218,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "__test_force_unknown",
     "__test_force_backend_unavailable",
     "__test_force_internal",
+    "__test_force_client_api_404",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
@@ -280,6 +291,11 @@ async fn run(cli: Cli, config: Config) -> Result<CommandOutput, SaeError> {
         Command::TestForceInternal => Err(SaeError::Internal(
             "synthetic INTERNAL for cli_integration test (test-support feature)".to_owned(),
         )),
+        #[cfg(feature = "test-support")]
+        Command::TestForceClientApi404 => Err(SaeError::Client(ClientError::Api {
+            status: 404,
+            body: r#"{"error":"not_found","message":"Not Found"}"#.to_owned(),
+        })),
         Command::Model { .. } => unreachable!("handled before Sae::new()"),
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -102,7 +102,7 @@ pub async fn harvest(
 
         let resp = match client.list_posts(team, page, query.as_deref()).await {
             Ok(r) => r,
-            Err(ClientError::Api(ref msg)) if is_pagination_limit(msg) => {
+            Err(ClientError::Api { ref body, .. }) if is_pagination_limit(body) => {
                 if let Some(ref oldest) = batch_oldest_ts {
                     if window_boundary.as_ref() == Some(oldest) {
                         progress_step(&["window didn't advance, stopping"]);

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -353,6 +353,14 @@ const MODEL_NOT_FOUND_PREFIX: &str = "Model not found";
 const BACKEND_UNAVAILABLE_HINT: &str =
     "Install the MLX backend (Apple Silicon required), or pass `--no-embed` for FTS-only search.";
 
+/// Shared `next_step` hint for `ClientError::Api { status: 404, .. }`
+/// (post-not-found path). Centralised so the production arm and unit tests
+/// cannot drift. The integration test (`tests/cli_integration.rs::T-CI009`)
+/// intentionally keeps an exact-string literal: it asserts the binary-boundary
+/// surface, not the in-process surface (#136).
+const POST_NOT_FOUND_HINT: &str =
+    "Verify the post number exists in esa, or run `sae search <keyword>` to find it.";
+
 impl SaeError {
     pub(crate) fn input_no_data_for_team(team: &str) -> Self {
         Self::InputUsage(format!(
@@ -374,9 +382,18 @@ impl SaeError {
             Self::Client(ClientError::TokenNotSet)
             | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => ErrorCode::UsageError,
             Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => ErrorCode::CantCreat,
+            // esa API 404 is an input failure (the post number does not exist
+            // in the team), not a server-side fault. Route to DATA_ERROR (65)
+            // so AI agents distinguish missing inputs from 5xx INTERNAL (#136).
+            Self::Client(ClientError::Api { status: 404, .. })
+            | Self::Sync(SyncError::Client(ClientError::Api { status: 404, .. })) => {
+                ErrorCode::DataError
+            }
             Self::Json(_)
-            | Self::Client(ClientError::Api(_))
-            | Self::Sync(SyncError::Client(ClientError::Api(_))) => ErrorCode::Internal,
+            | Self::Client(ClientError::Api { .. } | ClientError::InvalidRequest(_))
+            | Self::Sync(SyncError::Client(
+                ClientError::Api { .. } | ClientError::InvalidRequest(_),
+            )) => ErrorCode::Internal,
             Self::Client(ClientError::Network(e))
             | Self::Sync(SyncError::Client(ClientError::Network(e)))
                 if e.is_decode() =>
@@ -429,6 +446,13 @@ impl SaeError {
             Self::Client(ClientError::TokenNotSet)
             | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => {
                 Some("Set `ESA_ACCESS_TOKEN=<token>` and retry.")
+            }
+            // esa API 404: the requested post number does not exist in the
+            // team. Pairs with the DATA_ERROR routing in `error_code()` (#136)
+            // so agents see both a 65 exit code and a recovery hint.
+            Self::Client(ClientError::Api { status: 404, .. })
+            | Self::Sync(SyncError::Client(ClientError::Api { status: 404, .. })) => {
+                Some(POST_NOT_FOUND_HINT)
             }
             // Direct API commands (get/create/update/archive/ship) bubble
             // ClientError::MaxRetries as Self::Client(_); the index/rebuild
@@ -647,11 +671,40 @@ mod tests {
         );
     }
 
-    // T-245: Client(Api) maps to INTERNAL (sysexits 70) — non-retryable HTTP 4xx
+    // T-245: Client(Api) with non-404 status maps to INTERNAL (sysexits 70)
+    // — non-retryable HTTP error from the esa API (5xx, 4xx other than 404).
     #[test]
     fn exit_code_client_api_is_internal() {
         assert_code(
-            &SaeError::Client(ClientError::Api("404 Not Found".into())),
+            &SaeError::Client(ClientError::Api {
+                status: 500,
+                body: "Internal Server Error".into(),
+            }),
+            codes::INTERNAL,
+        );
+    }
+
+    // T-346: Client(Api { status: 404 }) maps to DATA_ERROR (sysexits 65)
+    // — input-side failure (post number does not exist in the team), distinct
+    // from server-side 5xx per #136.
+    #[test]
+    fn exit_code_client_api_404_is_data_error() {
+        assert_code(
+            &SaeError::Client(ClientError::Api {
+                status: 404,
+                body: r#"{"error":"not_found","message":"Not Found"}"#.into(),
+            }),
+            codes::DATA_ERROR,
+        );
+    }
+
+    // T-347: Client(InvalidRequest) maps to INTERNAL (sysexits 70) — pre-call
+    // request construction failure (URL parse, bad token header), a
+    // program-detectable bug, not user input.
+    #[test]
+    fn exit_code_client_invalid_request_is_internal() {
+        assert_code(
+            &SaeError::Client(ClientError::InvalidRequest("invalid URL".into())),
             codes::INTERNAL,
         );
     }
@@ -703,12 +756,30 @@ mod tests {
         );
     }
 
-    // T-248: Sync(Client(Api)) maps to INTERNAL (sysexits 70) — non-retryable HTTP 4xx
+    // T-248: Sync(Client(Api)) with non-404 status maps to INTERNAL (sysexits 70)
+    // — index/rebuild path mirrors the direct-call routing of T-245.
     #[test]
     fn exit_code_sync_client_api_is_internal() {
         assert_code(
-            &SaeError::Sync(SyncError::Client(ClientError::Api("404 Not Found".into()))),
+            &SaeError::Sync(SyncError::Client(ClientError::Api {
+                status: 503,
+                body: "Service Unavailable".into(),
+            })),
             codes::INTERNAL,
+        );
+    }
+
+    // T-348: Sync(Client(Api { status: 404 })) maps to DATA_ERROR (sysexits 65)
+    // — index/rebuild path mirrors T-346 so the 404 routing is symmetric across
+    // direct API commands and bulk sync.
+    #[test]
+    fn exit_code_sync_client_api_404_is_data_error() {
+        assert_code(
+            &SaeError::Sync(SyncError::Client(ClientError::Api {
+                status: 404,
+                body: r#"{"error":"not_found","message":"Not Found"}"#.into(),
+            })),
+            codes::DATA_ERROR,
         );
     }
 
@@ -1121,6 +1192,64 @@ mod tests {
         assert_eq!(
             env.error.message,
             "Embedding count mismatch: expected 5, got 4"
+        );
+    }
+
+    // T-349: next_step for Client(Api { status: 404 }) returns the post-not-found
+    // hint so AI agents recover from missing post numbers (#136). Mirrors T-340
+    // (BackendUnavailable) — the hint surface and the routing surface must
+    // agree at the source.
+    #[test]
+    fn next_step_client_api_404_returns_post_not_found_hint() {
+        let err = SaeError::Client(ClientError::Api {
+            status: 404,
+            body: r#"{"error":"not_found"}"#.into(),
+        });
+        assert_eq!(err.next_step(), Some(POST_NOT_FOUND_HINT));
+    }
+
+    // T-350: next_step for Sync(Client(Api { status: 404 })) returns the same hint
+    // as T-349 so direct API and bulk sync paths share guidance.
+    #[test]
+    fn next_step_sync_client_api_404_returns_post_not_found_hint() {
+        let err = SaeError::Sync(SyncError::Client(ClientError::Api {
+            status: 404,
+            body: r#"{"error":"not_found"}"#.into(),
+        }));
+        assert_eq!(err.next_step(), Some(POST_NOT_FOUND_HINT));
+    }
+
+    // T-351: next_step for Client(Api { status: 500 }) returns None — only 404
+    // carries a recovery hint, 5xx is server-side and not actionable on the
+    // agent side.
+    #[test]
+    fn next_step_client_api_non_404_returns_none() {
+        let err = SaeError::Client(ClientError::Api {
+            status: 500,
+            body: "Internal Server Error".into(),
+        });
+        assert_eq!(err.next_step(), None);
+    }
+
+    // T-352: to_error_envelope(Client(Api { status: 404 })) composes the
+    // ADR-0060 wire payload with code=DATA_ERROR, retryable=false, and the
+    // post-not-found next_step. Mirrors T-342 so the composition surface is
+    // pinned alongside the individual method tests.
+    #[test]
+    fn to_error_envelope_client_api_404_composes_data_error_payload() {
+        let err = SaeError::Client(ClientError::Api {
+            status: 404,
+            body: r#"{"error":"not_found","message":"Not Found"}"#.into(),
+        });
+        let env = err.to_error_envelope();
+        assert_eq!(env.error.code, ErrorCode::DataError);
+        assert!(!env.error.retryable);
+        assert_eq!(env.error.next_step.as_deref(), Some(POST_NOT_FOUND_HINT));
+        assert!(env.error.candidates.is_empty());
+        assert!(
+            env.error.message.contains("HTTP 404"),
+            "message should mention HTTP 404; got: {}",
+            env.error.message
         );
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -270,3 +270,43 @@ fn force_internal_with_json_emits_internal_envelope() {
         "error.message must be present"
     );
 }
+
+// T-CI009: synthetic esa API 404 path exits 65 (DATA_ERROR) with
+// `error.code = "DATA_ERROR"`. Pins the binary-boundary routing for the
+// esa-404 reclassification (#136): the `ClientError::Api { status: 404, .. }`
+// → DATA_ERROR mapping must survive the `error_code()` → `exit_code()` →
+// process exit chain. Without this pin, the routing only lives in unit tests
+// (T-346 / T-348 / T-352) and could regress silently. The hint string is
+// exact-equality matched so the wire-level surface cannot drift from the
+// in-process surface pinned by T-349 / T-352.
+#[cfg(feature = "test-support")]
+#[test]
+fn force_client_api_404_with_json_emits_data_error_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "__test_force_client_api_404"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(65),
+        "exit code must be 65 (DATA_ERROR); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(env["error"]["code"], "DATA_ERROR");
+    assert_eq!(env["error"]["retryable"], false);
+    assert_eq!(
+        env["error"]["next_step"],
+        "Verify the post number exists in esa, or run `sae search <keyword>` to find it."
+    );
+    let message = env["error"]["message"]
+        .as_str()
+        .expect("error.message must be a string");
+    assert!(
+        message.contains("HTTP 404"),
+        "message must surface the HTTP 404 status; got: {message}"
+    );
+}


### PR DESCRIPTION
Closes #136

## 概要

esa API の 404 (post not found) が `code: INTERNAL` / exit `70` (SOFTWARE) として返り、サーバ起因の 5xx と判別できない状態だった。AI エージェントが「入力した post 番号が存在しない」と「サーバ障害」を終了シグナルだけで判別できず、OUTCOME.md の Behavior「回復可能な失敗と終端失敗を終了シグナルだけで判別する」が崩れていた。

- `ClientError::Api(String)` → `Api { status: u16, body: String }` に拡張し HTTP status を保持
- `SaeError::error_code()` で `status: 404` を `DataError` (exit 65) に分岐、それ以外の HTTP error は従来通り `Internal` (70)
- `next_step` に 404 用ヒント追加 (「Verify the post number exists in esa, or run `sae search <keyword>` to find it.」)
- Hidden test seam `__test_force_client_api_404` + `T-CI009` で binary-boundary の routing を pin

## 設計判断

### DATA_ERROR (65) を選んだ理由 — NOT_FOUND (66) ではなく

Issue Constraints が「`DATA_ERROR` (or `NOT_FOUND`) として返り」と両案を挙げていたが、`DATA_ERROR` を選択。

- `envelope::ErrorCode` (sae 側) には `NotFound` variant が存在しない。`NOT_FOUND` (66) を採用するなら amici baseline に `codes::NOT_FOUND` を追加する **別 issue** が前段に必要（ADR-0066 playbook の 3 段ワークフロー: amici baseline → downstream routing → audit follow-up）。
- 404 は「入力した post 番号が esa 上に存在しない」 = **入力データ起因**。`NOINPUT` (66 / 標準入力不足) より `DATAERR` (65 / 入力データ形式不正) のほうが semantic に合致する。
- 既存の `DATA_ERROR` (65) routing (日付形式不正) と axis が揃う: どちらも「user が渡した値が処理対象として有効でない」。

### `ClientError::Api(String)` を struct variant 化

Issue Constraints が「`ClientError::Api { status: StatusCode, body: String }` に拡張」と明記。message パースで status 復元する対症療法を NG としていたため、type-level で status を持つ struct variant 一択。URL parse / token format error は別の variant (`InvalidRequest`) に分離し、HTTP error 専用 variant を厳密化。

### `#[non_exhaustive]` 付与

`ClientError` は `pub mod client` 経由で外部公開されている。今回の struct variant 化は破壊変更だが、以後の variant 追加を非破壊にするため `#[non_exhaustive]` を追加（ADR-0066 playbook の L41-45 と同パターン）。

### Net 状態 (#126 / #127 / #136)

`error.code` で分岐する agent retry policy は破壊変更を自動吸収できる:

| 失敗の種別                                 | error.code         | exit code |
| ------------------------------------------ | ------------------ | --------- |
| 日付形式不正                               | `DATA_ERROR`       | 65        |
| **esa API 404 (本変更で追加)**             | **`DATA_ERROR`**   | **65**    |
| esa API 5xx / 4xx (404 以外)               | `INTERNAL`         | 70        |
| MLX backend 不在 / embedder invariant 違反 | `INTERNAL`         | 70        |
| 分類不能 (`SaeError::Other`)               | `UNKNOWN`          | 104       |

## スコープ外

- 401 / 403 / 422 など他 HTTP status の reclassify（別 issue で検討）
- amici / yomu / recall への横展開

## テスト計画

- [x] `cargo nextest run --features test-support --profile ci` → 341/341 passed (T-345 / T-346 / T-347 / T-348 / T-349 / T-350 / T-351 / T-352 / T-CI009 を追加)
- [x] `cargo nextest run --profile ci` → 337/337 passed (default features)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` → clean
- [x] CHANGELOG / README の exit code 表と BREAKING 注記を更新
- [ ] CI green 確認 (push 後)