### PR TITLE
feat: index に embed を統合し search を read-only 化（yomu 整列）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -684,9 +684,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -716,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1364,7 +1364,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1739,7 +1739,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2316,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror",
@@ -2398,7 +2398,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2457,7 +2457,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2596,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2691,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2728,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "cdd578e94101503d97e2b286bbf8db2135035ca24b2ce4cbf3f9e2fb2bbf1eee"
 dependencies = [
  "cc",
  "js-sys",
@@ -2845,7 +2845,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sae search - < query.txt
 sae get 42
 ```
 
-`--team` を省略した場合は `default_team` → 設定済みチームが1つだけならそれ → どちらでもなければ `USAGE_ERROR` (64) の順で解決される。`index` / `rebuild` / `embed` だけは team が必須 positional。
+`--team` を省略した場合は `default_team` → 設定済みチームが1つだけならそれ → どちらでもなければ `USAGE_ERROR` (64) の順で解決される。`index` / `rebuild` だけは team が必須 positional。
 
 ### 投稿の作成・更新
 
@@ -107,10 +107,13 @@ sae archive 42 --dry-run
 # 埋め込みモデルをダウンロード（初回のみ）
 sae model download
 
-# チャンクの埋め込み
-sae embed myteam
+# モデル導入後は sae index / sae rebuild がチャンク生成と埋め込みをまとめて実行
+# （未導入で未埋め込みチャンクが残ると EmbedderUnavailable (75) で失敗するため、
+#  先に model download。すべて埋め込み済みならモデル無しでも index は成功）
+sae index myteam
 
-# 以降の検索は FTS + ベクトルのハイブリッド
+# 検索は読み取り専用（FTS + ベクトルのハイブリッド）。esa の最新を反映するには
+# sae index を再実行する（search は自動で再取得・再埋め込みしない）
 sae search "認証フローの設計方針"
 
 # embedder のロードコストを避けて FTS のみで検索（CI / スクリプト用途）
@@ -145,17 +148,17 @@ sysexits.h の symbolic name (`EX_USAGE`, `EX_SOFTWARE` 等) は数値の出典�
 | 0    | (none)         | 正常終了         |                                                          |             |
 | 64   | USAGE_ERROR    | 入力エラー       | 不明なチーム、トークン未設定、未 index 実行              | しない      |
 | 65   | DATA_ERROR     | データ形式不正   | `--after` / `--before` の日付形式不正 (`YYYY-MM-DD` 以外)、esa API 404 (指定 post 番号がチームに存在しない) | しない      |
-| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、esa API の 404 以外の HTTP エラー (5xx および 401/403/422 等の 4xx)、MLX backend 不在 (`sae embed` / `sae model download` 共通)、model download 検証失敗 (`ModelDownloadError::ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected)、embedder invariant 違反 (例: batch count mismatch) | しない      |
+| 70   | INTERNAL       | 内部エラー       | JSON parse 失敗、esa API の 404 以外の HTTP エラー (5xx および 401/403/422 等の 4xx)、MLX backend 不在 (`sae index` / `sae model download` 共通)、model download 検証失敗 (`ModelDownloadError::ProbeFailed`)、`ProbeError` (HandlerNotInstalled / ModelLoadFailed / SetupRejected)、embedder invariant 違反 (例: batch count mismatch) | しない      |
 | 73   | CANT_CREAT     | データ層エラー   | DB open 失敗、ファイル作成不可                           | 状況による  |
 | 74   | IO_ERROR       | I/O エラー       | ファイル読み書き失敗、`ProbeError::SubprocessFailed`     | 状況による  |
-| 75   | TEMP_FAILURE   | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout) | する  |
+| 75   | TEMP_FAILURE   | 一時的エラー     | esa API rate limit、ネットワーク障害、model download 一時的失敗 (429, 5xx, timeout)、embedding モデル未インストールで `sae index` / `rebuild` が埋め込み不能 (`EmbedderUnavailable`、`sae model download` で解消) | する  |
 | 104  | UNKNOWN        | 分類不能         | model probe fallback、未型化の embedder ランタイムエラー (`anyhow::Error` 経由)、その他の想定外例外。分類済み 70 と区別する ADR-0066 L136 の意図に対応 | しない |
 
 > ⚠️ 破壊的変更（issue #91 / amici #34 migration）: 旧 schema (`1` / `2` / `4`) からの切り替え。スクリプト / CI で specific number に branch している場合は更新が必要。
 
 > ⚠️ 破壊的変更（issue #126 / ADR-0066 Group 2 baseline）: 日付形式不正が 64 → 65、catch-all (`SaeError::Other`) が 70 → 104 に変化。`--json` の `error.code` も同様に `USAGE_ERROR` → `DATA_ERROR`、`INTERNAL` → `UNKNOWN`。
 
-> ⚠️ 破壊的変更（issue #127 / `SaeError::Other` routing audit）: #126 で catch-all が 70 → 104 に動いた一方、以下の 2 種の失敗は **70 (INTERNAL) に分類される** — `sae embed` / `sae search` での MLX backend 不在 (`SaeError::BackendUnavailable`)、`sae embed` / `sae search` での embedder invariant 違反 (`SaeError::Internal`、例: batch count mismatch)。`sae model download` 側 (既に 70) と routing を揃え、agent が「ハードウェア / 環境不一致 or プログラム不変条件違反」シグナルとして検知できるようにする。**net 状態**: agent retry policy は `error.code` (= `"INTERNAL"` か `"UNKNOWN"`) で分岐すれば #126 / #127 双方の変更を吸収できる。
+> ⚠️ 破壊的変更（issue #127 / `SaeError::Other` routing audit）: #126 で catch-all が 70 → 104 に動いた一方、以下の 2 種の失敗は **70 (INTERNAL) に分類される** — `sae index` / `sae search` での MLX backend 不在 (`SaeError::BackendUnavailable`)、`sae index` / `sae search` での embedder invariant 違反 (`SaeError::Internal`、例: batch count mismatch)。`sae model download` 側 (既に 70) と routing を揃え、agent が「ハードウェア / 環境不一致 or プログラム不変条件違反」シグナルとして検知できるようにする。**net 状態**: agent retry policy は `error.code` (= `"INTERNAL"` か `"UNKNOWN"`) で分岐すれば #126 / #127 双方の変更を吸収できる。
 
 > ⚠️ 破壊的変更（issue #136 / esa API 404 reclassify）: esa API が 404 (post not found) を返したときの exit code が `70` → `65`、`--json` の `error.code` が `"INTERNAL"` → `"DATA_ERROR"` に変化。`next_step` に「Verify the post number exists in esa, or run `sae search <keyword>` to find it.」が付くため、agent が「入力 post 番号間違い」と「サーバ起因 5xx」を判別できる。**net 状態**: 404 (入力データ起因) は 65、404 以外の HTTP error (5xx および 401/403/422 等) は 70 のまま。`error.code` で分岐していれば変更は自動吸収される。
 

--- a/src/commands/embed_batch.rs
+++ b/src/commands/embed_batch.rs
@@ -6,12 +6,13 @@ use crate::tools::SaeError;
 
 pub(crate) const BATCH_SIZE: u32 = 512;
 
+#[derive(Debug)]
 pub(crate) struct BatchResult {
     pub(crate) added: u32,
     pub(crate) processed: u32,
-    pub(crate) budget_exhausted: bool,
 }
 
+#[derive(Debug)]
 pub(crate) struct EmbedAllResult {
     pub(crate) added: u32,
     pub(crate) total_chunks: u32,
@@ -57,7 +58,6 @@ where
         return Ok(BatchResult {
             added: 0,
             processed: 0,
-            budget_exhausted: false,
         });
     }
     let texts: Vec<&str> = batch.iter().map(|(_, c)| c.as_str()).collect();
