### PR TITLE
test(output): insta snapshot で text / YAML format を pin (#152)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2497,7 @@ dependencies = [
  "amici",
  "bytemuck",
  "clap",
+ "insta",
  "jiff",
  "reqwest 0.13.3",
  "rurico",
@@ -2652,6 +2665,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
+insta = "1"
 rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06", features = ["test-support"] }
 tempfile = "3"
 wiremock = "0.6"

--- a/src/output.rs
+++ b/src/output.rs
@@ -205,7 +205,50 @@ pub(crate) fn status(statuses: &[TeamStatus]) -> Result<CommandOutput, SaeError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::EsaUser;
     use crate::storage::{EmbedResult, MatchSource, SyncState};
+
+    fn make_post() -> EsaPost {
+        EsaPost {
+            number: 42,
+            name: "Onboarding".to_owned(),
+            full_name: "design/Onboarding".to_owned(),
+            body_md: Some("# Welcome\n\nFirst paragraph.".to_owned()),
+            category: Some("design".to_owned()),
+            tags: vec!["docs".to_owned(), "team".to_owned()],
+            wip: false,
+            kind: "stock".to_owned(),
+            url: "https://example.esa.io/posts/42".to_owned(),
+            created_at: "2025-01-01 00:00:00".to_owned(),
+            updated_at: "2025-01-15 12:00:00".to_owned(),
+            created_by: EsaUser {
+                screen_name: "alice".to_owned(),
+            },
+            updated_by: EsaUser {
+                screen_name: "alice".to_owned(),
+            },
+            revision_number: 3,
+        }
+    }
+
+    fn make_result(
+        post_number: u32,
+        name: &str,
+        section: Option<&str>,
+        score: f32,
+        snippet: &str,
+        source: MatchSource,
+    ) -> SearchResult {
+        SearchResult {
+            post_number,
+            post_name: name.to_owned(),
+            post_url: format!("https://example.esa.io/posts/{post_number}"),
+            section_title: section.map(str::to_owned),
+            snippet: snippet.to_owned(),
+            score,
+            match_source: source,
+        }
+    }
 
     fn make_synced(team: &str, posts: u32) -> TeamStatus {
         TeamStatus {
@@ -353,15 +396,7 @@ mod tests {
     // T-089: search human fts fallback shows notice
     #[test]
     fn search_human_fts_fallback_shows_notice() {
-        let results = vec![SearchResult {
-            post_number: 1,
-            post_name: "Test".to_owned(),
-            post_url: "https://example.com".to_owned(),
-            section_title: None,
-            snippet: String::new(),
-            score: 0.5,
-            match_source: MatchSource::Fts,
-        }];
+        let results = vec![make_result(1, "Test", None, 0.5, "", MatchSource::Fts)];
         let out = search(&results, "q", false, false, None, &[]).unwrap();
         assert!(out.markdown.contains("semantic search unavailable"));
     }
@@ -369,15 +404,7 @@ mod tests {
     // T-090: search human hybrid does not show fallback notice
     #[test]
     fn search_human_hybrid_no_fallback_notice() {
-        let results = vec![SearchResult {
-            post_number: 1,
-            post_name: "Test".to_owned(),
-            post_url: "https://example.com".to_owned(),
-            section_title: None,
-            snippet: String::new(),
-            score: 0.5,
-            match_source: MatchSource::Fts,
-        }];
+        let results = vec![make_result(1, "Test", None, 0.5, "", MatchSource::Fts)];
         let out = search(&results, "q", true, false, None, &[]).unwrap();
         assert!(!out.markdown.contains("semantic search unavailable"));
     }
@@ -440,5 +467,59 @@ mod tests {
             "storage warning should come second (downstream); got: {:?}",
             out.notes
         );
+    }
+
+    // T-401: format_post_frontmatter typical post → frontmatter snapshot.
+    // Out of scope: wip:true / updated_by != created_by (separate pin if needed).
+    #[test]
+    fn format_post_frontmatter_typical_post_snapshot() {
+        let post = make_post();
+        insta::assert_snapshot!(format_post_frontmatter(&post));
+    }
+
+    // T-402: search hybrid with section_title present vs absent → markdown snapshot.
+    #[test]
+    fn search_semantic_hybrid_two_results_snapshot() {
+        let results = vec![
+            make_result(
+                101,
+                "Architecture",
+                Some("Overview"),
+                0.9123,
+                "First snippet content",
+                MatchSource::Semantic,
+            ),
+            make_result(
+                102,
+                "Pricing model",
+                None,
+                0.7456,
+                "Second snippet content",
+                MatchSource::Fts,
+            ),
+        ];
+        let out = search(&results, "design", true, false, None, &[]).unwrap();
+        insta::assert_snapshot!(out.markdown);
+    }
+
+    // T-403: search FTS fallback with embed_info → markdown snapshot
+    // (agents parse the embed hint).
+    #[test]
+    fn search_fts_fallback_with_embed_info_snapshot() {
+        let results = vec![make_result(
+            1,
+            "Test post",
+            None,
+            0.5,
+            "snippet text",
+            MatchSource::Fts,
+        )];
+        let info = EmbedInfo {
+            processed: 5,
+            budget_exhausted: true,
+            team: "demo".to_owned(),
+        };
+        let out = search(&results, "test", false, false, Some(info), &[]).unwrap();
+        insta::assert_snapshot!(out.markdown);
     }
 }

--- a/src/snapshots/sae__output__tests__format_post_frontmatter_typical_post_snapshot.snap
+++ b/src/snapshots/sae__output__tests__format_post_frontmatter_typical_post_snapshot.snap
@@ -1,0 +1,17 @@
+---
+source: src/output.rs
+expression: format_post_frontmatter(&post)
+---
+---
+title: "design/Onboarding"
+category: "design"
+tags: ["docs", "team"]
+author: "@alice"
+updated_at: "2025-01-15 12:00:00"
+number: 42
+url: https://example.esa.io/posts/42
+---
+
+# Welcome
+
+First paragraph.

--- a/src/snapshots/sae__output__tests__search_fts_fallback_with_embed_info_snapshot.snap
+++ b/src/snapshots/sae__output__tests__search_fts_fallback_with_embed_info_snapshot.snap
@@ -1,0 +1,9 @@
+---
+source: src/output.rs
+expression: out.markdown
+---
+(semantic search unavailable, showing text-match results)
+[0.5000] Test post (#1)  https://example.esa.io/posts/1
+  snippet text
+(Embedded 5 new chunks)
+Hint: more chunks pending. Run 'sae embed demo' to index all.

--- a/src/snapshots/sae__output__tests__search_semantic_hybrid_two_results_snapshot.snap
+++ b/src/snapshots/sae__output__tests__search_semantic_hybrid_two_results_snapshot.snap
@@ -1,0 +1,8 @@
+---
+source: src/output.rs
+expression: out.markdown
+---
+[0.9123] Architecture > Overview (#101)  https://example.esa.io/posts/101
+  First snippet content
+[0.7456] Pricing model (#102)  https://example.esa.io/posts/102
+  Second snippet content


### PR DESCRIPTION
## 概要

- `format_post_frontmatter` (YAML frontmatter) と `output::search` (markdown) を insta snapshot で凍結
- format 変更時に snapshot diff で intent 確認可能、 behavior 変更なし
- 2026-05-17 audit downgrade row #69 / #70 の follow-up

## 変更内容

| File | Change |
| --- | --- |
| `Cargo.toml` | `insta = "1"` を dev-deps に追加 |
| `src/output.rs` | `make_post()` / `make_result()` helper + T-401 / T-402 / T-403 (3 snapshot test) 追加。 T-089 / T-090 の inline `SearchResult` を `make_result` に置換 (polish 改善) |
| `src/snapshots/` | 3 snapshot file 新規 (frontmatter typical / semantic hybrid / FTS fallback + embed_info hint) |

## テスト計画

- [x] `cargo nextest run`: 376 / 376 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] /polish (6 tool 並列): med 2 件 fix 適用、 残り findings なし
- [x] snapshot 内容を目視確認 (intent 通り)

## スコープ

- AC #1: frontmatter 1 snapshot (title + category + tags 含む typical post)
- AC #2: search markdown 2 snapshot (semantic hybrid / FTS fallback + embed_info)
- Out of scope: wip:true / `updated_by != created_by` 分岐 (follow-up 候補)
- Out of scope: `EsaPost` / `SearchResult` fixture の test-support feature 統合 (sync.rs / client.rs / output.rs の 3 module 重複は別 issue)

Closes #152