### PR TITLE
feat(envelope): clap InvalidSubcommand 時に subcommand 候補を envelope に乗せる (#148)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod storage;
 pub mod sync;
 pub mod tools;
 
+use clap::error::ErrorKind;
+
 pub use envelope::CommandOutput;
 pub use tools::{Sae, SaeError};
 
@@ -60,7 +62,15 @@ pub fn render_error(err: &SaeError, json_mode: bool, config: Option<&config::Con
 ///
 /// Only the first non-empty line of the clap message lands in the envelope; the
 /// usage block and subcommand list that follow are noisy for machine consumers.
-pub fn render_parse_error(e: &clap::Error, json_mode: bool) -> String {
+///
+/// Caller supplies `subcommands`: the user-facing subcommand list. Must not
+/// include hidden/test seams or deprecated entries — those would mislead an
+/// agent's retry. The list feeds the `candidates` array when, and only
+/// when, the failure is `ErrorKind::InvalidSubcommand`. Other clap error
+/// kinds (`MissingRequiredArgument`, `UnknownArgument`, etc.) keep
+/// `candidates: []` so agents do not see irrelevant subcommand lists in
+/// missing-arg failures (#148).
+pub fn render_parse_error(e: &clap::Error, json_mode: bool, subcommands: &[&str]) -> String {
     if json_mode {
         let raw = e.to_string();
         let message = raw
@@ -69,17 +79,98 @@ pub fn render_parse_error(e: &clap::Error, json_mode: bool) -> String {
             .unwrap_or("")
             .trim()
             .to_owned();
+        let candidates = if e.kind() == ErrorKind::InvalidSubcommand {
+            subcommands.iter().map(|&s| s.to_owned()).collect()
+        } else {
+            vec![]
+        };
         let env = envelope::ErrorEnvelope {
             error: envelope::ErrorPayload {
                 code: envelope::ErrorCode::UsageError,
                 message,
                 next_step: None,
-                candidates: vec![],
+                candidates,
                 retryable: false,
             },
         };
         envelope::render_json_error(&env)
     } else {
         e.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Arg, Command};
+
+    fn parse_envelope(out: &str) -> serde_json::Value {
+        serde_json::from_str(out).expect("envelope must be JSON")
+    }
+
+    // T-397: InvalidSubcommand → candidates lists every supplied subcommand
+    // verbatim. Closes #148: typo recovery surfaces in `--json` envelope.
+    #[test]
+    fn render_parse_error_invalid_subcommand_emits_candidates() {
+        let cmd = Command::new("sae")
+            .subcommand(Command::new("search"))
+            .subcommand(Command::new("get"));
+        let err = cmd.try_get_matches_from(["sae", "sserach"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidSubcommand, "test premise");
+
+        let out = render_parse_error(&err, true, &["search", "get"]);
+        let env = parse_envelope(&out);
+        assert_eq!(
+            env["error"]["candidates"],
+            serde_json::json!(["search", "get"])
+        );
+        assert_eq!(env["error"]["code"], "USAGE_ERROR");
+    }
+
+    /// Envelope's `candidates: Vec<String>` carries `skip_serializing_if =
+    /// "Vec::is_empty"`, so an empty list appears as a missing field rather
+    /// than `[]`. Agents read both as "no candidates" — this helper accepts
+    /// either shape.
+    fn assert_candidates_absent(env: &serde_json::Value) {
+        let c = &env["error"]["candidates"];
+        assert!(
+            c.is_null() || c.as_array().is_some_and(Vec::is_empty),
+            "candidates must be absent or empty; got: {c}"
+        );
+    }
+
+    // T-398: MissingRequiredArgument keeps candidates absent so agents do
+    // not see an irrelevant subcommand list when the failure is a missing
+    // positional. Regression guard against future "any usage error →
+    // suggest subcommands" simplifications.
+    #[test]
+    fn render_parse_error_missing_required_arg_keeps_candidates_empty() {
+        let cmd = Command::new("sae")
+            .subcommand(Command::new("get").arg(Arg::new("number").required(true)));
+        let err = cmd.try_get_matches_from(["sae", "get"]).unwrap_err();
+        assert_eq!(
+            err.kind(),
+            ErrorKind::MissingRequiredArgument,
+            "test premise"
+        );
+
+        let out = render_parse_error(&err, true, &["search", "get"]);
+        let env = parse_envelope(&out);
+        assert_candidates_absent(&env);
+    }
+
+    // T-399: UnknownArgument also keeps candidates absent. Pairs with T-398
+    // to pin the `==` predicate against `match _ => non-empty` drift.
+    #[test]
+    fn render_parse_error_unknown_argument_keeps_candidates_empty() {
+        let cmd = Command::new("sae").subcommand(Command::new("status"));
+        let err = cmd
+            .try_get_matches_from(["sae", "status", "--unknownflag"])
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnknownArgument, "test premise");
+
+        let out = render_parse_error(&err, true, &["search", "get"]);
+        let env = parse_envelope(&out);
+        assert_candidates_absent(&env);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,12 +204,27 @@ enum ModelCommand {
     Download,
 }
 
-// Includes the deprecated `harvest` (split into `index`/`rebuild` in v0.3.0)
-// so `sae harvest` reaches clap as an unrecognized subcommand instead of being
-// silently rewritten to `sae search harvest` by the shorthand expander.
-// `__test_force_unknown` is the hidden test seam (#127 OPS-005); listing it
-// here keeps the production binary from rewriting it to `sae search
-// __test_force_unknown` so users see clap's "unrecognized subcommand" error.
+// User-facing subcommand list, used as the `candidates` array for
+// `ErrorKind::InvalidSubcommand` (#148). Excludes:
+//   - `__test_*` seams (hidden, not for agent retry)
+//   - `harvest` (deprecated in v0.3.0; surfacing it as a "did you mean"
+//     would tell an agent to retry into the same clap error)
+// Kept manually parallel to the live `Cli` enum; drift is guarded by
+// `public_subcommands_matches_cli_non_hidden` in tests.
+const PUBLIC_SUBCOMMANDS: &[&str] = &[
+    "index", "rebuild", "search", "get", "create", "update", "archive", "ship", "embed", "status",
+    "model",
+];
+
+// Superset consulted by `try_expand_shorthand`. The `__test_force_*` entries
+// are hidden test seams (#127 OPS-005); listing them here keeps the
+// production binary from rewriting `sae __test_force_unknown` to
+// `sae search __test_force_unknown` so users see clap's "unrecognized
+// subcommand" error.
+// Also includes the deprecated `harvest` (split into `index`/`rebuild` in
+// v0.3.0) so `sae harvest` reaches clap as an unrecognized subcommand
+// instead of being silently rewritten to `sae search harvest` (pinned by
+// `deprecated_harvest_not_rewritten_as_search`, T-034c).
 const KNOWN_SUBCOMMANDS: &[&str] = &[
     "index",
     "rebuild",
@@ -344,7 +359,7 @@ fn handle_parse_error(e: &clap::Error, json_mode: bool) -> ExitCode {
         return ExitCode::SUCCESS;
     }
     if json_mode {
-        eprintln!("{}", render_parse_error(e, true));
+        eprintln!("{}", render_parse_error(e, true, PUBLIC_SUBCOMMANDS));
     } else {
         let _ = e.print();
     }
@@ -599,6 +614,26 @@ mod tests {
             }
             other => panic!("expected Archive, got {other:?}"),
         }
+    }
+
+    // T-400: PUBLIC_SUBCOMMANDS must match Cli's non-hidden subcommands
+    // (kept lock-step manually). Guards against drift when a new subcommand
+    // is added to enum Command without updating the constant (#148).
+    #[test]
+    fn public_subcommands_matches_cli_non_hidden() {
+        let cmd = Cli::command();
+        let from_cli: Vec<&str> = cmd
+            .get_subcommands()
+            .filter(|s| !s.is_hide_set())
+            .map(clap::Command::get_name)
+            .collect();
+        assert_eq!(
+            from_cli.as_slice(),
+            PUBLIC_SUBCOMMANDS,
+            "PUBLIC_SUBCOMMANDS drifted from Cli's non-hidden subcommands. \
+             Add the new subcommand to PUBLIC_SUBCOMMANDS, hide it from Cli, \
+             or reorder to match the enum definition."
+        );
     }
 
     // T-042: help output contains Examples section

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -412,6 +412,46 @@ fn no_team_envelope_lists_known_teams_as_candidates() {
     );
 }
 
+// T-CI015: end-to-end — a typo subcommand emits a `--json` envelope whose
+// `error.candidates` lists the user-facing subcommands without any
+// `__test_*` seam leaking. Closes #148.
+#[test]
+fn invalid_subcommand_envelope_lists_public_subcommands() {
+    let dir = tempdir().unwrap();
+    let output = sae_command(dir.path())
+        .args(["--json", "sserach", "test query"])
+        .output()
+        .expect("failed to spawn sae binary");
+
+    assert!(
+        !output.status.success(),
+        "typo subcommand must exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let env = parse_stderr_envelope(&stderr);
+    assert_eq!(env["error"]["code"], "USAGE_ERROR");
+
+    let candidates = env["error"]["candidates"]
+        .as_array()
+        .expect("candidates must be an array");
+    assert!(
+        !candidates.is_empty(),
+        "InvalidSubcommand must surface candidates; envelope: {env}"
+    );
+    assert!(
+        candidates
+            .iter()
+            .all(|c| !c.as_str().is_some_and(|s| s.starts_with("__test_"))),
+        "test-seam subcommands must not leak to user-facing candidates; got: {candidates:?}"
+    );
+    for required in ["search", "get", "status"] {
+        assert!(
+            candidates.iter().any(|c| c == required),
+            "candidates must include {required:?}; got: {candidates:?}"
+        );
+    }
+}
+
 // T-CI011: SSRF guard rejects http://127.0.0.1 base_url at construction time.
 // Integration tests cannot see `with_base_url_unchecked` (gated on `cfg(test)`
 // in the lib build), so they exercise the strict `with_base_url` path.


### PR DESCRIPTION
## Summary

`render_parse_error` は従来 `error.candidates` を常に空配列で返してたため、`sae sserach query` のような typo を検知した clap usage error から agent が recovery 候補を取れず、stderr の人間向け usage を parse する必要があった。

- `render_parse_error(e, json_mode, subcommands: &[&str])` に signature 拡張。`e.kind() == ErrorKind::InvalidSubcommand` のときだけ caller が渡した subcommand list を `candidates` に乗せる。他の clap error 種 (`MissingRequiredArgument` / `UnknownArgument`) は引き続き空
- `main.rs` に `PUBLIC_SUBCOMMANDS` (11 entries) を新規導入。`__test_*` seam (#127 OPS-005) と deprecated `harvest` (v0.3.0 で削除) を明示的に除外し、agent が retry しても無意味な entry を surface しない
- `KNOWN_SUBCOMMANDS` (17 entries) は `try_expand_shorthand` 用に従来通り superset を維持 (T-034c の前提)
- T-400 で `PUBLIC_SUBCOMMANDS` が `Cli::command()` の non-hidden subcommand と一致することを compile-time 直前で drift 検知

## Test plan

- [x] `cargo nextest run` — 371/371 pass (default)
- [x] `cargo nextest run --features test-support` — 376/376 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] T-397: InvalidSubcommand → candidates 入り
- [x] T-398: MissingRequiredArgument → candidates absent (regression guard)
- [x] T-399: UnknownArgument → candidates absent (regression guard)
- [x] T-400: PUBLIC_SUBCOMMANDS == Cli's non-hidden subcommands (drift insurance)
- [x] T-CI015: end-to-end `sae --json sserach` で candidates non-empty + no `__test_*` leak + 必須 subcommand 存在

## Limitations (accepted for v1)

sub-subcommand error (例: `sae model garbge`) も `InvalidSubcommand` を返すが、clap error の context が child level やから candidates list が parent (`PUBLIC_SUBCOMMANDS`) を返す。修正には `clap::Error` の context walk が必要、follow-up issue 領域。

## Notes

`assert_candidates_absent` helper は envelope の `skip_serializing_if = "Vec::is_empty"` 仕様で空 candidates が field omit される (JSON 上 `null`) ことを吸収。

Closes #148.