@@ -79,6 +79,68 @@ where
     Ok(BatchResult {
         added,
         processed: batch_len,
-        budget_exhausted: batch_len == budget,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{self, Db};
+    use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
+
+    fn db_with_chunks(n: u32) -> Db {
+        let db = Db::open_memory().unwrap();
+        for i in 1..=n {
+            storage::upsert_post(db.conn(), &storage::test_post_row(i)).unwrap();
+            storage::rechunk_post(db.conn(), i, "# Hello\nWorld").unwrap();
+        }
+        db
+    }
+
+    fn ok_embed(texts: &[&str]) -> Result<Vec<ChunkedEmbedding>, SaeError> {
+        Ok(texts
+            .iter()
+            .map(|_| ChunkedEmbedding::new(vec![vec![0.5; EMBEDDING_DIMS]]))
+            .collect())
+    }
+
+    // T-411: embed_one_batch embeds pending chunks within budget and clears them
+    #[test]
+    fn embed_one_batch_embeds_pending() {
+        let db = db_with_chunks(1);
+        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 1);
+        let result = embed_one_batch(db.conn(), 256, ok_embed).unwrap();
+        assert_eq!(result.processed, 1, "one chunk should be processed");
+        assert_eq!(result.added, 1, "one embedding should be inserted");
+        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 0);
+    }
+
+    // T-412: embed_all loops embed_one_batch until every pending chunk is embedded
+    #[test]
+    fn embed_all_embeds_all_pending() {
+        let db = db_with_chunks(2);
+        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 2);
+        let result = embed_all(db.conn(), ok_embed, |_| {}).unwrap();
+        assert_eq!(result.total_chunks, 2, "both chunks should be processed");
+        assert_eq!(result.added, 2, "both embeddings should be inserted");
+        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 0);
+    }
+
+    // T-413: embed_one_batch rejects an embedding-count mismatch as Internal
+    // (#127 invariant: embedder returning the wrong vector count is a
+    // programmer-detectable bug, routed to INTERNAL not the anyhow-swallow path).
+    #[test]
+    fn embed_one_batch_rejects_count_mismatch() {
+        let db = db_with_chunks(1);
+        let result = embed_one_batch(db.conn(), 256, |_| Ok(vec![]));
+        assert!(
+            matches!(result, Err(SaeError::Internal(_))),
+            "count mismatch must surface as Internal, got {result:?}"
+        );
+        assert_eq!(
+            storage::count_unembedded_chunks(db.conn()).unwrap(),
+            1,
+            "a rejected batch must not change the unembedded count"
+        );
+    }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,6 +1,4 @@
-use std::env;
 use std::io::{self, IsTerminal, Read};
-use std::process::{Command, Stdio};
 
 use crate::config::Config;
 use crate::envelope::CommandOutput;
@@ -9,15 +7,12 @@ use amici::model::{ModelLoad, record_degraded};
 use jiff::Timestamp;
 use jiff::civil::Date;
 use jiff::tz::TimeZone;
-use rurico::embed::ChunkedEmbedding;
 use rurico::reranker::Rerank;
 
 use super::embedder::try_load_embedder;
 use super::reranker::try_load_reranker;
 use crate::output;
 use crate::tools::{SaeError, require_db};
-
-const SEARCH_EMBED_BUDGET: u32 = 128;
 
 fn parse_date_arg(s: Option<&str>, flag: &str) -> Result<Option<Timestamp>, SaeError> {
     let Some(s) = s else {
@@ -32,43 +27,6 @@ fn parse_date_arg(s: Option<&str>, flag: &str) -> Result<Option<Timestamp>, SaeE
         .to_zoned(TimeZone::UTC)
         .map_err(|e| SaeError::InputData(format!("failed to zone date to UTC: {e}")))?;
     Ok(Some(zoned.timestamp()))
-}
-
-/// Embeds up to `budget` pending chunks in one batch.
-/// Returns `(processed, budget_exhausted)` — `budget_exhausted` signals more chunks remain.
-fn auto_embed_pending_with<F>(
-    db: &storage::Db,
-    budget: u32,
-    embed_fn: F,
-) -> Result<(u32, bool), SaeError>
-where
-    F: Fn(&[&str]) -> Result<Vec<ChunkedEmbedding>, SaeError>,
-{
-    let result = super::embed_batch::embed_one_batch(db.conn(), budget, embed_fn)?;
-    if result.processed == 0 {
-        return Ok((0, false));
-    }
-    tracing::debug!(
-        chunks = result.processed,
-        "auto_embed_pending: embedded chunks during search"
-    );
-    Ok((result.processed, result.budget_exhausted))
-}
-
-fn spawn_background_index(team: &str) {
-    let Ok(exe) = env::current_exe() else {
-        tracing::warn!("background index skipped: current_exe() failed");
-        return;
-    };
-    if let Err(e) = Command::new(exe)
-        .args(["index", team])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        tracing::warn!(error = %e, "background index spawn failed");
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -97,28 +55,6 @@ pub(crate) fn run_search(
             record_degraded(*reason, "search: embedder load");
         }
         (result.as_ref().ok(), result.is_err())
-    };
-    let embed_info = if let Some(emb) = embedder {
-        match auto_embed_pending_with(&db, SEARCH_EMBED_BUDGET, |texts| {
-            emb.embed_documents_batch(texts)
-                // Other (UNKNOWN): embedder's runtime error is an opaque
-                // `anyhow::Error` (no typed variant from amici/rurico).
-                // Mirrors `tools::Sae::embed`; promoting requires upstream
-                // typed surface first.
-                .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
-        }) {
-            Ok((processed, budget_exhausted)) => Some(output::EmbedInfo {
-                processed,
-                budget_exhausted,
-                team: team.to_owned(),
-            }),
-            Err(e) => {
-                tracing::warn!(error = %e, "auto-embed failed, continuing with existing embeddings");
-                None
-            }
-        }
-    } else {
-        None
     };
     let query_embedding = if let Some(e) = embedder {
         match e.embed_query(query) {
@@ -159,24 +95,20 @@ pub(crate) fn run_search(
     for w in &search_output.warnings {
         tracing::warn!("{w}");
     }
-    let semantic = query_embedding.is_some();
-    let output = output::search(
+    // `semantic` reflects whether vector search actually ran, not just whether
+    // the embedder loaded: hybrid_search skips vectors when nothing is embedded
+    // yet (e.g. indexed before `model download`), so report FTS — not a
+    // misleading "hybrid" — in that case. Mirrors hybrid_search's own guard.
+    let semantic = query_embedding.is_some() && storage::has_embeddings(db.conn());
+    // Search is read-only — no auto-embed, no background index. Build the
+    // index explicitly with `sae index` / `sae rebuild` (mirrors yomu).
+    output::search(
         &search_output.results,
         query,
         semantic,
         embedder_load_failed,
-        embed_info,
         &search_output.warnings,
-    )?;
-    // 5-minute TTL: long enough that repeated user searches within a single
-    // workflow do not trigger redundant background harvests (coalescing), but
-    // short enough that an idle period (e.g., next day) re-fetches before the
-    // next search returns stale results.
-    const PREFETCH_TTL_SECS: u64 = 5 * 60;
-    if !storage::sync_harvested_within(db.conn(), PREFETCH_TTL_SECS) {
-        spawn_background_index(team);
-    }
-    Ok(output)
+    )
 }
 
 fn read_stdin_value(
@@ -228,131 +160,7 @@ pub fn resolve_search_query(query: Option<String>) -> Result<String, SaeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
     use std::io::Cursor;
-
-    fn make_test_row(number: u32) -> storage::EsaPostRow {
-        storage::EsaPostRow {
-            body_md: "# Hello\nWorld".into(),
-            category: None,
-            ..storage::test_post_row(number)
-        }
-    }
-
-    // T-065: auto_embed_pending_with skips embed_fn when no unembedded chunks
-    #[test]
-    fn auto_embed_skips_when_no_unembedded_chunks() {
-        let db = storage::Db::open_memory().unwrap();
-        let called = Cell::new(false);
-        let result = auto_embed_pending_with(&db, 256, |_| {
-            called.set(true);
-            Ok(vec![])
-        });
-        assert!(result.is_ok());
-        assert!(
-            !called.get(),
-            "embed_fn must not be called when no chunks pending"
-        );
-    }
-
-    // T-066: auto_embed_pending_with embeds chunks within budget
-    #[test]
-    fn auto_embed_embeds_pending_chunks() {
-        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
-
-        let db = storage::Db::open_memory().unwrap();
-        let row = make_test_row(1);
-        storage::upsert_post(db.conn(), &row).unwrap();
-        storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
-
-        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 1);
-
-        let result = auto_embed_pending_with(&db, 256, |texts| {
-            Ok(texts
-                .iter()
-                .map(|_| ChunkedEmbedding::new(vec![vec![0.5; EMBEDDING_DIMS]]))
-                .collect())
-        });
-        assert!(result.is_ok());
-        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 0);
-    }
-
-    // T-067: auto_embed_pending_with respects budget and leaves excess chunks unembedded
-    #[test]
-    fn auto_embed_respects_budget() {
-        use rurico::embed::{ChunkedEmbedding, EMBEDDING_DIMS};
-
-        let db = storage::Db::open_memory().unwrap();
-        for i in 1u32..=2 {
-            let row = make_test_row(i);
-            storage::upsert_post(db.conn(), &row).unwrap();
-            storage::rechunk_post(db.conn(), i, "# Hello\nWorld").unwrap();
-        }
-
-        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 2);
-
-        let result = auto_embed_pending_with(&db, 1, |texts| {
-            Ok(texts
-                .iter()
-                .map(|_| ChunkedEmbedding::new(vec![vec![0.5; EMBEDDING_DIMS]]))
-                .collect())
-        });
-        assert!(result.is_ok());
-        assert!(
-            result.unwrap().1,
-            "budget=1 with 2 chunks should signal budget exhausted"
-        );
-        assert_eq!(
-            storage::count_unembedded_chunks(db.conn()).unwrap(),
-            1,
-            "budget=1 should leave 1 chunk unembedded"
-        );
-    }
-
-    // T-068: auto_embed_pending_with propagates embed_fn error without side effects
-    #[test]
-    fn auto_embed_propagates_embed_error() {
-        let db = storage::Db::open_memory().unwrap();
-        let row = make_test_row(1);
-        storage::upsert_post(db.conn(), &row).unwrap();
-        storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
-
-        assert_eq!(storage::count_unembedded_chunks(db.conn()).unwrap(), 1);
-
-        let result =
-            auto_embed_pending_with(&db, 256, |_| Err(SaeError::Other("model OOM".into())));
-        assert!(result.is_err(), "embed_fn error should propagate");
-        assert!(result.unwrap_err().to_string().contains("model OOM"));
-        assert_eq!(
-            storage::count_unembedded_chunks(db.conn()).unwrap(),
-            1,
-            "failed embed must not change unembedded count"
-        );
-    }
-
-    // T-069: auto_embed_pending_with rejects embedding count mismatch
-    #[test]
-    fn auto_embed_rejects_count_mismatch() {
-        let db = storage::Db::open_memory().unwrap();
-        let row = make_test_row(1);
-        storage::upsert_post(db.conn(), &row).unwrap();
-        storage::rechunk_post(db.conn(), 1, "# Hello\nWorld").unwrap();
-
-        let result = auto_embed_pending_with(&db, 256, |_| Ok(vec![]));
-        assert!(result.is_err(), "count mismatch should be an error");
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Embedding count mismatch"),
-            "error should describe the mismatch"
-        );
-        assert_eq!(
-            storage::count_unembedded_chunks(db.conn()).unwrap(),
-            1,
-            "mismatched embed must not change unembedded count"
-        );
-    }
 
     fn resolve_search(
         value: Option<&str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub fn __test_search_with_warnings() -> Result<CommandOutput, SaeError> {
         score: 0.5,
         match_source: storage::MatchSource::Fts,
     };
-    output::search(&[result], "test query", true, false, None, &warnings)
+    output::search(&[result], "test query", true, false, &warnings)
 }
 
 /// Renders [`CommandOutput`] for stdout. With `json_mode` set, emits the

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Fetch new esa posts incrementally and index them
+    /// Fetch new esa posts incrementally and index them (chunks + embeddings)
     #[command(after_help = "\
 Examples:
   sae index myteam")]
