### PR TITLE
docs(search): magic value の rationale を追加 (#150)

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -168,6 +168,10 @@ pub(crate) fn run_search(
         embed_info,
         &search_output.warnings,
     )?;
+    // 5-minute TTL: long enough that repeated user searches within a single
+    // workflow do not trigger redundant background harvests (coalescing), but
+    // short enough that an idle period (e.g., next day) re-fetches before the
+    // next search returns stale results.
     const PREFETCH_TTL_SECS: u64 = 5 * 60;
     if !storage::sync_harvested_within(db.conn(), PREFETCH_TTL_SECS) {
         spawn_background_index(team);

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -126,6 +126,12 @@ fn append_search_filters(
     append_timestamp_day_cutoff_filter(sql, params, "p.updated_at", true, before.as_deref());
 }
 
+const SNIPPET_CHAR_LIMIT: usize = 200;
+
+/// Truncate `s` to at most `max_chars` characters (not bytes), appending
+/// `...` only when truncated. Uses `char_indices().nth()` to find the
+/// char-boundary byte position, so the result is always valid UTF-8 even
+/// for multi-byte input (e.g., CJK).
 fn truncate_snippet(s: &str, max_chars: usize) -> String {
     match s.char_indices().nth(max_chars) {
         None => s.to_owned(),
@@ -211,6 +217,10 @@ fn apply_recency_boost(
                     recency_decay(age_days, RECENCY_HALF_LIFE)
                 })
                 .unwrap_or(0.0);
+            // Boost factor `1.0 + RECENCY_WEIGHT * decay` caps at
+            // `1.0 + RECENCY_WEIGHT` (currently 1.2×); changing `RECENCY_WEIGHT`
+            // shifts the cap proportionally and must be reflected in T-103
+            // expected score deltas.
             let boosted = rrf_score * (1.0 + RECENCY_WEIGHT * decay);
             (post_number, boosted)
         })
@@ -265,6 +275,9 @@ pub(crate) fn fts_search(
     collect_storage_rows(rows)
 }
 
+// 10× oversample before MaxSim dedup: each chunk holds multiple sub-embeddings
+// (`ChunkedEmbedding`), so KNN must fetch enough rows to give the dedup step
+// real candidates. Larger value gains recall, smaller cuts query latency.
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
 
 pub(crate) fn vec_search(
@@ -350,6 +363,14 @@ pub(crate) fn vec_search(
     Ok(hits)
 }
 
+// Candidate pool multipliers: fetch more candidates than the user-requested
+// `limit` so RRF merging and recency boost have headroom. The reranker case
+// pulls 4× because cross-encoder reordering can promote any of the 4× pool;
+// the non-rerank case pulls 3× since RRF + recency only reshuffle relative
+// rank inside the pool.
+const RERANK_CANDIDATE_MULT: u32 = 4;
+const BASE_CANDIDATE_MULT: u32 = 3;
+
 pub fn hybrid_search(
     conn: &Connection,
     query: &str,
@@ -360,9 +381,9 @@ pub fn hybrid_search(
     reranker: Option<&dyn Rerank>,
 ) -> Result<SearchOutput, StorageError> {
     let candidate_limit = if reranker.is_some() {
-        limit * 4
+        limit * RERANK_CANDIDATE_MULT
     } else {
-        limit * 3
+        limit * BASE_CANDIDATE_MULT
     };
 
     let fts_hits = fts_search(conn, query, candidate_limit, filter)?;
@@ -461,7 +482,7 @@ pub fn hybrid_search(
                 post_name: meta.name,
                 post_url: meta.url,
                 section_title,
-                snippet: truncate_snippet(&snippet, 200),
+                snippet: truncate_snippet(&snippet, SNIPPET_CHAR_LIMIT),
                 score: score as f32,
                 // Semantic takes priority when a post matched both sources.
                 match_source: if vec_hit.is_some() {


### PR DESCRIPTION
## 概要

- `src/storage/search.rs` / `src/commands/search.rs` の 5 件 magic value に rationale を追加
- 3 件は WHY コメント、 2 件は named const 化 + rationale comment + rustdoc
- behavior 変更なし、 documentation 追加 + const 抽出のみ

## 修正箇所

| Audit row | 場所 | 種別 | 内容 |
| --- | --- | --- | --- |
| #5 | `apply_recency_boost` (`src/storage/search.rs:213`) | WHY comment | boost cap = `1.0 + RECENCY_WEIGHT` (1.2× at decay=1.0)、 `RECENCY_WEIGHT` 変更で cap が動く依存関係 |
| #9 | `VEC_MAXSIM_OVERSAMPLE` (`src/storage/search.rs:268`) | WHY comment | 10× の recall vs query latency tradeoff、 `ChunkedEmbedding` sub-emb 構造との関連 |
| #10 | `hybrid_search` candidate_limit (`src/storage/search.rs:353`) | named const | `RERANK_CANDIDATE_MULT` (= 4) / `BASE_CANDIDATE_MULT` (= 3) 抽出 + rationale |
| #17 | `truncate_snippet` (`src/storage/search.rs:129`) | named const + rustdoc | `SNIPPET_CHAR_LIMIT` (= 200) 抽出 + UTF-8 boundary safety を rustdoc に明示 |
| #63 | `PREFETCH_TTL_SECS` (`src/commands/search.rs:171`) | WHY comment | 5-minute TTL の freshness vs background prefetch coalescing |

## テスト計画

- [x] `cargo nextest run` 373 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] behavior 変更なし (named const 化は同値変換、 既存 test T-106 / T-191 / T-192 が `truncate_snippet` 仕様を pin)

## 関連

- Closes #150
- 関連 audit: `docs/audit/2026-05-17-undocumented-decisions.md` row #5 / #9 / #10 / #17 / #63
- 関連 const: `RECENCY_HALF_LIFE` / `RECENCY_WEIGHT` / `RRF_K` (`src/storage/search.rs:157-160`)

## メモ

- const 配置は file 既存 pattern (primary use site の直前に co-locate) に従う
- `truncate_snippet` は private 関数だが、 contract documentation のため `///` (rustdoc) を採用
- Item #5 comment は cap の数値 (1.2×) を埋め込むのではなく、 `RECENCY_WEIGHT` 変更時の cap shift を強調 (comment が即 stale にならない設計)