### PR TITLE
fix(search): reranker 失敗時の degraded warning を symmetric に push (#138 subtask 1)

### DIFF
--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -429,6 +429,7 @@ pub fn hybrid_search(
             }
             Err(e) => {
                 warn!(%e, "cross-encoder reranking failed, keeping heuristic order");
+                warnings.push(format!("reranker failed ({e}), falling back to RRF order"));
                 apply_recency_boost(merged, &post_meta, now)
             }
         }
@@ -1532,5 +1533,64 @@ mod tests {
                 r.score
             );
         }
+    }
+
+    // T-221: hybrid_search with a failing reranker pushes a degraded-warning note
+    // symmetric with the vec_search failure path so AI agents see the same
+    // `warnings[]` signal regardless of which hybrid component degraded.
+    #[test]
+    fn hybrid_search_failing_reranker_pushes_warning() {
+        use rurico::reranker::{RankedResult, Rerank, RerankerError};
+
+        struct FailingReranker;
+
+        impl Rerank for FailingReranker {
+            fn score(&self, _query: &str, _document: &str) -> Result<f32, RerankerError> {
+                Err(RerankerError::Inference(
+                    "forced failure for T-221".to_owned(),
+                ))
+            }
+            fn score_batch(&self, _pairs: &[(&str, &str)]) -> Result<Vec<f32>, RerankerError> {
+                Err(RerankerError::Inference(
+                    "forced failure for T-221".to_owned(),
+                ))
+            }
+            fn rerank(
+                &self,
+                _query: &str,
+                _documents: &[&str],
+            ) -> Result<Vec<RankedResult>, RerankerError> {
+                Err(RerankerError::Inference(
+                    "forced failure for T-221".to_owned(),
+                ))
+            }
+        }
+
+        let db = Db::open_memory().unwrap();
+        setup_db_with_posts(&db);
+
+        let reranker = FailingReranker;
+        let output = hybrid_search(
+            db.conn(),
+            "認証の仕組み",
+            None,
+            10,
+            Timestamp::now(),
+            &SearchFilter::default(),
+            Some(&reranker),
+        )
+        .unwrap();
+        assert!(
+            !output.results.is_empty(),
+            "fallback path should still produce results"
+        );
+        assert!(
+            output
+                .warnings
+                .iter()
+                .any(|w| w.contains("reranker failed") && w.contains("falling back")),
+            "expected warnings to include reranker failure note, got: {:?}",
+            output.warnings
+        );
     }
 }


### PR DESCRIPTION
Refs #138 (subtask 1 of 4)
Related: #140 (wiring split-out)

## 概要

`src/storage/search.rs` の degraded path に **非対称** が残っていた:

- vec search 失敗時 (`:373-382`) → `warnings[]` に user-visible note を push
- reranker 失敗時 (`:421-433`) → `tracing::warn!` のみ。`warnings[]` に何も push しない

agent から `--json` envelope を観測する場合、reranker が落ちて RRF only にフォールバックしても degraded シグナルが出ないため、silent な品質低下が起きていた。

本 PR は **storage 層** での対称化のみを行い、envelope `notes[]` までの配線は #140 として切り出す。

## 変更内容

- `src/storage/search.rs:421-437` reranker `Err` branch に `warnings.push(...)` を追加。format は既存の vec_search 失敗 note と揃える (`"reranker failed ({e}), falling back to RRF order"`)
- 単体テスト `hybrid_search_failing_reranker_pushes_warning` (T-221) を追加
  - `FailingReranker` ローカル stub で `RerankerError::Inference` を強制
  - `output.warnings` に `"reranker failed"` と `"falling back"` の両方が含まれることを assert

## スコープ分割について

`#138` subtask 1 の acceptance criteria は本来 3 件:

| # | Acceptance | Status |
| - | ---------- | ------ |
| 1 | reranker failure path appends string to `warnings` | 本 PR で close |
| 2 | output envelope sets `degraded=true` and surfaces note in `notes[]` | **#140 に分割** |
| 3 | integration test exercises hermetic reranker failure | **#140 に分割** |

advisor の指摘で **`SearchOutput.warnings` → envelope `notes[]` の wiring 自体が現状欠落** (`src/commands/search.rs:159-161` で `tracing::warn!` するだけで `output::search` に渡してへん) と判明。配線設計は本来別 PR で扱うべき範疇なので、#140 に切り出して narrow PR とした。

## 動作確認

- [x] `cargo nextest run` — 342 tests passed (T-221 含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## 関連 ADR

- sae-ADR-0001 "JSON envelope and agent-stdout contract" Implementation Guidelines 行 "Symmetric degraded warnings" がこの修正の根拠 (ADR は現状 `docs/` 配下で gitignored、未 commit)
