### PR TITLE
fix(client): with_base_url が production throttle を適用するよう construct シグネチャを拡張 (#153)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -159,7 +159,7 @@ impl EsaClient {
     /// tests that need wiremock should use [`EsaClient::with_base_url_unchecked`].
     pub fn with_base_url(token: String, base_url: String) -> Result<Self, ClientError> {
         validate_base_url(&base_url)?;
-        Ok(Self::construct(token, base_url))
+        Ok(Self::construct(token, base_url, REQUEST_INTERVAL))
     }
 
     /// Test-only constructor that bypasses the SSRF allowlist so wiremock
@@ -168,15 +168,15 @@ impl EsaClient {
     /// into the binary path.
     #[cfg(test)]
     pub(crate) fn with_base_url_unchecked(token: String, base_url: String) -> Self {
-        Self::construct(token, base_url)
+        Self::construct(token, base_url, Duration::ZERO)
     }
 
-    fn construct(token: String, base_url: String) -> Self {
+    fn construct(token: String, base_url: String, request_interval: Duration) -> Self {
         Self {
             http: Client::new(),
             token,
             base_url,
-            request_interval: Duration::ZERO,
+            request_interval,
             last_request: Mutex::new(None),
         }
     }
@@ -880,5 +880,22 @@ mod tests {
     fn validate_base_url_rejects_invalid_url() {
         let err = validate_base_url("not-a-url").expect_err("garbage must be rejected");
         assert!(matches!(err, ClientError::InvalidRequest(_)));
+    }
+
+    // T-388: with_base_url uses production REQUEST_INTERVAL so the esa
+    // 75 req / 15 min quota throttle is enforced.
+    #[test]
+    fn with_base_url_sets_request_interval() {
+        let client =
+            EsaClient::with_base_url("tok".into(), "https://example.esa.io".into()).unwrap();
+        assert_eq!(client.request_interval, REQUEST_INTERVAL);
+    }
+
+    // T-389: with_base_url_unchecked keeps Duration::ZERO so wiremock-backed
+    // tests are not gated by the production rate limiter.
+    #[test]
+    fn with_base_url_unchecked_keeps_zero_interval() {
+        let client = EsaClient::with_base_url_unchecked("tok".into(), "http://127.0.0.1/".into());
+        assert_eq!(client.request_interval, Duration::ZERO);
     }
 }


### PR DESCRIPTION
## 概要

- `EsaClient::construct` が `request_interval: Duration::ZERO` を固定していた latent bug を修正
- `with_base_url` (production) → `REQUEST_INTERVAL`、`with_base_url_unchecked` (test) → `Duration::ZERO` を明示的に渡す形に変更
- 両 path を pin する regression test T-388 / T-389 を追加

## テスト計画

- [x] `cargo nextest run` 373 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] T-388: production path で REQUEST_INTERVAL pin (red 確認済み → green pass)
- [x] T-389: test path で Duration::ZERO pin (現状の wiremock fast-path 保持)

## /polish 結果

- Phase 1 review (simplify Reuse/Quality/Efficiency + codex + coderabbit + gemini) 通過
- Quality: T-388/T-389 のコメントを invariant-only に書き直し (CLAUDE.md「WHY not WHAT」準拠)
- Efficiency: throttle() の TOCTOU race を Phase 1 で検出 → pre-existing + 本 fix で window が active になる → 別 issue #155 で follow-up

## 関連

- Closes #153
- Follow-up: #155 (throttle() の Mutex TOCTOU race、本 PR で active になる)
- ADR drift: ADR-0004 line 122 の `with_base_url` 説明は本 fix で更に乖離 — 既存 issue #154 (ADR drift) で対応予定