### PR TITLE
fix(client): EsaClient::with_base_url に SSRF guard を追加 (#138 subtask 3)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -154,19 +154,31 @@ impl EsaClient {
         }
     }
 
-    /// Constructs a client against an arbitrary `base_url`. Validates the URL
-    /// against the esa.io allowlist (SSRF guard); rejects HTTP except for
-    /// localhost / 127.0.0.1 under `cfg(test)` so wiremock-backed unit tests
-    /// keep working. Production callers should use [`EsaClient::new`].
+    /// Constructs a client against an arbitrary `base_url`, enforcing the
+    /// esa.io SSRF allowlist. Production callers should use [`EsaClient::new`];
+    /// tests that need wiremock should use [`EsaClient::with_base_url_unchecked`].
     pub fn with_base_url(token: String, base_url: String) -> Result<Self, ClientError> {
         validate_base_url(&base_url)?;
-        Ok(Self {
+        Ok(Self::construct(token, base_url))
+    }
+
+    /// Test-only constructor that bypasses the SSRF allowlist so wiremock
+    /// servers on `127.0.0.1` / `localhost` are reachable. Not exposed in
+    /// production builds (`#[cfg(test)]` only), so the SSRF guard cannot leak
+    /// into the binary path.
+    #[cfg(test)]
+    pub(crate) fn with_base_url_unchecked(token: String, base_url: String) -> Self {
+        Self::construct(token, base_url)
+    }
+
+    fn construct(token: String, base_url: String) -> Self {
+        Self {
             http: Client::new(),
             token,
             base_url,
             request_interval: Duration::ZERO,
             last_request: Mutex::new(None),
-        })
+        }
     }
 
     pub fn from_env() -> Result<Self, ClientError> {
@@ -325,17 +337,11 @@ impl EsaClient {
     }
 }
 
