### PR TITLE
feat(envelope): SaeError::candidates() を config 由来の team 一覧で実装 (#139)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,12 @@ pub fn render_success(out: &CommandOutput, json_mode: bool) -> String {
 }
 
 /// Renders a `SaeError` for stderr. JSON mode wraps it via `to_error_envelope`.
-pub fn render_error(err: &SaeError, json_mode: bool) -> String {
+///
+/// `config` feeds [`SaeError::candidates`] for the team-list cases (#139).
+/// Pass `None` when the failure occurred before `Config::load()` completed.
+pub fn render_error(err: &SaeError, json_mode: bool, config: Option<&config::Config>) -> String {
     if json_mode {
-        envelope::render_json_error(&err.to_error_envelope())
+        envelope::render_json_error(&err.to_error_envelope(config))
     } else {
         err.to_string()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,9 +327,9 @@ fn emit_success(out: &CommandOutput, json_mode: bool) -> ExitCode {
     }
 }
 
-fn emit_error(err: &SaeError, json_mode: bool) {
+fn emit_error(err: &SaeError, json_mode: bool, config: Option<&Config>) {
     if json_mode {
-        eprintln!("{}", render_error(err, true));
+        eprintln!("{}", render_error(err, true, config));
     } else {
         exit_error(&err.to_string());
     }
@@ -369,14 +369,15 @@ async fn main() -> ExitCode {
         Ok(c) => c,
         Err(e) => {
             let err: SaeError = e.into();
-            emit_error(&err, json_mode);
+            emit_error(&err, json_mode, None);
             return err.exit_code();
         }
     };
+    let config_for_emit = config.clone();
     match run(cli, config).await {
         Ok(out) => emit_success(&out, json_mode),
         Err(e) => {
-            emit_error(&e, json_mode);
+            emit_error(&e, json_mode, Some(&config_for_emit));
             e.exit_code()
         }
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -493,11 +493,32 @@ impl SaeError {
         }
     }
 
-    /// Always returns empty for now. Future revisions may populate
-    /// config-derived candidates for `NoTeamSpecified`/`UnknownTeam` once
-    /// `Config` is threaded into the call site.
-    pub(crate) fn candidates(&self) -> Vec<String> {
-        Vec::new()
+    /// Returns suggestion candidates for recoverable failures so AI agents
+    /// can surface a Did-you-mean list to the caller without a follow-up
+    /// `sae status` roundtrip (#139).
+    ///
+    /// `config` is threaded from [`emit_error`] in `main.rs`. Pass `None` for
+    /// failures that occur before `Config::load()` completes — the only such
+    /// variants are config-load failures themselves, which never produce
+    /// team-list candidates anyway.
+    ///
+    /// Order is preserved as written in `config.json`; the suite is
+    /// deliberately unfiltered (no fuzzy match) per the issue scope.
+    ///
+    /// Wildcard default: every other variant returns empty. Unlike
+    /// [`Self::next_step`], the candidate surface is intentionally restricted
+    /// to the team-list cases — `next_step` carries a per-variant editorial
+    /// hint, but `candidates` is a wire-format vocabulary that only the
+    /// recoverable team failures legitimately populate. A new `SaeError`
+    /// variant added later wanting suggestions should be explicit, not
+    /// inherit a `vec![]` default by mistake.
+    pub(crate) fn candidates(&self, config: Option<&Config>) -> Vec<String> {
+        match self {
+            Self::Config(ConfigError::NoTeamSpecified | ConfigError::UnknownTeam(_)) => {
+                config.map(|c| c.teams.clone()).unwrap_or_default()
+            }
+            _ => Vec::new(),
+        }
     }
 
     /// Mirrors the `TempFailure` classification from [`Self::error_code`].
@@ -509,13 +530,16 @@ impl SaeError {
     /// [`Self::retryable`], and the formatted message into an [`ErrorEnvelope`]
     /// for `--json` rendering. Kept here so the envelope module avoids a
     /// dependency on `SaeError` (which would form a cycle).
-    pub(crate) fn to_error_envelope(&self) -> ErrorEnvelope {
+    ///
+    /// `config` is consulted by [`Self::candidates`] for the team-list cases.
+    /// Pass `None` when the failure occurred before `Config::load()` completed.
+    pub(crate) fn to_error_envelope(&self, config: Option<&Config>) -> ErrorEnvelope {
         ErrorEnvelope {
             error: ErrorPayload {
                 code: self.error_code(),
                 message: self.to_string(),
                 next_step: self.next_step().map(String::from),
-                candidates: self.candidates(),
+                candidates: self.candidates(config),
                 retryable: self.retryable(),
             },
         }
@@ -978,7 +1002,7 @@ mod tests {
     #[test]
     fn to_error_envelope_input_data_composes_data_error_payload() {
         let err = SaeError::InputData("Invalid date '--after 2025-xx-xx'".into());
-        let env = err.to_error_envelope();
+        let env = err.to_error_envelope(None);
         assert_eq!(env.error.code, ErrorCode::DataError);
         assert!(!env.error.retryable);
         assert!(env.error.next_step.is_none());
@@ -1032,19 +1056,69 @@ mod tests {
         }
     }
 
-    // T-324: candidates_returns_empty_in_phase_2_1
+    // T-324: candidates(None) returns empty for every variant — without a
+    // Config there is no team list to derive suggestions from. Pins the
+    // pre-Config-load failure path (main.rs:372).
     #[test]
-    fn candidates_returns_empty_in_phase_2_1() {
+    fn candidates_returns_empty_without_config() {
         for err in [
             SaeError::InputUsage("anything".into()),
             SaeError::InputData("anything".into()),
             SaeError::Config(ConfigError::NoTeamSpecified),
+            SaeError::Config(ConfigError::UnknownTeam("gajj".into())),
             SaeError::Other("internal".into()),
         ] {
             assert_eq!(
-                err.candidates(),
+                err.candidates(None),
                 Vec::<String>::new(),
-                "Phase 2.1 returns empty Vec for {err:?}"
+                "candidates(None) must be empty for {err:?}"
+            );
+        }
+    }
+
+    fn config_with_teams(teams: &[&str]) -> Config {
+        Config {
+            teams: teams.iter().map(|&t| t.to_owned()).collect(),
+            default_team: None,
+            embed_budget: 50,
+        }
+    }
+
+    // T-394: NoTeamSpecified with a populated Config returns the team list
+    // verbatim (config-order, no sorting) so agents can pick a recovery team
+    // without a follow-up `sae status` roundtrip (#139).
+    #[test]
+    fn candidates_returns_teams_for_no_team_specified() {
+        let cfg = config_with_teams(&["gaji", "gaji-platform"]);
+        let err = SaeError::Config(ConfigError::NoTeamSpecified);
+        assert_eq!(err.candidates(Some(&cfg)), vec!["gaji", "gaji-platform"]);
+    }
+
+    // T-395: UnknownTeam(_) also surfaces the full team list. The
+    // mistaken-team name is already in the message; the candidates field
+    // gives agents the recovery set without fuzzy filtering (out of scope).
+    #[test]
+    fn candidates_returns_teams_for_unknown_team() {
+        let cfg = config_with_teams(&["alpha", "beta"]);
+        let err = SaeError::Config(ConfigError::UnknownTeam("alphaa".into()));
+        assert_eq!(err.candidates(Some(&cfg)), vec!["alpha", "beta"]);
+    }
+
+    // T-396: every other variant ignores the Config and returns empty even
+    // when one is supplied. Prevents accidental team-list leakage on
+    // unrelated failures.
+    #[test]
+    fn candidates_ignores_config_for_unrelated_variants() {
+        let cfg = config_with_teams(&["x", "y"]);
+        for err in [
+            SaeError::InputUsage("bad".into()),
+            SaeError::InputData("bad".into()),
+            SaeError::Other("oops".into()),
+        ] {
+            assert_eq!(
+                err.candidates(Some(&cfg)),
+                Vec::<String>::new(),
+                "{err:?} must not leak the team list"
             );
         }
     }
@@ -1210,7 +1284,7 @@ mod tests {
     // composition (T-337 pattern) for the new variant.
     #[test]
     fn to_error_envelope_backend_unavailable_composes_internal_payload() {
-        let env = SaeError::BackendUnavailable.to_error_envelope();
+        let env = SaeError::BackendUnavailable.to_error_envelope(None);
         assert_eq!(env.error.code, ErrorCode::Internal);
         assert!(!env.error.retryable);
         assert_eq!(
@@ -1226,7 +1300,7 @@ mod tests {
     #[test]
     fn to_error_envelope_internal_variant_composes_internal_payload() {
         let err = SaeError::Internal("Embedding count mismatch: expected 5, got 4".into());
-        let env = err.to_error_envelope();
+        let env = err.to_error_envelope(None);
         assert_eq!(env.error.code, ErrorCode::Internal);
         assert!(!env.error.retryable);
         assert!(env.error.next_step.is_none());
@@ -1283,7 +1357,7 @@ mod tests {
             status: 404,
             body: r#"{"error":"not_found","message":"Not Found"}"#.into(),
         });
-        let env = err.to_error_envelope();
+        let env = err.to_error_envelope(None);
         assert_eq!(env.error.code, ErrorCode::DataError);
         assert!(!env.error.retryable);
         assert_eq!(env.error.next_step.as_deref(), Some(POST_NOT_FOUND_HINT));

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -4,6 +4,7 @@
 //! routing (stdout vs stderr) are all exercised together.
 
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -344,6 +345,70 @@ fn force_search_warning_with_json_emits_degraded_envelope() {
             .iter()
             .any(|n| n.as_str().is_some_and(|s| s.contains("reranker failed"))),
         "notes[] must surface the reranker-failure warning; got: {notes:?}"
+    );
+}
+
+/// Writes a `config.json` with the given teams into the test home so the
+/// binary's `Config::load()` picks it up. Pairs with [`sae_command`] which
+/// already sets `XDG_CONFIG_HOME=home/.config`.
+fn write_config_with_teams(home: &Path, teams: &[&str]) {
+    let dir = home.join(".config").join("sae");
+    fs::create_dir_all(&dir).expect("config dir");
+    let body = serde_json::json!({ "teams": teams }).to_string();
+    fs::write(dir.join("config.json"), body).expect("write config.json");
+}
+
+// T-CI013: `--team unknownteam` against a multi-team config emits a JSON
+// envelope whose `error.candidates` lists every team verbatim (config order,
+// no fuzzy filter). Closes #139: agents recover from a typo in one
+// roundtrip instead of re-running `sae status` for the team list.
+#[test]
+fn unknown_team_envelope_lists_known_teams_as_candidates() {
+    let dir = tempdir().unwrap();
+    write_config_with_teams(dir.path(), &["alpha", "beta"]);
+
+    let output = sae_command(dir.path())
+        .args(["--json", "get", "1", "--team", "unknownteam"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(
+        !output.status.success(),
+        "unknown team should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(
+        env["error"]["candidates"],
+        serde_json::json!(["alpha", "beta"]),
+        "candidates must list configured teams in config order; envelope: {env}"
+    );
+}
+
+// T-CI014: when no `--team` is provided AND the config has multiple teams
+// without a default, the resulting `NoTeamSpecified` envelope also surfaces
+// the team list. The two recoverable team failures share the same
+// candidates contract (#139).
+#[test]
+fn no_team_envelope_lists_known_teams_as_candidates() {
+    let dir = tempdir().unwrap();
+    write_config_with_teams(dir.path(), &["alpha", "beta"]);
+
+    let output = sae_command(dir.path())
+        .args(["--json", "get", "1"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(
+        !output.status.success(),
+        "no-team-resolved should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(
+        env["error"]["candidates"],
+        serde_json::json!(["alpha", "beta"]),
+        "candidates must list teams when no team is selectable; envelope: {env}"
     );
 }
 


### PR DESCRIPTION
## Summary

`SaeError::candidates()` を従来の `Vec::new()` stub から、`config` 由来の team 一覧返却に置き換え。`UnknownTeam` / `NoTeamSpecified` で `--json` envelope の `error.candidates` に candidate 配列が乗るので、agent は 1 回の取得で recovery target を得られる。

- `candidates(&self, config: Option<&Config>) -> Vec<String>` に signature 拡張。`NoTeamSpecified` / `UnknownTeam(_)` の 2 arm で `config.teams.clone()` を返す。それ以外は wildcard で `vec![]`
- `to_error_envelope` / `render_error` / `emit_error` に `Option<&Config>` を threading。`Config::load` 失敗時は `None`、`run()` 失敗時は `Some(&config_for_emit)` (clone で借用衝突回避)
- order は `config.json` の記載順そのまま (fuzzy match は scope 外)

## Test plan

- [x] `cargo nextest run` — 366/366 pass (+5 new: T-394/395/396 + T-CI013/CI014)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] T-394: `NoTeamSpecified` + `Some(&config)` → team list 返却
- [x] T-395: `UnknownTeam(_)` + `Some(&config)` → team list 返却
- [x] T-396: 他 variant は `Some(&config)` 渡しても empty (team list leak 防止)
- [x] T-324 (rewritten): `candidates(None)` は全 variant で empty (pre-Config-load 経路 pin)
- [x] T-CI013: `--json get 1 --team unknownteam` で `error.candidates == ["alpha", "beta"]`
- [x] T-CI014: `--json get 1` (no --team) で `error.candidates == ["alpha", "beta"]`

## Out of scope

Issue acceptance #2 (clap `InvalidSubcommand` 時の KNOWN_SUBCOMMANDS suggestion) は別経路 (`render_parse_error`) で、`clap::Error::kind()` 判定が必要なため follow-up issue に切る。本 PR は team-list candidates に scope を絞る。

## ADR

local ADR-0002 (gitignored) の Open Questions を closed に更新済み。PR diff には現れない。

Closes #139.
