### PR TITLE
fix(envelope): SearchOutput.warnings を --json envelope notes[] に転送 (#140)

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -166,6 +166,7 @@ pub(crate) fn run_search(
         semantic,
         embedder_load_failed,
         embed_info,
+        &search_output.warnings,
     )?;
     const PREFETCH_TTL_SECS: u64 = 5 * 60;
     if !storage::sync_harvested_within(db.conn(), PREFETCH_TTL_SECS) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,26 @@ pub mod tools;
 pub use envelope::CommandOutput;
 pub use tools::{Sae, SaeError};
 
+/// Hidden test seam: builds a [`CommandOutput`] by running `output::search`
+/// with a synthetic search result and a non-empty `search_warnings` slice so
+/// `tests/cli_integration.rs` can pin the `--json` envelope wiring for #140
+/// without seeding a SQLite DB or loading a real reranker. The production
+/// binary built with `cargo install` never exposes this symbol.
+#[cfg(feature = "test-support")]
+pub fn __test_search_with_warnings() -> Result<CommandOutput, SaeError> {
+    let warnings = vec!["reranker failed (forced for test), falling back to RRF order".to_owned()];
+    let result = storage::SearchResult {
+        post_number: 1,
+        post_name: "test post".to_owned(),
+        post_url: "https://example.com/posts/1".to_owned(),
+        section_title: None,
+        snippet: "synthetic snippet".to_owned(),
+        score: 0.5,
+        match_source: storage::MatchSource::Fts,
+    };
+    output::search(&[result], "test query", true, false, None, &warnings)
+}
+
 /// Renders [`CommandOutput`] for stdout. With `json_mode` set, emits the
 /// `SuccessEnvelope`; otherwise the default-mode markdown.
 pub fn render_success(out: &CommandOutput, json_mode: bool) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,14 @@ Examples:
     #[cfg(feature = "test-support")]
     #[command(name = "__test_force_client_api_404", hide = true)]
     TestForceClientApi404,
+    /// Hidden test seam: emit a `CommandOutput` whose `notes[]` contains a
+    /// reranker-failure warning so `tests/cli_integration.rs` can pin the
+    /// `--json` envelope wiring for #140 (storage warnings → envelope notes)
+    /// without seeding a SQLite DB or loading a real reranker. `test-support`
+    /// feature only.
+    #[cfg(feature = "test-support")]
+    #[command(name = "__test_force_search_warning", hide = true)]
+    TestForceSearchWarning,
 }
 
 #[derive(Debug, Subcommand)]
@@ -219,6 +227,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "__test_force_backend_unavailable",
     "__test_force_internal",
     "__test_force_client_api_404",
+    "__test_force_search_warning",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
@@ -296,6 +305,8 @@ async fn run(cli: Cli, config: Config) -> Result<CommandOutput, SaeError> {
             status: 404,
             body: r#"{"error":"not_found","message":"Not Found"}"#.to_owned(),
         })),
+        #[cfg(feature = "test-support")]
+        Command::TestForceSearchWarning => sae::__test_search_with_warnings(),
         Command::Model { .. } => unreachable!("handled before Sae::new()"),
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -22,6 +22,7 @@ pub(crate) fn search(
     semantic: bool,
     embedder_load_failed: bool,
     embed_info: Option<EmbedInfo>,
+    search_warnings: &[String],
 ) -> Result<CommandOutput, SaeError> {
     let search_mode = if semantic { "hybrid" } else { "fts" };
     let data = serde_json::json!({
@@ -62,15 +63,15 @@ pub(crate) fn search(
         }
         lines.join("\n")
     };
+    let mut notes = Vec::new();
     if embedder_load_failed {
-        Ok(CommandOutput::with_notes(
-            markdown,
-            data,
-            true,
-            vec!["semantic search unavailable, falling back to FTS".to_owned()],
-        ))
-    } else {
+        notes.push("semantic search unavailable, falling back to FTS".to_owned());
+    }
+    notes.extend(search_warnings.iter().cloned());
+    if notes.is_empty() {
         Ok(CommandOutput::ok(markdown, data))
+    } else {
+        Ok(CommandOutput::with_notes(markdown, data, true, notes))
     }
 }
 
@@ -337,7 +338,7 @@ mod tests {
     // T-087: search data includes search_mode hybrid
     #[test]
     fn search_json_hybrid_includes_search_mode() {
-        let out = search(&[], "test", true, false, None).unwrap();
+        let out = search(&[], "test", true, false, None, &[]).unwrap();
         assert_eq!(out.data["search_mode"], "hybrid");
         assert!(out.data["results"].is_array());
     }
@@ -345,7 +346,7 @@ mod tests {
     // T-088: search data includes search_mode fts
     #[test]
     fn search_json_fts_includes_search_mode() {
-        let out = search(&[], "test", false, false, None).unwrap();
+        let out = search(&[], "test", false, false, None, &[]).unwrap();
         assert_eq!(out.data["search_mode"], "fts");
     }
 
@@ -361,7 +362,7 @@ mod tests {
             score: 0.5,
             match_source: MatchSource::Fts,
         }];
-        let out = search(&results, "q", false, false, None).unwrap();
+        let out = search(&results, "q", false, false, None, &[]).unwrap();
         assert!(out.markdown.contains("semantic search unavailable"));
     }
 
@@ -377,14 +378,14 @@ mod tests {
             score: 0.5,
             match_source: MatchSource::Fts,
         }];