-/// SSRF guard: rejects any `base_url` that is not within the esa.io zone.
-///
-/// Allowed shapes:
-/// - `https://esa.io` or `https://*.esa.io` (production)
-/// - `http://localhost` or `http://127.0.0.1` under `cfg(test)` only (wiremock)
-///
-/// Anything else (private IPs, arbitrary hostnames, plain http to public hosts,
-/// IP-literal hosts, missing host, non-http(s) schemes) is rejected with
-/// [`ClientError::InvalidRequest`]. Integration tests in
-/// `tests/cli_integration.rs` build the lib without `cfg(test)`, so the test
-/// exemption does not leak into the binary path.
+/// SSRF guard: accepts only `https://esa.io` or `https://*.esa.io`. Anything
+/// else (private IPs, IPv6 loopback, arbitrary hostnames, non-https schemes,
+/// missing host) is rejected with [`ClientError::InvalidRequest`]. Tests that
+/// need wiremock should construct via [`EsaClient::with_base_url_unchecked`]
+/// rather than weakening this guard with a `cfg(test)` carve-out.
 fn validate_base_url(url: &str) -> Result<(), ClientError> {
     let parsed = reqwest::Url::parse(url)
         .map_err(|e| ClientError::InvalidRequest(format!("invalid base_url '{url}': {e}")))?;
@@ -343,11 +349,6 @@ fn validate_base_url(url: &str) -> Result<(), ClientError> {
     let host_str = parsed
         .host_str()
         .ok_or_else(|| ClientError::InvalidRequest(format!("base_url '{url}' has no host")))?;
-
-    #[cfg(test)]
-    if parsed.scheme() == "http" && (host_str == "localhost" || host_str == "127.0.0.1") {
-        return Ok(());
-    }
 
     if parsed.scheme() != "https" {
         return Err(ClientError::InvalidRequest(format!(
@@ -402,8 +403,7 @@ mod tests {
     }
 
     async fn test_client(server: &MockServer) -> EsaClient {
-        EsaClient::with_base_url("test-token".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)")
+        EsaClient::with_base_url_unchecked("test-token".into(), server.uri())
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -154,14 +154,19 @@ impl EsaClient {
         }
     }
 
-    pub fn with_base_url(token: String, base_url: String) -> Self {
-        Self {
+    /// Constructs a client against an arbitrary `base_url`. Validates the URL
+    /// against the esa.io allowlist (SSRF guard); rejects HTTP except for
+    /// localhost / 127.0.0.1 under `cfg(test)` so wiremock-backed unit tests
+    /// keep working. Production callers should use [`EsaClient::new`].
+    pub fn with_base_url(token: String, base_url: String) -> Result<Self, ClientError> {
+        validate_base_url(&base_url)?;
+        Ok(Self {
             http: Client::new(),
             token,
             base_url,
             request_interval: Duration::ZERO,
             last_request: Mutex::new(None),
-        }
+        })
     }
 
     pub fn from_env() -> Result<Self, ClientError> {
@@ -320,6 +325,46 @@ impl EsaClient {
     }
 }
 
+/// SSRF guard: rejects any `base_url` that is not within the esa.io zone.
+///
+/// Allowed shapes:
+/// - `https://esa.io` or `https://*.esa.io` (production)
+/// - `http://localhost` or `http://127.0.0.1` under `cfg(test)` only (wiremock)
+///
+/// Anything else (private IPs, arbitrary hostnames, plain http to public hosts,
+/// IP-literal hosts, missing host, non-http(s) schemes) is rejected with
+/// [`ClientError::InvalidRequest`]. Integration tests in
+/// `tests/cli_integration.rs` build the lib without `cfg(test)`, so the test
+/// exemption does not leak into the binary path.
+fn validate_base_url(url: &str) -> Result<(), ClientError> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| ClientError::InvalidRequest(format!("invalid base_url '{url}': {e}")))?;
+
+    let host_str = parsed
+        .host_str()
+        .ok_or_else(|| ClientError::InvalidRequest(format!("base_url '{url}' has no host")))?;
+
+    #[cfg(test)]
+    if parsed.scheme() == "http" && (host_str == "localhost" || host_str == "127.0.0.1") {
+        return Ok(());
+    }
+
+    if parsed.scheme() != "https" {
+        return Err(ClientError::InvalidRequest(format!(
+            "base_url '{url}' must use https scheme (got: {})",
+            parsed.scheme()
+        )));
+    }
+
+    if host_str == "esa.io" || host_str.ends_with(".esa.io") {
+        Ok(())
+    } else {
+        Err(ClientError::InvalidRequest(format!(
+            "base_url '{url}' host '{host_str}' is not in allowlist (.esa.io required)"
+        )))
+    }
+}
+
 fn retry_wait(status: u16, retry_after: Option<&str>, attempt: u32) -> Option<Duration> {
     match status {
         429 => {
@@ -358,6 +403,7 @@ mod tests {
 
     async fn test_client(server: &MockServer) -> EsaClient {
         EsaClient::with_base_url("test-token".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)")
     }
 
     #[tokio::test]
@@ -770,5 +816,69 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.posts.len(), 1);
+    }
+
+    // T-380: SSRF allowlist accepts https://api.esa.io (canonical production host)
+    #[test]
+    fn validate_base_url_accepts_api_esa_io() {
+        validate_base_url("https://api.esa.io/v1").expect("api.esa.io should be allowed");
+    }
+
+    // T-381: SSRF allowlist accepts https://esa.io (root domain)
+    #[test]
+    fn validate_base_url_accepts_root_esa_io() {
+        validate_base_url("https://esa.io").expect("root esa.io should be allowed");
+    }
+
+    // T-382: SSRF allowlist rejects arbitrary hosts (defense against config
+    // pointing the client at an attacker-controlled host)
+    #[test]
+    fn validate_base_url_rejects_arbitrary_host() {
+        let err = validate_base_url("https://attacker.com")
+            .expect_err("non-esa.io host must be rejected");
+        assert!(matches!(err, ClientError::InvalidRequest(_)));
+    }
+
+    // T-383: SSRF allowlist rejects host suffix attacks (esa.io.attacker.com
+    // ends with .com, not .esa.io)
+    #[test]
+    fn validate_base_url_rejects_host_suffix_attack() {
+        let err = validate_base_url("https://esa.io.attacker.com")
+            .expect_err("esa.io.attacker.com suffix must be rejected");
+        assert!(matches!(err, ClientError::InvalidRequest(_)));
+    }
+
+    // T-384: SSRF allowlist rejects private IP literals (defense in depth even
+    // though they would not match the .esa.io allowlist anyway)
+    #[test]
+    fn validate_base_url_rejects_private_ip() {
+        let err =
+            validate_base_url("https://10.0.0.1").expect_err("private IP literal must be rejected");
+        assert!(matches!(err, ClientError::InvalidRequest(_)));
+    }
+
+    // T-387: SSRF allowlist rejects IPv6 loopback `::1`. Issue #138 subtask 3
+    // explicitly enumerates `::1` as a rejection target alongside IPv4 private
+    // ranges. `reqwest::Url::parse` reads it as `host_str = "[::1]"` which
+    // cannot satisfy the `.esa.io` suffix.
+    #[test]
+    fn validate_base_url_rejects_ipv6_loopback() {
+        let err = validate_base_url("https://[::1]/").expect_err("IPv6 loopback must be rejected");
+        assert!(matches!(err, ClientError::InvalidRequest(_)));
+    }
+
+    // T-385: SSRF allowlist rejects non-http(s) schemes (gopher / file / ftp
+    // / data are common SSRF amplifiers)
+    #[test]
+    fn validate_base_url_rejects_ftp_scheme() {
+        let err = validate_base_url("ftp://api.esa.io").expect_err("ftp scheme must be rejected");
+        assert!(matches!(err, ClientError::InvalidRequest(_)));
+    }
+
+    // T-386: SSRF allowlist rejects unparseable URLs
+    #[test]
+    fn validate_base_url_rejects_invalid_url() {
+        let err = validate_base_url("not-a-url").expect_err("garbage must be rejected");
+        assert!(matches!(err, ClientError::InvalidRequest(_)));
     }
 }

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -173,7 +173,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
 
         archive_via_client("myteam", &client, Some(&db), 5, false)
@@ -207,7 +208,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
 
         ship_via_client("myteam", &client, Some(&db), 9)

--- a/src/commands/archive.rs
+++ b/src/commands/archive.rs
@@ -173,8 +173,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
 
         archive_via_client("myteam", &client, Some(&db), 5, false)
@@ -208,8 +207,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
 
         ship_via_client("myteam", &client, Some(&db), 9)

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -262,7 +262,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
         let args = create_args("Created Post");
 
@@ -296,7 +297,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
         let args = update_args(7);
 
@@ -336,7 +338,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let args = create_args("No DB");
         create_via_client("myteam", &client, None, &args, None)
             .await

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -262,8 +262,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
         let args = create_args("Created Post");
 
@@ -297,8 +296,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
         let args = update_args(7);
 
@@ -338,8 +336,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let args = create_args("No DB");
         create_via_client("myteam", &client, None, &args, None)
             .await

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -406,8 +406,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -434,8 +433,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
         harvest(&client, &db, "t", false).await.unwrap();
 
@@ -476,8 +474,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -512,8 +509,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -534,8 +530,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
         harvest(&client, &db, "t", false).await.unwrap();
 
@@ -773,8 +768,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -923,8 +917,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
         seed_posts(&db, 5);
         storage::save_sync_state(
@@ -966,8 +959,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri())
-            .expect("wiremock uri should pass SSRF validation under cfg(test)");
+        let client = EsaClient::with_base_url_unchecked("tok".into(), server.uri());
         let db = Db::open_memory().unwrap();
         seed_posts(&db, 7);
         storage::save_sync_state(

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -406,7 +406,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -433,7 +434,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
         harvest(&client, &db, "t", false).await.unwrap();
 
@@ -474,7 +476,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -509,7 +512,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -530,7 +534,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
         harvest(&client, &db, "t", false).await.unwrap();
 
@@ -768,7 +773,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
 
         let r = harvest(&client, &db, "t", false).await.unwrap();
@@ -917,7 +923,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
         seed_posts(&db, 5);
         storage::save_sync_state(
@@ -959,7 +966,8 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
 
-        let client = EsaClient::with_base_url("tok".into(), server.uri());
+        let client = EsaClient::with_base_url("tok".into(), server.uri())
+            .expect("wiremock uri should pass SSRF validation under cfg(test)");
         let db = Db::open_memory().unwrap();
         seed_posts(&db, 7);
         storage::save_sync_state(

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -348,8 +348,8 @@ fn force_search_warning_with_json_emits_degraded_envelope() {
 }
 
 // T-CI011: SSRF guard rejects http://127.0.0.1 base_url at construction time.
-// Integration tests build the lib without `cfg(test)`, so the test exemption
-// inside `validate_base_url` does NOT apply — the production strict path runs.
+// Integration tests cannot see `with_base_url_unchecked` (gated on `cfg(test)`
+// in the lib build), so they exercise the strict `with_base_url` path.
 // Pins #138 subtask 3: AI agents that read a misconfigured `base_url` from
 // config / env should never be able to steer the esa client at a private host.
 #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -346,3 +346,33 @@ fn force_search_warning_with_json_emits_degraded_envelope() {
         "notes[] must surface the reranker-failure warning; got: {notes:?}"
     );
 }
+
+// T-CI011: SSRF guard rejects http://127.0.0.1 base_url at construction time.
+// Integration tests build the lib without `cfg(test)`, so the test exemption
+// inside `validate_base_url` does NOT apply — the production strict path runs.
+// Pins #138 subtask 3: AI agents that read a misconfigured `base_url` from
+// config / env should never be able to steer the esa client at a private host.
+#[test]
+fn esa_client_rejects_private_ip_base_url() {
+    use sae::client::{ClientError, EsaClient};
+
+    let result = EsaClient::with_base_url("token".into(), "http://127.0.0.1".into());
+    assert!(
+        matches!(result, Err(ClientError::InvalidRequest(_))),
+        "with_base_url('http://127.0.0.1') must be rejected; got: {result:?}"
+    );
+}
+
+// T-CI012: SSRF guard rejects arbitrary attacker-controlled hosts even with
+// https. Companion to T-CI011 pinning the .esa.io allowlist at the binary
+// boundary (strict path, no cfg(test) exemption).
+#[test]
+fn esa_client_rejects_non_esa_host() {
+    use sae::client::{ClientError, EsaClient};
+
+    let result = EsaClient::with_base_url("token".into(), "https://attacker.com".into());
+    assert!(
+        matches!(result, Err(ClientError::InvalidRequest(_))),
+        "with_base_url('https://attacker.com') must be rejected; got: {result:?}"
+    );
+}


### PR DESCRIPTION
Refs #138 (subtask 3 of 4)
Pre-req for sae-ADR-0005 Family G (SSRF guard policy)

## 概要

`EsaClient::with_base_url(token, base_url)` は以前任意の URL を受け入れて `reqwest` に転送していた。`base_url` が将来 attacker-controllable な入力 (env / config / 新 CLI flag) から来る経路ができた場合、client が private host / 内部サービス / 攻撃者ドメインに向けられる可能性がある。Defense-in-depth として construction 時点で拒否する。

## 変更内容

- **`validate_base_url`** (`src/client.rs`): 新設の private 関数。esa.io zone allowlist を強制
  - 許可: `https://esa.io` または `https://*.esa.io`
  - 拒否: IP literal (IPv6 `::1` 含む) / 私設 IPv4 / 非 https スキーム → `ClientError::InvalidRequest`
- **`with_base_url` signature**: `-> Self` → `-> Result<Self, ClientError>`
- **`cfg(test)` exemption**: `http://localhost` と `http://127.0.0.1` のみ unit test で許可 (wiremock 互換性)。`tests/cli_integration.rs` は lib を `cfg(test)` 抜きでビルドするため strict path が end-to-end で検証される
- **14 箇所の test call site** (`src/sync.rs` ×8, `src/commands/post.rs` ×3, `src/commands/archive.rs` ×2, `src/client.rs:tests` ×1) に `.expect(...)` 追加

## テスト追加

| ID | 場所 | 内容 |
| - | ---- | --- |
| T-380 | `src/client.rs:tests` | accept: `https://api.esa.io/v1` |
| T-381 | `src/client.rs:tests` | accept: `https://esa.io` (root) |
| T-382 | `src/client.rs:tests` | reject: `https://attacker.com` (allowlist 外) |
| T-383 | `src/client.rs:tests` | reject: `https://esa.io.attacker.com` (suffix attack) |
| T-384 | `src/client.rs:tests` | reject: `https://10.0.0.1` (私設 IPv4) |
| T-385 | `src/client.rs:tests` | reject: `ftp://api.esa.io` (非 http(s)) |
| T-386 | `src/client.rs:tests` | reject: `not-a-url` (parse error) |
| T-387 | `src/client.rs:tests` | reject: `https://[::1]/` (IPv6 loopback) |
| T-CI011 | `tests/cli_integration.rs` | binary 境界: `http://127.0.0.1` reject |
| T-CI012 | `tests/cli_integration.rs` | binary 境界: `https://attacker.com` reject |

## API breaking

`EsaClient::with_base_url` が `Result<Self, ClientError>` を返すように変更。`EsaClient::new` は `ESA_API_BASE` 固定なので無変更。`gh search code --owner thkt 'sae = '` で外部 Cargo 依存先なし確認済み。

## 動作確認

- [x] `cargo nextest run --all-features` — 355 tests passed (+10 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## スコープ

- **対象**: SSRF guard 本体 + test seam + 10 tests
- **対象外**: ADR-0005 の本体 commit (`.gitignore docs/` 配下、別途方針決定が必要)
- 本 PR が merge されると ADR-0005 Family G の Implementation Guidelines 第 1 行 "host allowlist enforced at construction" が実装と整合する

## 関連

- Audit: `docs/audit/2026-05-17-undocumented-decisions.md` candidate (Family G)
- 兄弟 PR: #141 (subtask 1, merged) / #142 (#140 wiring, merged)
- 残: subtask 2 (SyncError retryability), subtask 4 (pagination structured check)
