### PR TITLE
docs(storage): 不変条件の WHY コメントを追加 (#151)

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,10 @@
+//! Storage layer for sae.
+//!
+//! Assumes single-process operation. WAL journaling + `busy_timeout=5000ms`
+//! handle ad-hoc contention from CLI re-invocations, but daemonized or
+//! concurrent CLI runs against the same DB file are unsupported (no advisory
+//! lock); moving to multi-process requires schema and lock redesign.
+
 pub(crate) mod embed;
 mod search;
 mod types;
@@ -92,6 +99,8 @@ const DDL: &str = "
     CREATE INDEX IF NOT EXISTS idx_chunks_post ON chunks(post_number);
 
     CREATE TABLE IF NOT EXISTS sync_state (
+        -- Singleton: one team per database, so sync_state has exactly one row.
+        -- The CHECK guards against schema changes that would allow multiple rows.
         id INTEGER PRIMARY KEY CHECK (id = 1),
         latest_updated_at TEXT,
         total_count INTEGER NOT NULL DEFAULT 0,
@@ -127,6 +136,9 @@ impl Db {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
+                // Best-effort: continue on chmod failure (restricted FS, exotic
+                // mount options) since DB functionality must not be blocked;
+                // the warn surfaces the failure so an operator can notice.
                 if let Err(e) = fs::set_permissions(parent, fs::Permissions::from_mode(0o700)) {
                     warn!(path = %parent.display(), error = %e, "failed to restrict data directory permissions");
                 }


### PR DESCRIPTION
## 概要

- `src/storage.rs` の暗黙不変条件 3 件に WHY コメントを注入
- behavior 変更なし、 documentation 追加のみ

## 修正箇所

| Audit row | 場所 | 内容 |
| --- | --- | --- |
| #29 (WAL + single-process) | module-doc (file 冒頭) | `//!` で WAL + single-process 前提を明示 (advisory lock 持たない、 daemonized / concurrent CLI 不可) |
| #31 (sync_state singleton) | `sync_state` schema 内 SQL コメント | `CHECK (id = 1)` の意図を pin (team-per-DB、 多 row schema 変更を guard) |
| #32 (chmod best-effort) | `Db::open` 内 Rust コメント | warn-and-continue の rationale 1 行 (non-Unix / restricted FS で DB 機能維持優先) |

## テスト計画

- [x] `cargo nextest run` 373 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] behavior 変更なし (コメント追加のみ、 既存 test で十分)

## 関連

- Closes #151
- 関連 audit: `docs/audit/2026-05-17-undocumented-decisions.md` row #29 / #31 / #32 (audit downgrade「やるべき」と精査済み)
- 関連 ADR: `docs/decisions/0003-sae-sqlite-schema-invariants-and-sync-atomicity.md` Schema Invariants 表

## メモ

- `docs/` は gitignore 配下のため ADR との直接 cross-reference は file path のみ
- audit row #29 (WAL + single-process) は ADR-0003 line 93 と内容重複。 source 側に short version を持たせる方針 (ADR は local-only、 source は新規 contributor が最初に触る場所)