-        let out = search(&results, "q", true, false, None).unwrap();
+        let out = search(&results, "q", true, false, None, &[]).unwrap();
         assert!(!out.markdown.contains("semantic search unavailable"));
     }
 
     // T-260: search degraded fallback populates notes
     #[test]
     fn search_degraded_fallback_populates_notes() {
-        let out = search(&[], "q", false, true, None).unwrap();
+        let out = search(&[], "q", false, true, None, &[]).unwrap();
         assert!(
             out.degraded,
             "embedder_load_failed=true should set degraded"
@@ -396,8 +397,48 @@ mod tests {
     // T-261: search no-embed (FTS without load failure) leaves notes empty
     #[test]
     fn search_no_embed_does_not_degrade() {
-        let out = search(&[], "q", false, false, None).unwrap();
+        let out = search(&[], "q", false, false, None, &[]).unwrap();
         assert!(!out.degraded);
         assert!(out.notes.is_empty());
+    }
+
+    // T-262: non-empty search_warnings alone (no embedder failure) sets degraded
+    // and surfaces the warnings as notes. Pins #140 wiring: storage warnings
+    // reach the envelope notes[] without depending on embedder_load_failed.
+    #[test]
+    fn search_warnings_alone_set_degraded_and_populate_notes() {
+        let warnings = vec!["reranker failed (boom), falling back to RRF order".to_owned()];
+        let out = search(&[], "q", true, false, None, &warnings).unwrap();
+        assert!(
+            out.degraded,
+            "non-empty warnings should set degraded even with embedder loaded"
+        );
+        assert_eq!(out.notes.len(), 1);
+        assert!(
+            out.notes[0].contains("reranker failed"),
+            "warning should be surfaced verbatim; got: {:?}",
+            out.notes
+        );
+    }
+
+    // T-263: embedder_load_failed + non-empty search_warnings produces ordered
+    // notes (embedder note first, then storage warnings). Order pinned so
+    // agents that read notes[0] keep the same upstream-first semantics.
+    #[test]
+    fn search_warnings_with_embedder_failure_preserve_order() {
+        let warnings = vec!["reranker failed (boom), falling back to RRF order".to_owned()];
+        let out = search(&[], "q", false, true, None, &warnings).unwrap();
+        assert!(out.degraded);
+        assert_eq!(out.notes.len(), 2);
+        assert!(
+            out.notes[0].contains("semantic search unavailable"),
+            "embedder note should come first (upstream degradation); got: {:?}",
+            out.notes
+        );
+        assert!(
+            out.notes[1].contains("reranker failed"),
+            "storage warning should come second (downstream); got: {:?}",
+            out.notes
+        );
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -416,7 +416,7 @@ mod tests {
         assert_eq!(out.notes.len(), 1);
         assert!(
             out.notes[0].contains("reranker failed"),
-            "warning should be surfaced verbatim; got: {:?}",
+            "warning should be surfaced in notes[0]; got: {:?}",
             out.notes
         );
     }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -310,3 +310,39 @@ fn force_client_api_404_with_json_emits_data_error_envelope() {
         "message must surface the HTTP 404 status; got: {message}"
     );
 }
+
+// T-CI010: synthetic reranker-failure search path emits a success envelope
+// with `degraded=true` and the storage-layer warning surfaced in `notes[]`.
+// Pins #140 wiring: `SearchOutput.warnings` reaches the `--json` envelope so
+// AI agents can detect the reranker fallback. Unit tests T-221 (storage push)
+// and T-262 / T-263 (output transform) cover the pieces; this test pins the
+// end-to-end process-boundary shape.
+#[cfg(feature = "test-support")]
+#[test]
+fn force_search_warning_with_json_emits_degraded_envelope() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "__test_force_search_warning"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(
+        output.status.success(),
+        "synthetic warning path is still a success; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let env: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}; got: {stdout}"));
+    assert_eq!(
+        env["degraded"], true,
+        "degraded must be true; got: {stdout}"
+    );
+    let notes = env["notes"].as_array().expect("notes must be an array");
+    assert!(
+        notes
+            .iter()
+            .any(|n| n.as_str().is_some_and(|s| s.contains("reranker failed"))),
+        "notes[] must surface the reranker-failure warning; got: {notes:?}"
+    );
+}


### PR DESCRIPTION
Closes #140
Related: #138 (Family B audit follow-up), #141 (subtask 1: storage push)

## 概要

`storage::SearchOutput.warnings` に push された文字列が `--json` envelope の `notes[]` まで届かない wiring gap を修正。これまで `commands/search.rs:159-161` は warnings を `tracing::warn!` に流して終了しており、`output::search` は `embedder_load_failed` しか観測していなかったため、AI agent は `--json` だけ見ると劣化を検知できなかった (sae-ADR-0001 "Symmetric degraded warnings" の規約が wire 不在で実現していない状態)。

## 変更内容

- **`output::search`**: `search_warnings: &[String]` 引数を追加。`degraded` を `embedder_load_failed OR !search_warnings.is_empty()` に変更。`notes[]` は embedder note (upstream) → search_warnings (downstream) の順で concat
- **`commands/search.rs:163`**: `search_output.warnings` を `output::search` に forward (`tracing::warn!` も維持: 人間運用の stderr log として有用)
- **`lib.rs`**: `__test_search_with_warnings` test-support seam を追加 (synthetic `SearchResult` + warnings で `output::search` を呼ぶ)
- **`main.rs`**: `__test_force_search_warning` 隠し subcommand を追加 (`#127` / `#136` の既存 `__test_force_*` と同じ shape)

## テスト追加

| ID | 場所 | 内容 |
| - | ---- | --- |
| T-262 | `src/output.rs:tests` | warnings 単独 (embedder ロード成功) で `degraded=true` + notes に surface |
| T-263 | `src/output.rs:tests` | embedder fail + warnings の concat 順序を pin (embedder note 先) |
| T-CI010 | `tests/cli_integration.rs` | process-boundary 統合テスト: `__test_force_search_warning` で envelope `degraded=true` + notes に "reranker failed" を assert |

T-260 / T-261 (embedder_load_failed 単独パス) は互換維持。

## スコープ

- **対象**: `SearchOutput.warnings → notes[]` の wire + test seam + 3 tests
- **対象外**: storage 層の reranker failure push (PR #141 で別途処理)
- 本 PR は #141 と独立して main から merge 可能 (test seam は synthetic な warnings を直接渡すため subtask 1 の storage push に依存しない)

## 動作確認

- [x] `cargo nextest run --all-features` — 344 tests passed (+3 new: T-262 / T-263 / T-CI010)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] hermetic execution: `cargo run --features test-support -- --json __test_force_search_warning` → envelope `{"degraded":true,"notes":["reranker failed (forced for test), falling back to RRF order"], ...}` 出力確認

## /polish 結果

simplify (reuse/quality/efficiency) + Codex + CodeRabbit + Gemini の 6 軸 review 実施。Gemini cross-family check で 0 Critical/Major。enhancer-code phase で `src/output.rs:419` の T-262 assertion message を `"surfaced verbatim"` → `"surfaced in notes[0]"` に微調整 (contains check のセマンティクスと整合)。

## 関連 ADR

- sae-ADR-0001 "JSON envelope and agent-stdout contract" Implementation Guidelines 行「Symmetric degraded warnings」(現状 `docs/` 配下で gitignored、未 commit)
- Audit row: `docs/audit/2026-05-17-undocumented-decisions.md` candidate #19 / #22