@@ -39,7 +39,7 @@ Examples:
         /// Team name
         team: String,
     },
-    /// Re-fetch all esa posts and rebuild the index from scratch
+    /// Re-fetch all esa posts and rebuild the index from scratch (chunks + embeddings)
     #[command(after_help = "\
 Examples:
   sae rebuild myteam")]
@@ -47,14 +47,16 @@ Examples:
         /// Team name
         team: String,
     },
-    /// Semantic search over indexed posts
+    /// Semantic search over indexed posts (read-only)
     #[command(after_help = "\
 Examples:
   sae search \"認証\" --team myteam --limit 5
   sae search \"認証\" --after 2025-01-01
   sae search \"認証\" --after 2025-01-01 --before 2025-06-30
   echo \"認証\" | sae search
-  sae search -")]
+  sae search -
+
+Search is read-only; build the index first with `sae index` (re-run it to refresh).")]
     Search {
         #[command(flatten)]
         args: SearchArgs,
@@ -125,14 +127,6 @@ Examples:
         /// Preview without shipping (no mutation API calls)
         #[arg(long)]
         dry_run: bool,
-    },
-    /// Embed all chunks (model must be downloaded first)
-    #[command(after_help = "\
-Examples:
-  sae embed myteam")]
-    Embed {
-        /// Team name
-        team: String,
     },
     /// Show sync status
     #[command(after_help = "\
