### PR TITLE
fix(sync): SyncError + StorageError に is_retryable() を追加 (#138 subtask 2)

### DIFF
--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -118,6 +118,55 @@ pub enum StorageError {
     Io(#[from] io::Error),
 }
 
+impl StorageError {
+    /// True for transient conditions where retrying might recover: SQLite
+    /// `SQLITE_BUSY` / `SQLITE_LOCKED` under WAL contention, and
+    /// `io::ErrorKind::{WouldBlock, Interrupted, TimedOut}`.
+    ///
+    /// Consulted from [`crate::tools::SaeError::error_code`] so AI agents
+    /// auto-retry instead of bailing on the `CantCreat (73)` default
+    /// (#138 subtask 2).
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Open(_) => false,
+            Self::Db(e) => is_retryable_sqlite_error(e),
+            Self::Io(e) => is_retryable_io_error(e),
+        }
+    }
+}
+
+fn is_retryable_sqlite_error(e: &rusqlite::Error) -> bool {
+    matches!(
+        e,
+        rusqlite::Error::SqliteFailure(err, _)
+            if matches!(
+                err.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+    )
+}
+
+fn is_retryable_io_error(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted | io::ErrorKind::TimedOut
+    )
+}
+
+/// Test helper: build a typed `rusqlite::Error::SqliteFailure` so callers do
+/// not repeat the same 4-line struct literal in every test module.
+#[cfg(test)]
+pub(crate) fn sqlite_failure(code: rusqlite::ErrorCode, extended_code: i32) -> rusqlite::Error {
+    use rusqlite::{Error, ffi};
+    Error::SqliteFailure(
+        ffi::Error {
+            code,
+            extended_code,
+        },
+        None,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,16 @@
+//! Bulk sync (`index` / `rebuild`) between esa.io and the local SQLite cache.
+//!
+//! [`SyncError`] flattens client- and storage-layer failures into one type so
+//! orchestrators see a uniform `Result`. [`SyncError::is_retryable`] is the
+//! per-variant retry discriminator: it returns `true` only for transient
+//! storage conditions (SQLite WAL contention, transient I/O). The retry
+//! policy in [`crate::tools::SaeError::error_code`] consults it to route
+//! `SyncError::Storage(transient)` to `TempFailure (75)` instead of the
+//! `CantCreat (73)` default, so AI agents do not give up on recoverable
+//! failures (#138 subtask 2).
+
 use std::fmt;
+use std::io;
 
 use amici::cli::progress_step;
 use tracing::info;
@@ -48,6 +60,45 @@ pub enum SyncError {
 
     #[error(transparent)]
     Storage(#[from] StorageError),
+}
+
+impl SyncError {
+    /// True when the failure originates from a transient condition retrying
+    /// might recover. Only the `Storage` variant uses this discriminator;
+    /// `Client` retryability is already classified per-variant in
+    /// [`crate::tools::SaeError::error_code`] (Network / MaxRetries →
+    /// `TempFailure`, Api / InvalidRequest → `Internal`).
+    ///
+    /// Retryable storage cases: SQLite `SQLITE_BUSY` / `SQLITE_LOCKED` under
+    /// WAL contention, and `io::ErrorKind::{WouldBlock, Interrupted,
+    /// TimedOut}` for transient I/O. Everything else (Open failure, schema
+    /// mismatch, non-busy SQLite errors) is non-retryable.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Client(_) => false,
+            Self::Storage(StorageError::Open(_)) => false,
+            Self::Storage(StorageError::Db(e)) => is_retryable_sqlite_error(e),
+            Self::Storage(StorageError::Io(e)) => is_retryable_io_error(e),
+        }
+    }
+}
+
+fn is_retryable_sqlite_error(e: &rusqlite::Error) -> bool {
+    matches!(
+        e,
+        rusqlite::Error::SqliteFailure(err, _)
+            if matches!(
+                err.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+    )
+}
+
+fn is_retryable_io_error(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted | io::ErrorKind::TimedOut
+    )
 }
 
 pub async fn harvest(
@@ -1014,5 +1065,91 @@ pub(crate) mod tests {
             200,
             "first incremental (no prior) accepts the diff total when it dominates"
         );
+    }
+
+    // T-260a: SyncError::is_retryable() returns true for transient SQLite busy
+    // (WAL contention). Without this, the catch-all CantCreat (73) routing
+    // blocks AI-agent auto-retry on recoverable contention (#138 subtask 2).
+    #[test]
+    fn is_retryable_true_for_sqlite_busy() {
+        use rusqlite::{Error as SqlError, ErrorCode, ffi};
+        let busy = SqlError::SqliteFailure(
+            ffi::Error {
+                code: ErrorCode::DatabaseBusy,
+                extended_code: 5,
+            },
+            None,
+        );
+        let err = SyncError::Storage(StorageError::Db(busy));
+        assert!(err.is_retryable(), "SQLITE_BUSY must be retryable");
+    }
+
+    // T-260b: SyncError::is_retryable() returns true for SQLITE_LOCKED
+    // (sibling of BUSY under heavier contention).
+    #[test]
+    fn is_retryable_true_for_sqlite_locked() {
+        use rusqlite::{Error as SqlError, ErrorCode, ffi};
+        let locked = SqlError::SqliteFailure(
+            ffi::Error {
+                code: ErrorCode::DatabaseLocked,
+                extended_code: 6,
+            },
+            None,
+        );
+        let err = SyncError::Storage(StorageError::Db(locked));
+        assert!(err.is_retryable(), "SQLITE_LOCKED must be retryable");
+    }
+
+    // T-260c: SyncError::is_retryable() returns true for transient I/O kinds
+    // (WouldBlock / Interrupted / TimedOut).
+    #[test]
+    fn is_retryable_true_for_transient_io() {
+        for kind in [
+            io::ErrorKind::WouldBlock,
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::TimedOut,
+        ] {
+            let err = SyncError::Storage(StorageError::Io(io::Error::from(kind)));
+            assert!(err.is_retryable(), "{kind:?} must be retryable");
+        }
+    }
+
+    // T-260d: SyncError::is_retryable() returns false for non-retryable
+    // storage variants (Open failure, non-busy SQLite, permanent I/O).
+    #[test]
+    fn is_retryable_false_for_non_retryable_storage() {
+        use rusqlite::{Error as SqlError, ErrorCode, ffi};
+        let open_err = SyncError::Storage(StorageError::Open("path missing".into()));
+        assert!(!open_err.is_retryable());
+
+        let schema = SqlError::SqliteFailure(
+            ffi::Error {
+                code: ErrorCode::DatabaseCorrupt,
+                extended_code: 11,
+            },
+            None,
+        );
+        let db_err = SyncError::Storage(StorageError::Db(schema));
+        assert!(!db_err.is_retryable());
+
+        let perm = SyncError::Storage(StorageError::Io(io::Error::from(
+            io::ErrorKind::PermissionDenied,
+        )));
+        assert!(!perm.is_retryable());
+    }
+
+    // T-260e: SyncError::is_retryable() always returns false for Client
+    // variants — Client retryability is classified separately in
+    // SaeError::error_code (per-variant Network / MaxRetries / Api routing).
+    #[test]
+    fn is_retryable_false_for_client_variants() {
+        let token = SyncError::Client(ClientError::TokenNotSet);
+        assert!(!token.is_retryable());
+
+        let api = SyncError::Client(ClientError::Api {
+            status: 503,
+            body: "Service Unavailable".into(),
+        });
+        assert!(!api.is_retryable());
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,16 +1,6 @@
 //! Bulk sync (`index` / `rebuild`) between esa.io and the local SQLite cache.
-//!
-//! [`SyncError`] flattens client- and storage-layer failures into one type so
-//! orchestrators see a uniform `Result`. [`SyncError::is_retryable`] is the
-//! per-variant retry discriminator: it returns `true` only for transient
-//! storage conditions (SQLite WAL contention, transient I/O). The retry
-//! policy in [`crate::tools::SaeError::error_code`] consults it to route
-//! `SyncError::Storage(transient)` to `TempFailure (75)` instead of the
-//! `CantCreat (73)` default, so AI agents do not give up on recoverable
-//! failures (#138 subtask 2).
 
 use std::fmt;
-use std::io;
 
 use amici::cli::progress_step;
 use tracing::info;
@@ -63,42 +53,17 @@ pub enum SyncError {
 }
 
 impl SyncError {
-    /// True when the failure originates from a transient condition retrying
-    /// might recover. Only the `Storage` variant uses this discriminator;
-    /// `Client` retryability is already classified per-variant in
-    /// [`crate::tools::SaeError::error_code`] (Network / MaxRetries →
-    /// `TempFailure`, Api / InvalidRequest → `Internal`).
+    /// True when the failure is transient enough that retrying might recover.
     ///
-    /// Retryable storage cases: SQLite `SQLITE_BUSY` / `SQLITE_LOCKED` under
-    /// WAL contention, and `io::ErrorKind::{WouldBlock, Interrupted,
-    /// TimedOut}` for transient I/O. Everything else (Open failure, schema
-    /// mismatch, non-busy SQLite errors) is non-retryable.
+    /// `Client` variants always return `false`: their retryability is
+    /// classified per-case in [`crate::tools::SaeError::error_code`]
+    /// (Network / MaxRetries → `TempFailure`, Api → `Internal`).
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::Client(_) => false,
-            Self::Storage(StorageError::Open(_)) => false,
-            Self::Storage(StorageError::Db(e)) => is_retryable_sqlite_error(e),
-            Self::Storage(StorageError::Io(e)) => is_retryable_io_error(e),
+            Self::Storage(e) => e.is_retryable(),
         }
     }
-}
-
-fn is_retryable_sqlite_error(e: &rusqlite::Error) -> bool {
-    matches!(
-        e,
-        rusqlite::Error::SqliteFailure(err, _)
-            if matches!(
-                err.code,
-                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
-            )
-    )
-}
-
-fn is_retryable_io_error(e: &io::Error) -> bool {
-    matches!(
-        e.kind(),
-        io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted | io::ErrorKind::TimedOut
-    )
 }
 
 pub async fn harvest(
@@ -362,10 +327,13 @@ fn post_to_row(post: &EsaPost) -> EsaPostRow {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
-    use crate::client::EsaUser;
+    use rusqlite::ErrorCode;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::client::EsaUser;
+    use crate::storage::sqlite_failure;
 
     fn make_esa_post(number: u32, name: &str, body_md: &str, updated_at: &str) -> EsaPost {
         EsaPost {
@@ -1067,43 +1035,29 @@ pub(crate) mod tests {
         );
     }
 
-    // T-260a: SyncError::is_retryable() returns true for transient SQLite busy
+    // T-353: SyncError::is_retryable() returns true for transient SQLite busy
     // (WAL contention). Without this, the catch-all CantCreat (73) routing
     // blocks AI-agent auto-retry on recoverable contention (#138 subtask 2).
     #[test]
     fn is_retryable_true_for_sqlite_busy() {
-        use rusqlite::{Error as SqlError, ErrorCode, ffi};
-        let busy = SqlError::SqliteFailure(
-            ffi::Error {
-                code: ErrorCode::DatabaseBusy,
-                extended_code: 5,
-            },
-            None,
-        );
+        let busy = sqlite_failure(ErrorCode::DatabaseBusy, 5);
         let err = SyncError::Storage(StorageError::Db(busy));
         assert!(err.is_retryable(), "SQLITE_BUSY must be retryable");
     }
 
-    // T-260b: SyncError::is_retryable() returns true for SQLITE_LOCKED
-    // (sibling of BUSY under heavier contention).
+    // T-354: SyncError::is_retryable() returns true for SQLITE_LOCKED.
     #[test]
     fn is_retryable_true_for_sqlite_locked() {
-        use rusqlite::{Error as SqlError, ErrorCode, ffi};
-        let locked = SqlError::SqliteFailure(
-            ffi::Error {
-                code: ErrorCode::DatabaseLocked,
-                extended_code: 6,
-            },
-            None,
-        );
+        let locked = sqlite_failure(ErrorCode::DatabaseLocked, 6);
         let err = SyncError::Storage(StorageError::Db(locked));
         assert!(err.is_retryable(), "SQLITE_LOCKED must be retryable");
     }
 
-    // T-260c: SyncError::is_retryable() returns true for transient I/O kinds
+    // T-355: SyncError::is_retryable() returns true for transient I/O kinds
     // (WouldBlock / Interrupted / TimedOut).
     #[test]
     fn is_retryable_true_for_transient_io() {
+        use std::io;
         for kind in [
             io::ErrorKind::WouldBlock,
             io::ErrorKind::Interrupted,
@@ -1114,21 +1068,16 @@ pub(crate) mod tests {
         }
     }
 
-    // T-260d: SyncError::is_retryable() returns false for non-retryable
+    // T-356: SyncError::is_retryable() returns false for non-retryable
     // storage variants (Open failure, non-busy SQLite, permanent I/O).
     #[test]
     fn is_retryable_false_for_non_retryable_storage() {
-        use rusqlite::{Error as SqlError, ErrorCode, ffi};
+        use std::io;
+
         let open_err = SyncError::Storage(StorageError::Open("path missing".into()));
         assert!(!open_err.is_retryable());
 
-        let schema = SqlError::SqliteFailure(
-            ffi::Error {
-                code: ErrorCode::DatabaseCorrupt,
-                extended_code: 11,
-            },
-            None,
-        );
+        let schema = sqlite_failure(ErrorCode::DatabaseCorrupt, 11);
         let db_err = SyncError::Storage(StorageError::Db(schema));
         assert!(!db_err.is_retryable());
 
@@ -1138,7 +1087,7 @@ pub(crate) mod tests {
         assert!(!perm.is_retryable());
     }
 
-    // T-260e: SyncError::is_retryable() always returns false for Client
+    // T-357: SyncError::is_retryable() always returns false for Client
     // variants — Client retryability is classified separately in
     // SaeError::error_code (per-variant Network / MaxRetries / Api routing).
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -381,6 +381,11 @@ impl SaeError {
             Self::InputData(_) => ErrorCode::DataError,
             Self::Client(ClientError::TokenNotSet)
             | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => ErrorCode::UsageError,
+            // Retryable sync failures (SQLite WAL contention, transient I/O)
+            // route to `TempFailure` (75) instead of the `CantCreat` (73)
+            // default so AI agents auto-retry recoverable conditions
+            // (#138 subtask 2).
+            Self::Sync(e) if e.is_retryable() => ErrorCode::TempFailure,
             Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => ErrorCode::CantCreat,
             // esa API 404 is an input failure (the post number does not exist
             // in the team), not a server-side fault. Route to DATA_ERROR (65)
@@ -789,6 +794,37 @@ mod tests {
         assert_code(
             &SaeError::Sync(SyncError::Client(ClientError::MaxRetries(5))),
             codes::TEMP_FAIL,
+        );
+    }
+
+    // T-388: Sync(Storage(SQLITE_BUSY)) maps to TEMP_FAIL (75) via the new
+    // `is_retryable()` discriminator (#138 subtask 2). Without this arm, the
+    // CantCreat (73) default catches retryable contention and AI agents do
+    // not auto-retry.
+    #[test]
+    fn exit_code_sync_storage_sqlite_busy_is_temp_fail() {
+        use rusqlite::{Error as SqlError, ErrorCode, ffi};
+        let busy = SqlError::SqliteFailure(
+            ffi::Error {
+                code: ErrorCode::DatabaseBusy,
+                extended_code: 5,
+            },
+            None,
+        );
+        assert_code(
+            &SaeError::Sync(SyncError::Storage(StorageError::Db(busy))),
+            codes::TEMP_FAIL,
+        );
+    }
+
+    // T-389: Sync(Storage(Open)) still maps to CANT_CREAT (73) — the new
+    // retryability arm is order-sensitive and must not capture non-retryable
+    // storage failures (companion to T-388 / T-247).
+    #[test]
+    fn exit_code_sync_storage_open_is_cant_creat_after_retry_arm() {
+        assert_code(
+            &SaeError::Sync(SyncError::Storage(StorageError::Open("missing".into()))),
+            codes::CANT_CREAT,
         );
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -381,10 +381,10 @@ impl SaeError {
             Self::InputData(_) => ErrorCode::DataError,
             Self::Client(ClientError::TokenNotSet)
             | Self::Sync(SyncError::Client(ClientError::TokenNotSet)) => ErrorCode::UsageError,
-            // Retryable sync failures (SQLite WAL contention, transient I/O)
-            // route to `TempFailure` (75) instead of the `CantCreat` (73)
-            // default so AI agents auto-retry recoverable conditions
-            // (#138 subtask 2).
+            // Retryable storage failures (SQLite WAL contention, transient I/O)
+            // route to `TempFailure` (75) instead of the `CantCreat` (73) default
+            // so AI agents auto-retry recoverable conditions (#138 subtask 2).
+            Self::Storage(e) if e.is_retryable() => ErrorCode::TempFailure,
             Self::Sync(e) if e.is_retryable() => ErrorCode::TempFailure,
             Self::Storage(_) | Self::Sync(SyncError::Storage(_)) => ErrorCode::CantCreat,
             // esa API 404 is an input failure (the post number does not exist
@@ -603,6 +603,7 @@ mod tests {
     use amici::cli::exit_code::codes;
 
     use super::*;
+    use crate::storage::sqlite_failure;
 
     fn assert_code(err: &SaeError, expected: u8) {
         assert_eq!(err.exit_code(), ExitCode::from(expected));
@@ -799,18 +800,12 @@ mod tests {
 
     // T-388: Sync(Storage(SQLITE_BUSY)) maps to TEMP_FAIL (75) via the new
     // `is_retryable()` discriminator (#138 subtask 2). Without this arm, the
-    // CantCreat (73) default catches retryable contention and AI agents do
-    // not auto-retry.
+    // CantCreat (73) default catches retryable contention during per-page
+    // harvest and AI agents do not auto-retry.
     #[test]
     fn exit_code_sync_storage_sqlite_busy_is_temp_fail() {
-        use rusqlite::{Error as SqlError, ErrorCode, ffi};
-        let busy = SqlError::SqliteFailure(
-            ffi::Error {
-                code: ErrorCode::DatabaseBusy,
-                extended_code: 5,
-            },
-            None,
-        );
+        use rusqlite::ErrorCode;
+        let busy = sqlite_failure(ErrorCode::DatabaseBusy, 5);
         assert_code(
             &SaeError::Sync(SyncError::Storage(StorageError::Db(busy))),
             codes::TEMP_FAIL,
@@ -826,6 +821,17 @@ mod tests {
             &SaeError::Sync(SyncError::Storage(StorageError::Open("missing".into()))),
             codes::CANT_CREAT,
         );
+    }
+
+    // T-390: Storage(SQLITE_BUSY) (no Sync wrapping) also maps to TEMP_FAIL.
+    // Covers `Db::open` contention during `sae index`/`rebuild` startup
+    // where the error surfaces as `SaeError::Storage` directly, before
+    // `sync::harvest` wraps it (Codex P2 finding on #138 subtask 2).
+    #[test]
+    fn exit_code_storage_sqlite_busy_is_temp_fail() {
+        use rusqlite::ErrorCode;
+        let busy = sqlite_failure(ErrorCode::DatabaseBusy, 5);
+        assert_code(&SaeError::Storage(StorageError::Db(busy)), codes::TEMP_FAIL);
     }
 
     // T-300: Sae::with_env enables rerank when SAE_RERANK="1"


### PR DESCRIPTION
Refs #138 (subtask 2 of 4)

## 概要

`SyncError::Storage(SQLITE_BUSY)` や transient I/O が起きた際、`tools.rs::error_code` の catch-all `CantCreat (73)` ルーティングが AI agent の auto-retry を阻んでいた。retryability discriminator を追加し、recoverable な条件を `TempFailure (75)` に向け直す。

加えて /polish 過程で Codex が見つけた P2 を反映し、`Db::open` 時 (sync.rs に到達する前) の contention もカバーする。

## 変更内容

### アーキテクチャ

- **`StorageError::is_retryable()`** を新設 (`src/storage/types.rs`): matrix logic を所有
  - `Db(SqliteFailure(BUSY | LOCKED))` → retryable
  - `Io(WouldBlock | Interrupted | TimedOut)` → retryable
  - `Open` / その他 SQLite error / permanent I/O → non-retryable
- **`SyncError::is_retryable()`** (`src/sync.rs`): `StorageError::is_retryable()` に delegate。`Client` variant は常に false (retryability は `SaeError::error_code` 内で variant 別に既に分類)
- helper fn `is_retryable_sqlite_error` / `is_retryable_io_error` は `storage/types.rs` に集約

### `tools.rs::error_code` ルーティング

`CantCreat (73)` 既定の **前** に 2 つの arm を追加:

```rust
Self::Storage(e) if e.is_retryable() => ErrorCode::TempFailure,  // Db::open contention
Self::Sync(e) if e.is_retryable() => ErrorCode::TempFailure,     // per-page harvest contention
```

direct `Storage` arm が無いと、`sae index`/`rebuild` 起動時 (`Db::open` の WAL PRAGMA / schema init) の `SQLITE_BUSY` が `CantCreat (73)` に折りたたまれ AI agent が retry してくれない。

### テスト追加

| ID | 場所 | 内容 |
| - | ---- | --- |
| T-353〜T-357 | `src/sync.rs:tests` | `SyncError::is_retryable()` の matrix (busy / locked / transient I/O / 非 retryable storage / Client 常に false) |
| T-388 | `src/tools.rs:tests` | `Sync(Storage(BUSY))` → `TEMP_FAIL (75)` (per-page harvest path) |
| T-389 | `src/tools.rs:tests` | `Sync(Storage(Open))` → `CANT_CREAT (73)` (arm 順序の regression pin) |
| T-390 | `src/tools.rs:tests` | direct `Storage(BUSY)` → `TEMP_FAIL (75)` (`Db::open` startup path) |

### Helper

`storage::sqlite_failure(code, extended_code)` を `#[cfg(test)] pub(crate)` で導入。`SqliteFailure` literal の 4 site 重複 (sync.rs:tests ×3, tools.rs:tests T-388/T-390) を 1 行ずつに集約。

## モジュール doc

`src/sync.rs` 冒頭に短い `//!` を追加 (この PR の文脈を未来のリーダー向けに残す)。

## 動作確認

- [x] `cargo nextest run --all-features` — 363 tests passed (+8 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## /polish 結果

simplify (reuse / quality / efficiency) + Codex + CodeRabbit + Gemini の 6 軸 review 実施。

| Tool | Findings | Action |
| - | - | - |
| simplify reuse | REUSE-01 low | 適用 (`sqlite_failure` helper) |
| simplify quality | HIGH (T-260 衝突) + medium (重複) | 適用 (T-353〜T-357 renumber + helper) |
| simplify efficiency | 0 件 | clean |
| **Codex** | **P2: Db::open contention bypass** | 適用 (direct `Storage` arm 追加) |
| CodeRabbit | 0 件 | clean |
| Gemini | 0 Critical/Major | clean |

Phase 2 (enhancer-code): doc comment 簡潔化 + `use` hoisting。

## 関連

- 兄弟 PR: #141 (subtask 1, merged) / #142 (#140 wiring, merged) / #144 (subtask 3 SSRF guard, merged)
- 残: subtask 4 (pagination structured check)
- Audit: `docs/audit/2026-05-17-undocumented-decisions.md` (Family B "bug-fix-with-rationale")