@@ -212,8 +206,7 @@ enum ModelCommand {
 // Kept manually parallel to the live `Cli` enum; drift is guarded by
 // `public_subcommands_matches_cli_non_hidden` in tests.
 const PUBLIC_SUBCOMMANDS: &[&str] = &[
-    "index", "rebuild", "search", "get", "create", "update", "archive", "ship", "embed", "status",
-    "model",
+    "index", "rebuild", "search", "get", "create", "update", "archive", "ship", "status", "model",
 ];
 
 // Superset consulted by `try_expand_shorthand`. The `__test_force_*` entries
@@ -225,6 +218,9 @@ const PUBLIC_SUBCOMMANDS: &[&str] = &[
 // v0.3.0) so `sae harvest` reaches clap as an unrecognized subcommand
 // instead of being silently rewritten to `sae search harvest` (pinned by
 // `deprecated_harvest_not_rewritten_as_search`, T-034c).
+// Likewise `embed` (removed once `index`/`rebuild` absorbed embedding) stays
+// listed so `sae embed` surfaces clap's error instead of being rewritten to
+// `sae search embed` (pinned by `removed_embed_not_rewritten_as_search`).
 const KNOWN_SUBCOMMANDS: &[&str] = &[
     "index",
     "rebuild",
@@ -293,7 +289,6 @@ async fn run(cli: Cli, config: Config) -> Result<CommandOutput, SaeError> {
         } => sae.get(number, team.as_deref(), with_body).await,
         Command::Create { args } => sae.create(args).await,
         Command::Update { args } => sae.update(args).await,
-        Command::Embed { team } => sae.embed(&team),
         Command::Archive {
             number,
             team,
@@ -738,16 +733,16 @@ mod tests {
         }
     }
 
-    // T-005: `sae embed myteam` still parses as Command::Embed (regression)
+    // T-005: `sae embed` (removed once index/rebuild absorbed embedding) must
+    // surface as a clap error, not be rewritten to `sae search embed`. Guarded
+    // by KNOWN_SUBCOMMANDS keeping `embed` (mirrors harvest's T-034c).
     #[test]
-    fn embed_still_parses_after_model_addition() {
-        let cli = parse_cli_args(["sae", "embed", "myteam"]).unwrap();
-        match cli.command {
-            Command::Embed { team } => {
-                assert_eq!(team, "myteam", "team should be myteam");
-            }
-            other => panic!("expected Embed, got {other:?}"),
-        }
+    fn removed_embed_not_rewritten_as_search() {
+        let result = parse_cli_args(["sae", "embed", "myteam"]);
+        assert!(
+            result.is_err(),
+            "removed `embed` must produce a clap error, not be rewritten as search"
+        );
     }
 
     // T-077: multi-positional args without valid search expansion → clap error
@@ -867,7 +862,7 @@ mod tests {
     #[test]
     fn all_subcommands_not_shorthand() {
         for cmd in [
-            "index", "rebuild", "get", "update", "ship", "archive", "embed", "status", "model",
+            "index", "rebuild", "get", "update", "ship", "archive", "status", "model",
         ] {
             let result = parse_cli_args(["sae", cmd]);
             assert!(

--- a/src/output.rs
+++ b/src/output.rs
@@ -298,6 +298,29 @@ mod tests {
         assert!(out.markdown.contains("Last sync: 2025-01-01 00:00:00"));
     }
 
+    // T-415: status human-readable surfaces the pending-embed hint when a
+    // synced team has unembedded chunks (covers the `pending_embed > 0` branch
+    // that points the user at `sae index`).
+    #[test]
+    fn status_human_synced_with_pending_embed_shows_index_hint() {
+        let ts = TeamStatus {
+            team: "team-a".to_owned(),
+            status: SyncStatus::Synced,
+            posts: 10,
+            pending_embed: 3,
+            sync_state: None,
+            error: None,
+            db_path: None,
+        };
+        let out = status(&[ts]).unwrap();
+        assert!(
+            out.markdown
+                .contains("Pending embed: 3 chunks (run 'sae index team-a' to embed)"),
+            "synced team with pending chunks must show the index hint; got: {}",
+            out.markdown
+        );
+    }
+
     // T-081: status human-readable not-synced team → expected lines
     #[test]
     fn status_human_not_synced_contains_expected_lines() {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,19 +1,32 @@
 use crate::client::EsaPost;
 use crate::envelope::CommandOutput;
-use crate::storage::{EmbedResult, SearchResult, SyncStatus, TeamStatus};
+use crate::storage::{SearchResult, SyncStatus, TeamStatus};
 use crate::sync::HarvestResult;
 use crate::tools::SaeError;
 
-pub(crate) fn harvest(result: &HarvestResult) -> Result<CommandOutput, SaeError> {
-    let markdown = result.to_string();
-    let data = serde_json::to_value(result)?;
+/// Renders the combined `index` / `rebuild` result: the harvest summary plus
+/// the embed outcome. `embedded` is `Some(n)` when chunks were embedded this
+/// run (omitted from markdown when zero), `None` when nothing was pending. The
+/// count lives under a nested `embed` key so it never collides with harvest
+/// fields, keeping the `--json` envelope shape stable.
+pub(crate) fn index(
+    harvest: &HarvestResult,
+    embedded: Option<u32>,
+) -> Result<CommandOutput, SaeError> {
+    let mut markdown = harvest.to_string();
+    if let Some(n) = embedded
+        && n > 0
+    {
+        markdown.push_str(&format!("\nEmbedded {n} chunks"));
+    }
+    let mut data = serde_json::to_value(harvest)?;
+    if let Some(obj) = data.as_object_mut() {
+        obj.insert(
+            "embed".to_owned(),
+            serde_json::json!({ "chunks_embedded": embedded.unwrap_or(0) }),
+        );
+    }
     Ok(CommandOutput::ok(markdown, data))
-}
-
-pub(crate) struct EmbedInfo {
-    pub(crate) processed: u32,
-    pub(crate) budget_exhausted: bool,
-    pub(crate) team: String,
 }
 
 pub(crate) fn search(
@@ -21,7 +34,6 @@ pub(crate) fn search(
     query: &str,
     semantic: bool,
     embedder_load_failed: bool,
-    embed_info: Option<EmbedInfo>,
     search_warnings: &[String],
 ) -> Result<CommandOutput, SaeError> {
     let search_mode = if semantic { "hybrid" } else { "fts" };
@@ -48,17 +60,6 @@ pub(crate) fn search(
             ));
             if !r.snippet.is_empty() {
                 lines.push(format!("  {}", r.snippet.replace('\n', " ")));
-            }
-        }
-        if let Some(info) = embed_info {
-            if info.processed > 0 {
-                lines.push(format!("(Embedded {} new chunks)", info.processed));
-            }
-            if info.budget_exhausted {
-                lines.push(format!(
-                    "Hint: more chunks pending. Run 'sae embed {}' to index all.",
-                    info.team
-                ));
             }
         }
         lines.join("\n")
@@ -131,20 +132,6 @@ pub(crate) fn action_result(action: &str, post: &EsaPost) -> Result<CommandOutpu
     Ok(CommandOutput::ok(markdown, data))
 }
 
-pub(crate) fn embed(result: &EmbedResult, total_chunks: u32) -> Result<CommandOutput, SaeError> {
-    let markdown = if result.chunks_embedded == 0 {
-        if total_chunks == 0 {
-            "Nothing to embed".to_owned()
-        } else {
-            format!("All {total_chunks} chunks already embedded")
-        }
-    } else {
-        format!("Embedded {} chunks", result.chunks_embedded)
-    };
-    let data = serde_json::to_value(result)?;
-    Ok(CommandOutput::ok(markdown, data))
-}
-
 /// Dry-run is always envelope-wrapped (consistent shape regardless of `--json`).
 /// `markdown` carries the pretty-printed payload for default-mode visibility.
 pub(crate) fn dry_run(payload: &serde_json::Value) -> Result<CommandOutput, SaeError> {
@@ -181,7 +168,7 @@ pub(crate) fn status(statuses: &[TeamStatus]) -> Result<CommandOutput, SaeError>
                 lines.push(format!("  Posts: {}", ts.posts));
                 if ts.pending_embed > 0 {
                     lines.push(format!(
-                        "  Pending embed: {} chunks (run 'sae embed {}' to index)",
+                        "  Pending embed: {} chunks (run 'sae index {}' to embed)",
                         ts.pending_embed, ts.team
                     ));
                 }
@@ -206,7 +193,7 @@ pub(crate) fn status(statuses: &[TeamStatus]) -> Result<CommandOutput, SaeError>
 mod tests {
     use super::*;
     use crate::client::EsaUser;
-    use crate::storage::{EmbedResult, MatchSource, SyncState};
+    use crate::storage::{MatchSource, SyncState};
 
     fn make_post() -> EsaPost {
         EsaPost {
@@ -319,30 +306,52 @@ mod tests {
         assert!(out.markdown.contains("Not yet synced"));
     }
 
-    // T-082: embed json data carries chunks_embedded
-    #[test]
-    fn embed_json_contains_chunks_embedded() {
-        let result = EmbedResult {
-            chunks_embedded: 42,
-        };
-        let out = embed(&result, 42).unwrap();
-        assert_eq!(out.data["chunks_embedded"], 42);
+    fn make_harvest(posts_fetched: u32) -> HarvestResult {
+        HarvestResult {
+            posts_fetched,
+            posts_stored: posts_fetched,
+            total_count: 10,
+            local_count: 10,
+            gap_detected: false,
+        }
     }
 
-    // T-083: embed human-readable with done=0 → "Nothing to embed"
+    // T-407: index merges harvest stats with the embed result — the embed count
+    // is appended to markdown and nested under a dedicated `embed` data key,
+    // kept separate from harvest fields so the envelope shape stays stable (#3).
     #[test]
-    fn embed_human_zero_done_returns_nothing_to_embed() {
-        let result = EmbedResult { chunks_embedded: 0 };
-        let out = embed(&result, 0).unwrap();
-        assert_eq!(out.markdown, "Nothing to embed");
+    fn index_merges_harvest_and_embed_result() {
+        let out = index(&make_harvest(2), Some(3)).unwrap();
+        assert!(
+            out.markdown.contains("Fetched 2 posts"),
+            "harvest line missing: {}",
+            out.markdown
+        );
+        assert!(
+            out.markdown.contains("Embedded 3 chunks"),
+            "embed line missing: {}",
+            out.markdown
+        );
+        assert_eq!(out.data["posts_fetched"], 2);
+        assert_eq!(out.data["embed"]["chunks_embedded"], 3);
     }
 
-    // T-084: embed human-readable chunks > 0 → "Embedded N chunks"
+    // T-408: index with nothing to embed (pending == 0) omits the embed line
+    // but keeps the `embed` key at zero so agents read a stable shape.
     #[test]
-    fn embed_human_nonzero_returns_embedded_count() {
-        let result = EmbedResult { chunks_embedded: 5 };
-        let out = embed(&result, 5).unwrap();
-        assert_eq!(out.markdown, "Embedded 5 chunks");
+    fn index_without_pending_embed_keeps_zero_embed_key() {
+        let out = index(&make_harvest(0), None).unwrap();
+        assert!(
+            out.markdown.contains("No updates"),
+            "harvest line missing: {}",
+            out.markdown
+        );
+        assert!(
+            !out.markdown.contains("Embedded"),
+            "embed line should be absent: {}",
+            out.markdown
+        );
+        assert_eq!(out.data["embed"]["chunks_embedded"], 0);
     }
 
     // T-085: status error variant — error field displayed
@@ -381,7 +390,7 @@ mod tests {
     // T-087: search data includes search_mode hybrid
     #[test]
     fn search_json_hybrid_includes_search_mode() {
-        let out = search(&[], "test", true, false, None, &[]).unwrap();
+        let out = search(&[], "test", true, false, &[]).unwrap();
         assert_eq!(out.data["search_mode"], "hybrid");
         assert!(out.data["results"].is_array());
     }
@@ -389,7 +398,7 @@ mod tests {
     // T-088: search data includes search_mode fts
     #[test]
     fn search_json_fts_includes_search_mode() {
-        let out = search(&[], "test", false, false, None, &[]).unwrap();
+        let out = search(&[], "test", false, false, &[]).unwrap();
         assert_eq!(out.data["search_mode"], "fts");
     }
 
@@ -397,7 +406,7 @@ mod tests {
     #[test]
     fn search_human_fts_fallback_shows_notice() {
         let results = vec![make_result(1, "Test", None, 0.5, "", MatchSource::Fts)];
-        let out = search(&results, "q", false, false, None, &[]).unwrap();
+        let out = search(&results, "q", false, false, &[]).unwrap();
         assert!(out.markdown.contains("semantic search unavailable"));
     }
 
@@ -405,14 +414,14 @@ mod tests {
     #[test]
     fn search_human_hybrid_no_fallback_notice() {
         let results = vec![make_result(1, "Test", None, 0.5, "", MatchSource::Fts)];
-        let out = search(&results, "q", true, false, None, &[]).unwrap();
+        let out = search(&results, "q", true, false, &[]).unwrap();
         assert!(!out.markdown.contains("semantic search unavailable"));
     }
 
     // T-260: search degraded fallback populates notes
     #[test]
     fn search_degraded_fallback_populates_notes() {
-        let out = search(&[], "q", false, true, None, &[]).unwrap();
+        let out = search(&[], "q", false, true, &[]).unwrap();
         assert!(
             out.degraded,
             "embedder_load_failed=true should set degraded"
@@ -424,7 +433,7 @@ mod tests {
     // T-261: search no-embed (FTS without load failure) leaves notes empty
     #[test]
     fn search_no_embed_does_not_degrade() {
-        let out = search(&[], "q", false, false, None, &[]).unwrap();
+        let out = search(&[], "q", false, false, &[]).unwrap();
         assert!(!out.degraded);
         assert!(out.notes.is_empty());
     }
@@ -435,7 +444,7 @@ mod tests {
     #[test]
     fn search_warnings_alone_set_degraded_and_populate_notes() {
         let warnings = vec!["reranker failed (boom), falling back to RRF order".to_owned()];
-        let out = search(&[], "q", true, false, None, &warnings).unwrap();
+        let out = search(&[], "q", true, false, &warnings).unwrap();
         assert!(
             out.degraded,
             "non-empty warnings should set degraded even with embedder loaded"
@@ -454,7 +463,7 @@ mod tests {
     #[test]
     fn search_warnings_with_embedder_failure_preserve_order() {
         let warnings = vec!["reranker failed (boom), falling back to RRF order".to_owned()];
-        let out = search(&[], "q", false, true, None, &warnings).unwrap();
+        let out = search(&[], "q", false, true, &warnings).unwrap();
         assert!(out.degraded);
         assert_eq!(out.notes.len(), 2);
         assert!(
@@ -498,28 +507,7 @@ mod tests {
                 MatchSource::Fts,
             ),
         ];
-        let out = search(&results, "design", true, false, None, &[]).unwrap();
-        insta::assert_snapshot!(out.markdown);
-    }
-
-    // T-403: search FTS fallback with embed_info → markdown snapshot
-    // (agents parse the embed hint).
-    #[test]
-    fn search_fts_fallback_with_embed_info_snapshot() {
-        let results = vec![make_result(
-            1,
-            "Test post",
-            None,
-            0.5,
-            "snippet text",
-            MatchSource::Fts,
-        )];
-        let info = EmbedInfo {
-            processed: 5,
-            budget_exhausted: true,
-            team: "demo".to_owned(),
-        };
-        let out = search(&results, "test", false, false, Some(info), &[]).unwrap();
+        let out = search(&results, "design", true, false, &[]).unwrap();
         insta::assert_snapshot!(out.markdown);
     }
 }

--- a/src/snapshots/sae__output__tests__search_fts_fallback_with_embed_info_snapshot.snap
+++ b/src/snapshots/sae__output__tests__search_fts_fallback_with_embed_info_snapshot.snap
@@ -1,9 +1,0 @@
----
-source: src/output.rs
-expression: out.markdown
----
-(semantic search unavailable, showing text-match results)
-[0.5000] Test post (#1)  https://example.esa.io/posts/1
-  snippet text
-(Embedded 5 new chunks)
-Hint: more chunks pending. Run 'sae embed demo' to index all.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -291,22 +291,6 @@ pub(crate) fn save_sync_state_at(
     Ok(())
 }
 
-/// Returns `true` if the last successful harvest completed within `secs` seconds of now.
-/// Returns `false` if no sync state exists (harvest has never run).
-pub fn sync_harvested_within(conn: &Connection, secs: u64) -> bool {
-    conn.query_row(
-        "SELECT (strftime('%s', 'now') - strftime('%s', updated_at)) < ?1 \
-         FROM sync_state WHERE id = 1",
-        [secs as i64],
-        |row| row.get::<_, bool>(0),
-    )
-    .map_err(|e| {
-        tracing::warn!(error = %e, "sync_state query failed, assuming harvest needed");
-        e
-    })
-    .unwrap_or(false)
-}
-
 pub fn count_posts(conn: &Connection) -> Result<u32, StorageError> {
     let count: u32 = conn.query_row("SELECT COUNT(*) FROM posts", [], |row| row.get(0))?;
     Ok(count)
@@ -521,57 +505,6 @@ mod tests {
         assert_eq!(state.local_count, 50);
         assert_eq!(state.last_page, Some(3));
         assert_eq!(state.updated_at, "2025-01-01 00:00:00");
-    }
-
-    // T-099: sync_harvested_within returns false when no sync state
-    #[test]
-    fn sync_harvested_within_false_when_no_state() {
-        let db = Db::open_memory().unwrap();
-        assert!(!sync_harvested_within(db.conn(), 300));
-    }
-
-    // T-099: sync_harvested_within returns true when harvest was recent
-    #[test]
-    fn sync_harvested_within_true_when_recent() {
-        let db = Db::open_memory().unwrap();
-        let now_epoch = i64::try_from(
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-        )
-        .expect("epoch seconds fit in i64");
-        save_sync_state_at(
-            db.conn(),
-            &SyncStateUpdate {
-                latest_updated_at: None,
-                total_count: 0,
-                local_count: 0,
-                last_page: None,
-            },
-            now_epoch,
-        )
-        .unwrap();
-        assert!(sync_harvested_within(db.conn(), 300));
-    }
-
-    // T-099: sync_harvested_within returns false when harvest was older than TTL
-    #[test]
-    fn sync_harvested_within_false_when_stale() {
-        let db = Db::open_memory().unwrap();
-        let stale_epoch = 1735689600i64; // 2025-01-01 00:00:00 UTC (far in the past)
-        save_sync_state_at(
-            db.conn(),
-            &SyncStateUpdate {
-                latest_updated_at: None,
-                total_count: 0,
-                local_count: 0,
-                last_page: None,
-            },
-            stale_epoch,
-        )
-        .unwrap();
-        assert!(!sync_harvested_within(db.conn(), 300));
     }
 
     // T-207: save_sync_state with last_page=None clears a previous checkpoint

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -101,11 +101,6 @@ impl TeamStatus {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct EmbedResult {
-    pub chunks_embedded: u32,
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
     #[error("Failed to open database: {0}")]
@@ -264,16 +259,5 @@ mod tests {
         assert_eq!(v["total_count"], 100);
         assert_eq!(v["local_count"], 50);
         assert_eq!(v["last_page"], 3);
-    }
-
-    // T-111: embed --json → EmbedResult JSON (chunks_embedded field)
-    #[test]
-    fn embed_result_serializes_to_json_with_chunks_embedded() {
-        let result = EmbedResult {
-            chunks_embedded: 150,
-        };
-        let json_str = serde_json::to_string(&result).expect("EmbedResult should serialize");
-        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
-        assert_eq!(v["chunks_embedded"], 150);
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "test-support"))]
 use std::convert::Infallible;
 use std::io;
 use std::process::ExitCode;
@@ -6,9 +7,14 @@ use std::sync::Arc;
 use amici::cli::embed_with_spinners;
 use amici::cli::env_lookup;
 use amici::cli::exit_code::CliError;
+#[cfg(not(feature = "test-support"))]
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use amici::model::{ModelDownloadError, download_and_verify_model};
-use rurico::embed::{Embed, ModelId, cached_artifacts};
+use rurico::embed::Embed;
+#[cfg(feature = "test-support")]
+use rurico::embed::MockEmbedder;
+#[cfg(not(feature = "test-support"))]
+use rurico::embed::{ModelId, cached_artifacts};
 use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeError;
 
@@ -529,6 +535,12 @@ impl CliError for SaeError {
 /// Returns `None` only when `Backend.source` carries a non-`ProbeError`
 /// payload — left open so a future amici/rurico change does not silently
 /// misclassify.
+///
+/// Its only non-test caller is the real-model [`load_embedder`], `cfg`'d out
+/// under `--features test-support`. The routing logic stays exercised by
+/// T-332..T-334; `allow(dead_code)` covers the test-support build where the
+/// production caller is absent.
+#[cfg_attr(feature = "test-support", allow(dead_code))]
 fn extract_probe_error(init_err: ModelInitError) -> Option<ProbeError> {
     match init_err {
         ModelInitError::ModelCorrupt { reason } => Some(ProbeError::ModelLoadFailed { reason }),
@@ -547,6 +559,13 @@ fn extract_probe_error(init_err: ModelInitError) -> Option<ProbeError> {
 /// loads the backend, classifying failures. Absent model → recoverable
 /// `EmbedderUnavailable` (75); hardware/OS backend missing → `BackendUnavailable`
 /// (70); corrupt model / probe failure → typed `Probe`.
+///
+/// Compiled out under `--features test-support`; the coverage build uses that
+/// feature, so the real-model loader is excluded from diff coverage (mirrors
+/// yomu's `try_load_embedder` cfg split). The test-support variant below
+/// returns a deterministic [`MockEmbedder`] so `index` / `rebuild` populate
+/// embeddings without a real model on CI runners.
+#[cfg(not(feature = "test-support"))]
 fn load_embedder() -> Result<Arc<dyn Embed>, SaeError> {
     // Resolve the model cache lazily (only when chunks are pending, since
     // `embed_with_spinners` skips the loader at pending == 0). Absent model is
@@ -590,6 +609,16 @@ fn load_embedder() -> Result<Arc<dyn Embed>, SaeError> {
             None => Err(SaeError::Other(format!("Model probe failed: {reason:?}"))),
         },
     }
+}
+
+/// Test-support embedder loader: returns a deterministic in-memory
+/// [`MockEmbedder`] so `index` / `rebuild` populate embeddings without a real
+/// model (CI runners have none). Compiled only under `--features test-support`;
+/// the production binary loads the real model via the `cfg(not(...))` variant
+/// above.
+#[cfg(feature = "test-support")]
+fn load_embedder() -> Result<Arc<dyn Embed>, SaeError> {
+    Ok(Arc::new(MockEmbedder::default()))
 }
 
 /// Embeds all pending chunks for `db`, obtaining the embedder via `load`.
@@ -1132,6 +1161,33 @@ mod tests {
         assert!(
             matches!(result, Err(SaeError::EmbedderUnavailable(_))),
             "pending chunks + loader failure must propagate EmbedderUnavailable, got {result:?}"
+        );
+    }
+
+    // T-414: embed_pending embeds every pending chunk through the test-support
+    // loader (MockEmbedder) — pins the happy path index/rebuild depend on,
+    // covering the embed_pending_with run arm and the production embed_pending
+    // binding without a real model. Compiled only under --features test-support
+    // (the coverage build), matching yomu's stub-embedder integration tests.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn embed_pending_embeds_all_pending_chunks() {
+        let db = Db::open_memory().unwrap();
+        upsert_post(db.conn(), &test_post_row(1)).unwrap();
+        rechunk_post(db.conn(), 1, "# Title\nBody text").unwrap();
+        assert_eq!(
+            count_unembedded_chunks(db.conn()).unwrap(),
+            1,
+            "fixture must leave exactly one unembedded chunk"
+        );
+        let result = embed_pending(&db)
+            .expect("embed_pending must succeed with MockEmbedder")
+            .expect("pending chunks must yield Some(EmbedAllResult)");
+        assert_eq!(result.added, 1, "the single pending chunk must be embedded");
+        assert_eq!(
+            count_unembedded_chunks(db.conn()).unwrap(),
+            0,
+            "no chunks must remain unembedded after embed_pending"
         );
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,13 +1,14 @@
 use std::convert::Infallible;
 use std::io;
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use amici::cli::embed_with_spinners;
 use amici::cli::env_lookup;
 use amici::cli::exit_code::CliError;
 use amici::model::embedder::{DegradedReason, try_load_embedder_with};
 use amici::model::{ModelDownloadError, download_and_verify_model};
-use rurico::embed::{Artifacts, ModelId, cached_artifacts};
+use rurico::embed::{Embed, ModelId, cached_artifacts};
 use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeError;
 
@@ -16,7 +17,7 @@ use crate::commands;
 use crate::config::{Config, ConfigError};
 use crate::envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload};
 use crate::output;
-use crate::storage::{Db, EmbedResult, StorageError, count_unembedded_chunks};
+use crate::storage::{Db, StorageError, count_unembedded_chunks};
 use crate::sync::{self, SyncError};
 
 pub use crate::commands::search::resolve_search_query;
@@ -132,85 +133,12 @@ impl Sae {
         let db_path = self.config.team_db_path(team)?;
         let db = Db::open(&db_path)?;
         let result = sync::harvest(&client, &db, team, full).await?;
-        output::harvest(&result)
-    }
-
-    pub fn embed(&self, team: &str) -> Result<CommandOutput, SaeError> {
-        let team = self.config.resolve_team(Some(team))?;
-        let db = require_db(&self.config, team)?;
-        let paths = require_embed_model()?;
-        let pending = count_unembedded_chunks(db.conn())?;
-
-        let result = embed_with_spinners(
-            pending,
-            |_| {
-                // Ok = typed probe variant; Err = fallback Display for the
-                // non-ProbeError path; None = callback never fired.
-                let mut captured: Option<Result<ProbeError, String>> = None;
-                match try_load_embedder_with(
-                    || Ok::<_, Infallible>(Some(paths)),
-                    |e| tracing::warn!(error = %e, "failed to delete corrupt model files"),
-                    |e| {
-                        let display = e.to_string();
-                        captured = Some(extract_probe_error(e).ok_or(display));
-                    },
-                ) {
-                    Ok(e) => Ok(e),
-                    // Mirrors `ModelDownload(BackendUnavailable)` routing via
-                    // `SaeError::BackendUnavailable` so embed and model download
-                    // surface the same INTERNAL signal for hardware mismatch
-                    // (#127 CHX-001; was `Other` → UNKNOWN before).
-                    Err(DegradedReason::BackendUnavailable) => Err(SaeError::BackendUnavailable),
-                    Err(reason) => match captured {
-                        Some(Ok(probe)) => Err(SaeError::Probe(probe)),
-                        // Other (UNKNOWN): `extract_probe_error` returned a non-`ProbeError`
-                        // payload that we surfaced via `Display`. No typed variant exists
-                        // yet for the remaining `DegradedReason` shapes coming from amici.
-                        Some(Err(detail)) => Err(SaeError::Other(format!(
-                            "Model probe failed: {reason:?}: {detail}"
-                        ))),
-                        // Other (UNKNOWN): probe callback never fired — amici returned a
-                        // `DegradedReason` without invoking the per-error hook. Genuine
-                        // unclassified path.
-                        None => Err(SaeError::Other(format!("Model probe failed: {reason:?}"))),
-                    },
-                }
-            },
-            |r: &commands::embed_batch::EmbedAllResult| {
-                format!("Embedded {} chunks", r.total_chunks)
-            },
-            |embedder, update| {
-                commands::embed_batch::embed_all(
-                    db.conn(),
-                    |texts| {
-                        embedder
-                            .embed_documents_batch(texts)
-                            // Other (UNKNOWN): embedder's runtime error is an opaque
-                            // `anyhow::Error` (no typed variant from amici/rurico).
-                            // Promoting requires upstream type surface first.
-                            .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
-                    },
-                    |n| update(&format!("Embedding... {n}/{pending} chunks")),
-                )
-            },
-        )?;
-
-        match result {
-            Some(all) => {
-                tracing::info!(
-                    total_added = all.added,
-                    total_chunks = all.total_chunks,
-                    "embed complete"
-                );
-                output::embed(
-                    &EmbedResult {
-                        chunks_embedded: all.added,
-                    },
-                    all.total_chunks,
-                )
-            }
-            None => output::embed(&EmbedResult { chunks_embedded: 0 }, 0),
-        }
+        // Embed pending chunks unconditionally — even when harvest fetched
+        // nothing — so a backlog left by an earlier model-less run clears on the
+        // next `index`. Mirrors yomu: never silently leave a chunk-only index.
+        // Harvest is already committed; an embed failure does not roll it back.
+        let embedded = embed_pending(&db)?.map(|r| r.added);
+        output::index(&result, embedded)
     }
 
     pub fn model_download() -> Result<CommandOutput, SaeError> {
@@ -322,11 +250,18 @@ pub enum SaeError {
     #[error("{0}")]
     InputData(String),
     /// MLX backend missing in the runtime hardware (e.g., running on a host
-    /// without Apple Silicon). Maps to `INTERNAL` (sysexits 70) so `sae embed`
+    /// without Apple Silicon). Maps to `INTERNAL` (sysexits 70) so `sae index`
     /// and `sae model download` surface the same hardware-mismatch signal
     /// (was split between 104 and 70 before #127 CHX-001).
     #[error("MLX backend is unavailable")]
     BackendUnavailable,
+    /// The embedding model is absent or failed to load when an
+    /// embedding-dependent command (e.g. `sae index`) needs to embed pending
+    /// chunks. Maps to `TEMP_FAIL` (sysexits 75) and is retryable because
+    /// `sae model download` clears it — distinct from the non-retryable
+    /// `InputUsage` usage-error path. Mirrors yomu's `EmbedderUnavailable`.
+    #[error("{0}")]
+    EmbedderUnavailable(String),
     /// Programmer-detectable invariant violation (e.g., embedder returned a
     /// vector count that does not match the requested batch). Maps to
     /// `INTERNAL` (sysexits 70) so agents distinguish bug signals from the
@@ -340,11 +275,10 @@ pub enum SaeError {
     Other(String),
 }
 
-/// Prefixes shared by the constructors below and [`SaeError::next_step`]
-/// lookup. Centralising them removes the implicit contract that constructor
-/// and lookup strings stay in sync by convention.
+/// Prefix shared by the constructor below and [`SaeError::next_step`] lookup.
+/// Centralising it removes the implicit contract that constructor and lookup
+/// strings stay in sync by convention.
 const NO_DATA_PREFIX: &str = "No data for team ";
-const MODEL_NOT_FOUND_PREFIX: &str = "Model not found";
 
 /// Shared `next_step` hint for both `SaeError::BackendUnavailable` (embed
 /// path) and `SaeError::ModelDownload(ModelDownloadError::BackendUnavailable)`
@@ -365,12 +299,6 @@ impl SaeError {
     pub(crate) fn input_no_data_for_team(team: &str) -> Self {
         Self::InputUsage(format!(
             "{NO_DATA_PREFIX}'{team}'. Run `sae index {team}` first."
-        ))
-    }
-
-    pub(crate) fn input_model_not_found() -> Self {
-        Self::InputUsage(format!(
-            "{MODEL_NOT_FOUND_PREFIX}. Run 'sae model download' first."
         ))
     }
 
@@ -413,6 +341,10 @@ impl SaeError {
             // Mirrors `ModelDownload(BackendUnavailable)` so the embed path and
             // model-download path agree on hardware-mismatch routing (#127 CHX-001).
             Self::BackendUnavailable => ErrorCode::Internal,
+            // Absent/unloadable embedding model is recoverable via
+            // `sae model download`, so route to TEMP_FAIL (75)/retryable rather
+            // than the non-retryable InputUsage path. Mirrors yomu's parity.
+            Self::EmbedderUnavailable(_) => ErrorCode::TempFailure,
             // Programmer-detectable invariant violation (embedder bug, etc.).
             // Routed to `INTERNAL` so it stays distinguishable from anyhow-swallow
             // `Other(=UNKNOWN)` per ADR-0066 L136 (#127).
@@ -442,9 +374,6 @@ impl SaeError {
             Self::InputUsage(s) if s.starts_with(NO_DATA_PREFIX) => {
                 Some("Run `sae index <team>` to fetch posts.")
             }
-            Self::InputUsage(s) if s.starts_with(MODEL_NOT_FOUND_PREFIX) => {
-                Some("Run `sae model download` to fetch the embedding model.")
-            }
             Self::Config(ConfigError::NoTeamSpecified) => {
                 Some("Pass --team <name> or set `SAE_TEAM=<name>`.")
             }
@@ -469,13 +398,16 @@ impl SaeError {
             Self::ModelDownload(ModelDownloadError::DownloadFailed(_)) => {
                 Some("Retry `sae model download`; the failure is transient.")
             }
-            // Mirrors `BackendUnavailable` below so both `sae embed` and
+            // Mirrors `BackendUnavailable` below so both `sae index` and
             // `sae model download` surface the same actionable hint on
             // hardware mismatch (#127 OPS-007).
             Self::ModelDownload(ModelDownloadError::BackendUnavailable) => {
                 Some(BACKEND_UNAVAILABLE_HINT)
             }
             Self::BackendUnavailable => Some(BACKEND_UNAVAILABLE_HINT),
+            Self::EmbedderUnavailable(_) => {
+                Some("Run `sae model download` to fetch the embedding model.")
+            }
             // Explicit catch-all arms per variant. Adding a new SaeError variant
             // must force a compile-time review (no wildcard).
             Self::InputUsage(_)
@@ -592,17 +524,6 @@ impl CliError for SaeError {
     }
 }
 
-fn require_embed_model() -> Result<Artifacts, SaeError> {
-    match cached_artifacts(ModelId::default()) {
-        Ok(Some(p)) => Ok(p),
-        Ok(None) => Err(SaeError::input_model_not_found()),
-        // Other (UNKNOWN): `cached_artifacts` returns an opaque `anyhow::Error`
-        // covering filesystem / permission / cache-layout edge cases. Promoting
-        // requires typed surface from rurico first.
-        Err(e) => Err(SaeError::Other(format!("Failed to check model cache: {e}"))),
-    }
-}
-
 /// Reverse [`From<ProbeError> for ModelInitError`] so per-variant `ProbeError`
 /// routing in [`SaeError::error_code`] survives amici's collapse boundary.
 /// Returns `None` only when `Backend.source` carries a non-`ProbeError`
@@ -622,12 +543,104 @@ fn extract_probe_error(init_err: ModelInitError) -> Option<ProbeError> {
     }
 }
 
+/// Production embedder loader for the embed path: resolves the model cache and
+/// loads the backend, classifying failures. Absent model → recoverable
+/// `EmbedderUnavailable` (75); hardware/OS backend missing → `BackendUnavailable`
+/// (70); corrupt model / probe failure → typed `Probe`.
+fn load_embedder() -> Result<Arc<dyn Embed>, SaeError> {
+    // Resolve the model cache lazily (only when chunks are pending, since
+    // `embed_with_spinners` skips the loader at pending == 0). Absent model is
+    // recoverable, so route to retryable `EmbedderUnavailable` (75) rather than
+    // the old non-retryable `InputUsage` (64) path.
+    let paths = match cached_artifacts(ModelId::default()) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            return Err(SaeError::EmbedderUnavailable(
+                "embedding model not installed".to_owned(),
+            ));
+        }
+        // Other (UNKNOWN): `cached_artifacts` returns an opaque `anyhow::Error`
+        // covering filesystem / cache-layout edges.
+        Err(e) => return Err(SaeError::Other(format!("Failed to check model cache: {e}"))),
+    };
+    // Ok = typed probe variant; Err = fallback Display for the non-ProbeError
+    // path; None = callback never fired.
+    let mut captured: Option<Result<ProbeError, String>> = None;
+    match try_load_embedder_with(
+        || Ok::<_, Infallible>(Some(paths)),
+        |e| tracing::warn!(error = %e, "failed to delete corrupt model files"),
+        |e| {
+            let display = e.to_string();
+            captured = Some(extract_probe_error(e).ok_or(display));
+        },
+    ) {
+        Ok(e) => Ok(e),
+        // Mirrors `ModelDownload(BackendUnavailable)` routing via
+        // `SaeError::BackendUnavailable` so embed and model download surface the
+        // same INTERNAL signal for hardware mismatch (#127 CHX-001).
+        Err(DegradedReason::BackendUnavailable) => Err(SaeError::BackendUnavailable),
+        Err(reason) => match captured {
+            Some(Ok(probe)) => Err(SaeError::Probe(probe)),
+            // Other (UNKNOWN): `extract_probe_error` returned a non-`ProbeError`
+            // payload that we surfaced via `Display`.
+            Some(Err(detail)) => Err(SaeError::Other(format!(
+                "Model probe failed: {reason:?}: {detail}"
+            ))),
+            // Other (UNKNOWN): probe callback never fired.
+            None => Err(SaeError::Other(format!("Model probe failed: {reason:?}"))),
+        },
+    }
+}
+
+/// Embeds all pending chunks for `db`, obtaining the embedder via `load`.
+/// Returns `None` when nothing is pending — `load` is never invoked then, so a
+/// model-less index still succeeds for FTS-only use. Production callers use
+/// [`embed_pending`]; tests inject a `load` double.
+fn embed_pending_with<L>(
+    db: &Db,
+    load: L,
+) -> Result<Option<commands::embed_batch::EmbedAllResult>, SaeError>
+where
+    L: FnOnce() -> Result<Arc<dyn Embed>, SaeError>,
+{
+    let pending = count_unembedded_chunks(db.conn())?;
+    embed_with_spinners(
+        pending,
+        // `embed_with_spinners` hands the loader a progress hook, but model
+        // loading reports no progress, so discard it here.
+        |_| load(),
+        |r: &commands::embed_batch::EmbedAllResult| format!("Embedded {} chunks", r.total_chunks),
+        |embedder, update| {
+            commands::embed_batch::embed_all(
+                db.conn(),
+                |texts| {
+                    embedder
+                        .embed_documents_batch(texts)
+                        // Other (UNKNOWN): embedder's runtime error is an opaque
+                        // `anyhow::Error` (no typed variant from amici/rurico).
+                        .map_err(|e| SaeError::Other(format!("Batch embedding failed: {e}")))
+                },
+                |n| update(&format!("Embedding... {n}/{pending} chunks")),
+            )
+        },
+    )
+}
+
+/// Production entry point for [`embed_pending_with`]: binds [`load_embedder`],
+/// so loader failures are classified into recoverable (`EmbedderUnavailable`,
+/// 75) versus terminal conditions.
+fn embed_pending(db: &Db) -> Result<Option<commands::embed_batch::EmbedAllResult>, SaeError> {
+    embed_pending_with(db, load_embedder)
+}
+
 #[cfg(test)]
 mod tests {
     use amici::cli::exit_code::codes;
 
     use super::*;
-    use crate::storage::sqlite_failure;
+    use std::cell::Cell;
+
+    use crate::storage::{rechunk_post, sqlite_failure, test_post_row, upsert_post};
 
     fn assert_code(err: &SaeError, expected: u8) {
         assert_eq!(err.exit_code(), ExitCode::from(expected));
@@ -901,17 +914,6 @@ mod tests {
         );
     }
 
-    // T-311: input_model_not_found_pins_next_step_download_hint
-    #[test]
-    fn input_model_not_found_pins_next_step_download_hint() {
-        let err = SaeError::input_model_not_found();
-        assert_eq!(
-            err.next_step(),
-            Some("Run `sae model download` to fetch the embedding model."),
-            "constructor and next_step must stay in sync"
-        );
-    }
-
     // T-312: next_step_config_no_team_specified
     #[test]
     fn next_step_config_no_team_specified() {
@@ -1054,6 +1056,83 @@ mod tests {
         ] {
             assert!(!err.retryable(), "{err:?} must not be retryable");
         }
+    }
+
+    // EmbedderUnavailable contract (T-404..T-406): the embedding model is not
+    // installed when `sae index` / `sae rebuild` needs to embed pending chunks.
+    // Mirrors yomu's `EmbedderUnavailable` — a recoverable (retryable) signal,
+    // distinct from the non-retryable `InputUsage` missing-model path, because
+    // `sae model download` clears it.
+
+    // T-404: EmbedderUnavailable maps to TEMP_FAIL (75)
+    #[test]
+    fn exit_code_embedder_unavailable_is_temp_fail() {
+        assert_code(
+            &SaeError::EmbedderUnavailable("model not installed".into()),
+            codes::TEMP_FAIL,
+        );
+    }
+
+    // T-405: EmbedderUnavailable is retryable (recoverable via model download)
+    #[test]
+    fn retryable_true_for_embedder_unavailable() {
+        assert!(
+            SaeError::EmbedderUnavailable("x".into()).retryable(),
+            "EmbedderUnavailable must be retryable"
+        );
+    }
+
+    // T-406: next_step for EmbedderUnavailable recommends model download
+    #[test]
+    fn next_step_embedder_unavailable_recommends_model_download() {
+        let err = SaeError::EmbedderUnavailable("x".into());
+        assert_eq!(
+            err.next_step(),
+            Some("Run `sae model download` to fetch the embedding model.")
+        );
+    }
+
+    // T-409: embed_pending skips the model load when no chunks are pending, so
+    // a model-less `index` / `rebuild` still succeeds (FTS-only). Pins the
+    // breaking-change-risk path weighed in Q1.
+    #[test]
+    fn embed_pending_with_no_pending_skips_loader() {
+        let db = Db::open_memory().unwrap();
+        let loader_called = Cell::new(false);
+        let result = embed_pending_with(&db, || {
+            loader_called.set(true);
+            Err(SaeError::Other("loader must not run".to_owned()))
+        });
+        assert!(
+            matches!(result, Ok(None)),
+            "no pending chunks must yield Ok(None), got {result:?}"
+        );
+        assert!(
+            !loader_called.get(),
+            "loader must not be invoked when nothing is pending"
+        );
+    }
+
+    // T-410: embed_pending propagates a loader failure when chunks are pending —
+    // pins Q1: model unavailable + pending chunks → `index` / `rebuild` fail
+    // with the typed error rather than leaving a chunk-only index.
+    #[test]
+    fn embed_pending_with_pending_propagates_loader_failure() {
+        let db = Db::open_memory().unwrap();
+        upsert_post(db.conn(), &test_post_row(1)).unwrap();
+        rechunk_post(db.conn(), 1, "# Title\nBody text").unwrap();
+        assert_eq!(
+            count_unembedded_chunks(db.conn()).unwrap(),
+            1,
+            "fixture must leave exactly one unembedded chunk"
+        );
+        let result = embed_pending_with(&db, || {
+            Err(SaeError::EmbedderUnavailable("not installed".to_owned()))
+        });
+        assert!(
+            matches!(result, Err(SaeError::EmbedderUnavailable(_))),
+            "pending chunks + loader failure must propagate EmbedderUnavailable, got {result:?}"
+        );
     }
 
     // T-324: candidates(None) returns empty for every variant — without a

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -29,6 +29,14 @@ fn sae_command(home: &Path) -> Command {
         .env("XDG_CONFIG_HOME", home.join(".config"))
         .env("XDG_DATA_HOME", home.join(".local/share"))
         .env("PATH", env::var_os("PATH").unwrap_or_default());
+    // cargo-llvm-cov instruments the spawned binary and directs its profile
+    // output via LLVM_PROFILE_FILE; the env_clear() above drops it, leaving the
+    // binary unable to write a profraw — so every integration-only path (the
+    // `__test_*` seams, search) reads as uncovered. Restore it when present.
+    // yomu sidesteps this by never calling env_clear().
+    if let Some(profile) = env::var_os("LLVM_PROFILE_FILE") {
+        cmd.env("LLVM_PROFILE_FILE", profile);
+    }
     cmd
 }
 
@@ -479,5 +487,37 @@ fn esa_client_rejects_non_esa_host() {
     assert!(
         matches!(result, Err(ClientError::InvalidRequest(_))),
         "with_base_url('https://attacker.com') must be rejected; got: {result:?}"
+    );
+}
+
+// T-CI012: `search --no-embed` against a seeded DB drives run_search's
+// read-only path end to end — covering the semantic-flag decision and the
+// success-envelope wiring (search.rs:102,105). Seeds via the public storage
+// API because sae cannot run `index` offline (esa fetch), unlike yomu's
+// local-file index.
+#[test]
+fn search_no_embed_against_seeded_db_exits_success() {
+    use sae::storage::{Db, rechunk_post, test_post_row, upsert_post};
+
+    let dir = tempdir().unwrap();
+    let home = dir.path();
+    write_config_with_teams(home, &["myteam"]);
+
+    // Db::open creates the parent data dir; seed one post + its chunks so FTS
+    // has something to match.
+    let db_path = home.join(".local/share/sae/myteam.db");
+    let db = Db::open(&db_path).expect("open seed db");
+    upsert_post(db.conn(), &test_post_row(1)).expect("seed post");
+    rechunk_post(db.conn(), 1, "# Title\nBody text").expect("seed chunks");
+    drop(db);
+
+    let output = sae_command(home)
+        .args(["search", "Title", "--no-embed", "--team", "myteam"])
+        .output()
+        .expect("run search");
+    assert!(
+        output.status.success(),
+        "search --no-embed against a seeded DB must exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }


### PR DESCRIPTION
## 概要

sae を yomu の embed/search パターンに整列。

## 変更

- index/rebuild が embed を内包し、embed サブコマンドを削除（KNOWN_SUBCOMMANDS は残置し clap エラーへ誘導）
- SaeError::EmbedderUnavailable (75/retryable) を追加し missing-model を正分類（旧 InputUsage 64/非retryable から修正、yomu 一致）
- search を read-only 化: auto_embed_pending_with（検索ついで embed）と spawn_background_index（5分TTL prefetch）を除去
  - prefetch は OUTCOME Non-goal「push型/常駐型同期は対象外」に違反していた
- search の semantic を has_embeddings に gate し、embed 未済時の search_mode:"hybrid" 誤報告を解消
- embed コアのテストを embed_batch に移設（T-411〜413、count-mismatch→Internal invariant 含む）

## 検証

cargo nextest 372 passed / clippy clean / fmt

## フォローアップ

- read-only 回帰テスト（yomu T-181/T-182 相当）: #175（test infra gap）

/polish 適用済み（F1 semantic 誤報告 + F5 embed テスト復活 + loader hook 分離）。